### PR TITLE
Store catchment and nexus BMI results in memory to pass to t-route BMI model (NGWPC-7421)

### DIFF
--- a/include/core/DomainLayer.hpp
+++ b/include/core/DomainLayer.hpp
@@ -56,9 +56,9 @@ namespace ngen
          * Any required connection to other components, e.g. providing inputs to a catchment feature,
          * is not yet implemented in this class.
         */
-        void update_models(boost::span<double> catchment_results, 
+        void update_models(boost::span<double> catchment_outflows, 
                            std::unordered_map<std::string, int> &catchment_indexes,
-                           boost::span<double> nexus_results,
+                           boost::span<double> nexus_downstream_flows,
                            std::unordered_map<std::string, int> &nexus_indexes,
                            int current_step) override {
             std::string current_timestamp = simulation_time.get_timestamp(output_time_index);

--- a/include/core/DomainLayer.hpp
+++ b/include/core/DomainLayer.hpp
@@ -56,9 +56,9 @@ namespace ngen
          * Any required connection to other components, e.g. providing inputs to a catchment feature,
          * is not yet implemented in this class.
         */
-        void update_models(std::vector<double> &catchment_results, 
+        void update_models(boost::span<double> catchment_results, 
                            std::unordered_map<std::string, int> &catchment_indexes,
-                           std::vector<double> &nexus_results,
+                           boost::span<double> nexus_results,
                            std::unordered_map<std::string, int> &nexus_indexes,
                            int current_step) override {
             std::string current_timestamp = simulation_time.get_timestamp(output_time_index);

--- a/include/core/DomainLayer.hpp
+++ b/include/core/DomainLayer.hpp
@@ -56,7 +56,11 @@ namespace ngen
          * Any required connection to other components, e.g. providing inputs to a catchment feature,
          * is not yet implemented in this class.
         */
-        void update_models() override{
+        void update_models(std::vector<double> &catchment_results, 
+                           std::unordered_map<std::string, int> &catchment_indexes,
+                           std::vector<double> &nexus_results,
+                           std::unordered_map<std::string, int> &nexus_indexes,
+                           int current_step) override {
             std::string current_timestamp = simulation_time.get_timestamp(output_time_index);
             try{
                 formulation->get_response(output_time_index, simulation_time.get_output_interval_seconds());

--- a/include/core/Layer.hpp
+++ b/include/core/Layer.hpp
@@ -102,7 +102,11 @@ namespace ngen
         /***
          * @brief Run one simulation timestep for each model in this layer
         */
-        virtual void update_models()
+        virtual void update_models(std::vector<double> &catchment_results, 
+                                   std::unordered_map<std::string, int> &catchment_indexes,
+                                   std::vector<double> &nexus_results,
+                                   std::unordered_map<std::string, int> &nexus_indexes,
+                                   int current_step)
         {
             auto idx = simulation_time.next_timestep_index();
             auto step = simulation_time.get_output_interval_seconds();
@@ -128,6 +132,10 @@ namespace ngen
                              +" at feature id "+id;
                     throw models::external::State_Exception(msg);
                 }
+#if NGEN_WITH_ROUTING
+                int results_index = catchment_indexes[id];
+                catchment_results[results_index + current_step] = response;
+#endif // NGEN_WITH_ROUTING
                 std::string output = std::to_string(output_time_index)+","+current_timestamp+","+
                                     r_c->get_output_line_for_timestep(output_time_index)+"\n";
                 r_c->write_output(output);

--- a/include/core/Layer.hpp
+++ b/include/core/Layer.hpp
@@ -103,9 +103,9 @@ namespace ngen
         /***
          * @brief Run one simulation timestep for each model in this layer
         */
-        virtual void update_models(boost::span<double> catchment_results, 
+        virtual void update_models(boost::span<double> catchment_outflows, 
                                    std::unordered_map<std::string, int> &catchment_indexes,
-                                   boost::span<double> nexus_results,
+                                   boost::span<double> nexus_downstream_flows,
                                    std::unordered_map<std::string, int> &nexus_indexes,
                                    int current_step)
         {
@@ -135,7 +135,7 @@ namespace ngen
                 }
 #if NGEN_WITH_ROUTING
                 int results_index = catchment_indexes[id];
-                catchment_results[results_index] = response;
+                catchment_outflows[results_index] = response;
 #endif // NGEN_WITH_ROUTING
                 std::string output = std::to_string(output_time_index)+","+current_timestamp+","+
                                     r_c->get_output_line_for_timestep(output_time_index)+"\n";

--- a/include/core/Layer.hpp
+++ b/include/core/Layer.hpp
@@ -7,6 +7,7 @@
 #include "LayerData.hpp"
 #include "Simulation_Time.hpp"
 #include "State_Exception.hpp"
+#include <boost/core/span.hpp>
 
 #if NGEN_WITH_MPI
 #include "HY_Features_MPI.hpp"
@@ -102,9 +103,9 @@ namespace ngen
         /***
          * @brief Run one simulation timestep for each model in this layer
         */
-        virtual void update_models(std::vector<double> &catchment_results, 
+        virtual void update_models(boost::span<double> catchment_results, 
                                    std::unordered_map<std::string, int> &catchment_indexes,
-                                   std::vector<double> &nexus_results,
+                                   boost::span<double> nexus_results,
                                    std::unordered_map<std::string, int> &nexus_indexes,
                                    int current_step)
         {
@@ -134,7 +135,7 @@ namespace ngen
                 }
 #if NGEN_WITH_ROUTING
                 int results_index = catchment_indexes[id];
-                catchment_results[results_index + current_step] = response;
+                catchment_results[results_index] = response;
 #endif // NGEN_WITH_ROUTING
                 std::string output = std::to_string(output_time_index)+","+current_timestamp+","+
                                     r_c->get_output_line_for_timestep(output_time_index)+"\n";

--- a/include/core/SurfaceLayer.hpp
+++ b/include/core/SurfaceLayer.hpp
@@ -28,9 +28,9 @@ namespace ngen
         /***
          * @brief Run one simulation timestep for each model in this layer
         */
-        void update_models(boost::span<double> catchment_results, 
+        void update_models(boost::span<double> catchment_outflows, 
                            std::unordered_map<std::string, int> &catchment_indexes,
-                           boost::span<double> nexus_results,
+                           boost::span<double> nexus_downstream_flows,
                            std::unordered_map<std::string, int> &nexus_indexes,
                            int current_step) override;
 

--- a/include/core/SurfaceLayer.hpp
+++ b/include/core/SurfaceLayer.hpp
@@ -28,9 +28,9 @@ namespace ngen
         /***
          * @brief Run one simulation timestep for each model in this layer
         */
-        void update_models(std::vector<double> &catchment_results, 
+        void update_models(boost::span<double> catchment_results, 
                            std::unordered_map<std::string, int> &catchment_indexes,
-                           std::vector<double> &nexus_results,
+                           boost::span<double> nexus_results,
                            std::unordered_map<std::string, int> &nexus_indexes,
                            int current_step) override;
 

--- a/include/core/SurfaceLayer.hpp
+++ b/include/core/SurfaceLayer.hpp
@@ -28,7 +28,11 @@ namespace ngen
         /***
          * @brief Run one simulation timestep for each model in this layer
         */
-        void update_models() override;
+        void update_models(std::vector<double> &catchment_results, 
+                           std::unordered_map<std::string, int> &catchment_indexes,
+                           std::vector<double> &nexus_results,
+                           std::unordered_map<std::string, int> &nexus_indexes,
+                           int current_step) override;
 
         private:
 

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -647,13 +647,13 @@ int main(int argc, char* argv[]) {
     for (int i = 0; i < catchment_collection->get_size(); ++i) {
         auto feature = catchment_collection->get_feature(i);
         std::string feature_id = feature->get_id();
-        catchment_indexes[feature_id] = i * num_times;
+        catchment_indexes[feature_id] = i;
     }
     nexus_results.resize(nexus_collection->get_size() * num_times);
     for (int i = 0; i < nexus_collection->get_size(); ++i) {
         auto feature = catchment_collection->get_feature(i);
         std::string feature_id = feature->get_id();
-        nexus_indexes[feature_id] = i * num_times;
+        nexus_indexes[feature_id] = i;
     }
 #endif // NGEN_WITH_ROUTING
 
@@ -687,10 +687,19 @@ int main(int argc, char* argv[]) {
                         LOG(ss.str(), LogLevel::DEBUG);
                         ss.str("");
                     }
+#if NGEN_WITH_ROUTING
+                    boost::span<double> catchment_span(catchment_results.data() + (count * catchment_indexes.size()),
+                                                       catchment_indexes.size());
+                    boost::span<double> nexus_span(nexus_results.data() + (count * nexus_indexes.size()),
+                                                   nexus_indexes.size());
+#else
+                    boost::span<double> catchment_span;
+                    boost::span<double> nexus_span;
+#endif
                     layer->update_models(
-                        catchment_results,
+                        catchment_span,
                         catchment_indexes,
-                        nexus_results,
+                        nexus_span,
                         nexus_indexes,
                         count
                     ); // assume update_models() calls time->advance_timestep()

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -638,18 +638,18 @@ int main(int argc, char* argv[]) {
     auto num_times = manager->Simulation_Time_Object->get_total_output_times();
 
     // T-ROUTE data storage
-    std::vector<double> catchment_results;
+    std::vector<double> catchment_outflows;
     std::unordered_map<std::string, int> catchment_indexes;
-    std::vector<double> nexus_results;
+    std::vector<double> nexus_downstream_flows;
     std::unordered_map<std::string, int> nexus_indexes;
 #if NGEN_WITH_ROUTING
-    catchment_results.resize(catchment_collection->get_size() * num_times);
+    catchment_outflows.resize(catchment_collection->get_size() * num_times);
     for (int i = 0; i < catchment_collection->get_size(); ++i) {
         auto feature = catchment_collection->get_feature(i);
         std::string feature_id = feature->get_id();
         catchment_indexes[feature_id] = i;
     }
-    nexus_results.resize(nexus_collection->get_size() * num_times);
+    nexus_downstream_flows.resize(nexus_collection->get_size() * num_times);
     for (int i = 0; i < nexus_collection->get_size(); ++i) {
         auto feature = catchment_collection->get_feature(i);
         std::string feature_id = feature->get_id();
@@ -688,9 +688,9 @@ int main(int argc, char* argv[]) {
                         ss.str("");
                     }
 #if NGEN_WITH_ROUTING
-                    boost::span<double> catchment_span(catchment_results.data() + (count * catchment_indexes.size()),
+                    boost::span<double> catchment_span(catchment_outflows.data() + (count * catchment_indexes.size()),
                                                        catchment_indexes.size());
-                    boost::span<double> nexus_span(nexus_results.data() + (count * nexus_indexes.size()),
+                    boost::span<double> nexus_span(nexus_downstream_flows.data() + (count * nexus_indexes.size()),
                                                    nexus_indexes.size());
 #else
                     boost::span<double> catchment_span;

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -530,6 +530,18 @@ int main(int argc, char* argv[]) {
     // TODO don't really need catchment_collection once catchments are added to nexus collection
     // Still using  catchments for geometry at the moment, fix this later
     // catchment_collection.reset();
+
+    // T-ROUTE data storage
+    std::unordered_map<std::string, int> nexus_indexes;
+#if NGEN_WITH_ROUTING
+    int nexus_collection_size = nexus_collection->get_size();
+    for (int i = 0; i < nexus_collection_size; ++i) {
+        auto feature = nexus_collection->get_feature(i);
+        std::string feature_id = feature->get_id();
+        nexus_indexes[feature_id] = i;
+    }
+#endif // NGEN_WITH_ROUTING
+
     nexus_collection.reset();
 
     // Still hacking nexus output for the moment
@@ -641,7 +653,6 @@ int main(int argc, char* argv[]) {
     std::vector<double> catchment_outflows;
     std::unordered_map<std::string, int> catchment_indexes;
     std::vector<double> nexus_downstream_flows;
-    std::unordered_map<std::string, int> nexus_indexes;
 #if NGEN_WITH_ROUTING
     catchment_outflows.resize(catchment_collection->get_size() * num_times);
     for (int i = 0; i < catchment_collection->get_size(); ++i) {
@@ -649,12 +660,7 @@ int main(int argc, char* argv[]) {
         std::string feature_id = feature->get_id();
         catchment_indexes[feature_id] = i;
     }
-    nexus_downstream_flows.resize(nexus_collection->get_size() * num_times);
-    for (int i = 0; i < nexus_collection->get_size(); ++i) {
-        auto feature = catchment_collection->get_feature(i);
-        std::string feature_id = feature->get_id();
-        nexus_indexes[feature_id] = i;
-    }
+    nexus_downstream_flows.resize(nexus_collection_size * num_times);
 #endif // NGEN_WITH_ROUTING
 
     for (int count = 0; count < num_times; count++) {

--- a/src/core/SurfaceLayer.cpp
+++ b/src/core/SurfaceLayer.cpp
@@ -4,11 +4,15 @@
  * @brief Run one simulation timestep for each model in this layer, then gather catchment output
 */
 
-void ngen::SurfaceLayer::update_models()
+void ngen::SurfaceLayer::update_models(std::vector<double> &catchment_results, 
+                                       std::unordered_map<std::string, int> &catchment_indexes,
+                                       std::vector<double> &nexus_results,
+                                       std::unordered_map<std::string, int> &nexus_indexes,
+                                       int current_step)
 {
     long current_time_index = output_time_index;
     
-    Layer::update_models();
+    Layer::update_models(catchment_results, catchment_indexes, nexus_results, nexus_indexes, current_step);
 
     //At this point, could make an internal routing pass, extracting flows from nexuses and routing
     //across the flowpath to the next nexus.
@@ -36,7 +40,10 @@ void ngen::SurfaceLayer::update_models()
 
         //std::cerr << "Requesting water from nexus, id = " << id << " at time = " <<current_time_index << ",  percent = 100, destination = " << cat_id << std::endl;
         double contribution_at_t = features.nexus_at(id)->get_downstream_flow(cat_id, current_time_index, 100.0);
-        
+#if NGEN_WITH_ROUTING
+        int nexus_index = nexus_indexes[id];
+        nexus_results[nexus_index + current_step] = contribution_at_t;
+#endif // NGEN_WITH_ROUTING
         if(nexus_outfiles[id].is_open()) {
         nexus_outfiles[id] << current_time_index << ", " << current_timestamp << ", " << contribution_at_t << std::endl;
         }

--- a/src/core/SurfaceLayer.cpp
+++ b/src/core/SurfaceLayer.cpp
@@ -4,15 +4,15 @@
  * @brief Run one simulation timestep for each model in this layer, then gather catchment output
 */
 
-void ngen::SurfaceLayer::update_models(boost::span<double> catchment_results, 
+void ngen::SurfaceLayer::update_models(boost::span<double> catchment_outflows, 
                                        std::unordered_map<std::string, int> &catchment_indexes,
-                                       boost::span<double> nexus_results,
+                                       boost::span<double> nexus_downstream_flows,
                                        std::unordered_map<std::string, int> &nexus_indexes,
                                        int current_step)
 {
     long current_time_index = output_time_index;
     
-    Layer::update_models(catchment_results, catchment_indexes, nexus_results, nexus_indexes, current_step);
+    Layer::update_models(catchment_outflows, catchment_indexes, nexus_downstream_flows, nexus_indexes, current_step);
 
     //At this point, could make an internal routing pass, extracting flows from nexuses and routing
     //across the flowpath to the next nexus.
@@ -42,7 +42,7 @@ void ngen::SurfaceLayer::update_models(boost::span<double> catchment_results,
         double contribution_at_t = features.nexus_at(id)->get_downstream_flow(cat_id, current_time_index, 100.0);
 #if NGEN_WITH_ROUTING
         int nexus_index = nexus_indexes[id];
-        nexus_results[nexus_index] = contribution_at_t;
+        nexus_downstream_flows[nexus_index] = contribution_at_t;
 #endif // NGEN_WITH_ROUTING
         if(nexus_outfiles[id].is_open()) {
         nexus_outfiles[id] << current_time_index << ", " << current_timestamp << ", " << contribution_at_t << std::endl;

--- a/src/core/SurfaceLayer.cpp
+++ b/src/core/SurfaceLayer.cpp
@@ -4,9 +4,9 @@
  * @brief Run one simulation timestep for each model in this layer, then gather catchment output
 */
 
-void ngen::SurfaceLayer::update_models(std::vector<double> &catchment_results, 
+void ngen::SurfaceLayer::update_models(boost::span<double> catchment_results, 
                                        std::unordered_map<std::string, int> &catchment_indexes,
-                                       std::vector<double> &nexus_results,
+                                       boost::span<double> nexus_results,
                                        std::unordered_map<std::string, int> &nexus_indexes,
                                        int current_step)
 {
@@ -42,7 +42,7 @@ void ngen::SurfaceLayer::update_models(std::vector<double> &catchment_results,
         double contribution_at_t = features.nexus_at(id)->get_downstream_flow(cat_id, current_time_index, 100.0);
 #if NGEN_WITH_ROUTING
         int nexus_index = nexus_indexes[id];
-        nexus_results[nexus_index + current_step] = contribution_at_t;
+        nexus_results[nexus_index] = contribution_at_t;
 #endif // NGEN_WITH_ROUTING
         if(nexus_outfiles[id].is_open()) {
         nexus_outfiles[id] << current_time_index << ", " << current_timestamp << ", " << contribution_at_t << std::endl;


### PR DESCRIPTION
The results of the formulations for catchments and nexuses are stored in a vector. This is the first step in moving the call to t-route from Routing_Py_Adapter to a BMI.

Using:
- C = number of local catchments in the ngen process
- N = number of local nexuses in the ngen process
- T = number of timesteps to be executed in the simulation

The catchment vector is size (C * T) and the nexus vector is (N * T).
The vector data structure can be thought of as an array of arrays of size C or N. Each catchment ID and nexus ID gets an index as its offset from the beginning of a timestep.

Using "A", "B", and "C" as example catchment IDs, here's a quick visualization of where the data for a catchment could be retrieved from the flat vector:
```
[["A", "B", "C"], // time step 1
 ["A", "B", "C"], // time step 2
 ["A", "B", "C"]] // time step 3
```

## Additions

- std::vector<double> containers for holding the results of the formulations. They will be used to pass data to the BMI version of t-route later.
- `std::unordered_map<string, int>` containers for looking up the index associated with catchments/nexuses IDs as an offset from the beginning of a timestep in the results vector.

## Changes

- `Layer::update_models` now includes the results containers and lookups in the parameters.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [x] Linux
