### PR TITLE
NWGPC-7242: t-route forcings (source_Troute.nc) read by NetCDFMeshPointsDataProvider

### DIFF
--- a/include/forcing/FlowMeshPolicy.h
+++ b/include/forcing/FlowMeshPolicy.h
@@ -1,0 +1,50 @@
+#ifndef FLOWMESHPOLICY_H
+#define FLOWMESHPOLICY_H
+
+#include <string>
+#include <algorithm>
+#include <map>
+#include <memory>
+#include <string>
+#include <exception>
+#include <chrono>
+#include "GenericDataProvider.hpp"
+#include "DataProviderSelectors.hpp"
+#include "DataProvider.hpp"
+#include "NetCDFMeshPointsDataProvider.hpp"
+
+namespace data_access {
+    class FlowMeshPolicy
+    {//FlowMeshPolicy
+        using time_point_type = std::chrono::time_point<std::chrono::system_clock>;
+        public:
+                static void getTimes( netCDF::NcFile const& nc_file,
+		             time_point_type const& start_time,
+		             std::vector< time_point_type >& times,
+                             std::chrono::seconds& stride );
+
+                static std::vector< std::string > getVarNames( netCDF::NcFile const& nc_file );
+
+                static void get_values( netCDF::NcFile const& nc_file,
+		                     MeshPointsSelector const& selector,
+					      boost::span<double> data,
+			                      size_t const& time_index,
+					      netCDF::NcVar const& ncvar,
+	                                      std::string const& source_units,
+					      double const& scale_factor,
+					      double const& offset );
+
+            static  double get_value( netCDF::NcFile const& nc_file,
+			               MeshPointsSelector const& selector, 
+			                data_access::ReSampleMethod m,
+			      size_t const& pt_index,
+	                      size_t const& time_index,
+			netCDF::NcVar const& ncvar,
+	                std::string const& source_units,
+			double const& scale_factor,
+			double const& offset );
+
+           static std::string convertVarName( std::string const& var_name_in );
+    };//FlowMeshPolicy
+}
+#endif //#ifndef FLOWMESHPOLICY_H

--- a/include/forcing/FlowMeshPolicy.h
+++ b/include/forcing/FlowMeshPolicy.h
@@ -2,16 +2,14 @@
 #define FLOWMESHPOLICY_H
 
 #include <string>
-#include <algorithm>
-#include <map>
-#include <memory>
-#include <string>
-#include <exception>
 #include <chrono>
-#include "GenericDataProvider.hpp"
-#include "DataProviderSelectors.hpp"
-#include "DataProvider.hpp"
-#include "NetCDFMeshPointsDataProvider.hpp"
+#include "forcing/MeshPointsSelectors.hpp"
+#include "forcing/DataProvider.hpp"
+
+namespace netCDF {
+    class NcVar;
+    class NcFile;
+}
 
 namespace data_access {
     class FlowMeshPolicy
@@ -19,30 +17,30 @@ namespace data_access {
         using time_point_type = std::chrono::time_point<std::chrono::system_clock>;
         public:
                 static void getTimes( netCDF::NcFile const& nc_file,
-		             time_point_type const& start_time,
-		             std::vector< time_point_type >& times,
+                             time_point_type const& start_time,
+                             std::vector< time_point_type >& times,
                              std::chrono::seconds& stride );
 
                 static std::vector< std::string > getVarNames( netCDF::NcFile const& nc_file );
 
                 static void get_values( netCDF::NcFile const& nc_file,
-		                     MeshPointsSelector const& selector,
-					      boost::span<double> data,
-			                      size_t const& time_index,
-					      netCDF::NcVar const& ncvar,
-	                                      std::string const& source_units,
-					      double const& scale_factor,
-					      double const& offset );
+                                     MeshPointsSelector const& selector,
+                                              boost::span<double> data,
+                                              size_t const& time_index,
+                                              netCDF::NcVar const& ncvar,
+                                              std::string const& source_units,
+                                              double const& scale_factor,
+                                              double const& offset );
 
             static  double get_value( netCDF::NcFile const& nc_file,
-			               MeshPointsSelector const& selector, 
-			                data_access::ReSampleMethod m,
-			      size_t const& pt_index,
-	                      size_t const& time_index,
-			netCDF::NcVar const& ncvar,
-	                std::string const& source_units,
-			double const& scale_factor,
-			double const& offset );
+                                       MeshPointsSelector const& selector, 
+                                        data_access::ReSampleMethod m,
+                              size_t const& pt_index,
+                              size_t const& time_index,
+                        netCDF::NcVar const& ncvar,
+                        std::string const& source_units,
+                        double const& scale_factor,
+                        double const& offset );
 
            static std::string convertVarName( std::string const& var_name_in );
     };//FlowMeshPolicy

--- a/include/forcing/MetMeshPolicy.h
+++ b/include/forcing/MetMeshPolicy.h
@@ -1,0 +1,51 @@
+#ifndef METMESHPOLICY_H
+#define METMESHPOLICY_H
+
+#include <string>
+#include <algorithm>
+#include <map>
+#include <memory>
+#include <string>
+#include <exception>
+#include <chrono>
+#include "GenericDataProvider.hpp"
+#include "DataProviderSelectors.hpp"
+#include "DataProvider.hpp"
+#include "NetCDFMeshPointsDataProvider.hpp"
+
+namespace data_access {
+    class MetMeshPolicy
+    {//MetMeshPolicy
+        using time_point_type = std::chrono::time_point<std::chrono::system_clock>;
+        public:
+                static void getTimes( netCDF::NcFile const& nc_file,
+		             time_point_type const& start_time,
+		             std::vector< time_point_type >& times,
+                             std::chrono::seconds& stride );
+
+                static std::vector< std::string > getVarNames( netCDF::NcFile const& nc_file );
+
+                static void get_values( netCDF::NcFile const& nc_file,
+		                     MeshPointsSelector const& selector,
+					      boost::span<double> data,
+			                      size_t const& time_index,
+					      netCDF::NcVar const& ncvar,
+	                                      std::string const& source_units,
+					      double const& scale_factor,
+					      double const& offset );
+
+            static  double get_value( netCDF::NcFile const& nc_file,
+			               MeshPointsSelector const& selector, 
+			                data_access::ReSampleMethod m,
+			      size_t const& pt_index,
+	                      size_t const& time_index,
+			netCDF::NcVar const& ncvar,
+	                std::string const& source_units,
+			double const& scale_factor,
+			double const& offset );
+
+         static std::string convertVarName( std::string const& var_name_in );
+
+    };//MetMeshPolicy
+}
+#endif //#ifndef METMESHPOLICY_H

--- a/include/forcing/MetMeshPolicy.h
+++ b/include/forcing/MetMeshPolicy.h
@@ -2,16 +2,14 @@
 #define METMESHPOLICY_H
 
 #include <string>
-#include <algorithm>
-#include <map>
-#include <memory>
-#include <string>
-#include <exception>
 #include <chrono>
-#include "GenericDataProvider.hpp"
-#include "DataProviderSelectors.hpp"
-#include "DataProvider.hpp"
-#include "NetCDFMeshPointsDataProvider.hpp"
+#include "forcing/MeshPointsSelectors.hpp"
+#include "forcing/DataProvider.hpp"
+
+namespace netCDF {
+    class NcVar;
+    class NcFile;
+}
 
 namespace data_access {
     class MetMeshPolicy
@@ -19,30 +17,30 @@ namespace data_access {
         using time_point_type = std::chrono::time_point<std::chrono::system_clock>;
         public:
                 static void getTimes( netCDF::NcFile const& nc_file,
-		             time_point_type const& start_time,
-		             std::vector< time_point_type >& times,
+                             time_point_type const& start_time,
+                             std::vector< time_point_type >& times,
                              std::chrono::seconds& stride );
 
                 static std::vector< std::string > getVarNames( netCDF::NcFile const& nc_file );
 
                 static void get_values( netCDF::NcFile const& nc_file,
-		                     MeshPointsSelector const& selector,
-					      boost::span<double> data,
-			                      size_t const& time_index,
-					      netCDF::NcVar const& ncvar,
-	                                      std::string const& source_units,
-					      double const& scale_factor,
-					      double const& offset );
+                                     MeshPointsSelector const& selector,
+                                              boost::span<double> data,
+                                              size_t const& time_index,
+                                              netCDF::NcVar const& ncvar,
+                                              std::string const& source_units,
+                                              double const& scale_factor,
+                                              double const& offset );
 
             static  double get_value( netCDF::NcFile const& nc_file,
-			               MeshPointsSelector const& selector, 
-			                data_access::ReSampleMethod m,
-			      size_t const& pt_index,
-	                      size_t const& time_index,
-			netCDF::NcVar const& ncvar,
-	                std::string const& source_units,
-			double const& scale_factor,
-			double const& offset );
+                                       MeshPointsSelector const& selector, 
+                                        data_access::ReSampleMethod m,
+                              size_t const& pt_index,
+                              size_t const& time_index,
+                        netCDF::NcVar const& ncvar,
+                        std::string const& source_units,
+                        double const& scale_factor,
+                        double const& offset );
 
          static std::string convertVarName( std::string const& var_name_in );
 

--- a/include/forcing/NetCDFMeshPointsDataProvider.hpp
+++ b/include/forcing/NetCDFMeshPointsDataProvider.hpp
@@ -21,6 +21,7 @@ namespace netCDF {
 
 namespace data_access
 {
+    template <typename MeshPolicy>
     class NetCDFMeshPointsDataProvider : public MeshPointsDataProvider
     {
         public:

--- a/include/forcing/TidalMeshPolicy.h
+++ b/include/forcing/TidalMeshPolicy.h
@@ -1,16 +1,15 @@
-#ifndef TIDALMETHPOLICY_H
-#define TIDALMETHPOLICY_H
+#ifndef TIDALMESHPOLICY_H
+#define TIDALMESHPOLICY_H
 
 #include <string>
-#include <algorithm>
-#include <map>
-#include <memory>
-#include <string>
-#include <exception>
 #include <chrono>
-#include "GenericDataProvider.hpp"
-#include "DataProviderSelectors.hpp"
-#include "DataProvider.hpp"
+#include "forcing/MeshPointsSelectors.hpp"
+#include "forcing/DataProvider.hpp"
+
+namespace netCDF {
+    class NcVar;
+    class NcFile;
+}
 
 namespace data_access {
     class TidalMeshPolicy
@@ -18,36 +17,36 @@ namespace data_access {
         using time_point_type = std::chrono::time_point<std::chrono::system_clock>;
         public:
                 static void getTimes( netCDF::NcFile const& nc_file,
-		             time_point_type const& start_time,
-		             std::vector< time_point_type >& times,
+                             time_point_type const& start_time,
+                             std::vector< time_point_type >& times,
                              std::chrono::seconds& stride );
 
                 static std::vector< std::string > getVarNames( netCDF::NcFile const& nc_file );
 
                 static void get_values( netCDF::NcFile const& nc_file,
-		                     MeshPointsSelector const& selector,
-					      boost::span<double> data,
-			                      size_t const& time_index,
-					      netCDF::NcVar const& ncvar,
-	                                      std::string const& source_units,
-					      double const& scale_factor,
-					      double const& offset );
+                                     MeshPointsSelector const& selector,
+                                              boost::span<double> data,
+                                              size_t const& time_index,
+                                              netCDF::NcVar const& ncvar,
+                                              std::string const& source_units,
+                                              double const& scale_factor,
+                                              double const& offset );
 
             static  double get_value( netCDF::NcFile const& nc_file,
-			               MeshPointsSelector const& selector, 
-			                data_access::ReSampleMethod m,
-			      size_t const& pt_index,
-	                      size_t const& time_index,
-			netCDF::NcVar const& ncvar,
-	                std::string const& source_units,
-			double const& scale_factor,
-			double const& offset );
+                                       MeshPointsSelector const& selector, 
+                                       data_access::ReSampleMethod m,
+                                       size_t const& pt_index,
+                                       size_t const& time_index,
+                                       netCDF::NcVar const& ncvar,
+                                       std::string const& source_units,
+                                       double const& scale_factor,
+                                       double const& offset );
 
          static std::string convertVarName( std::string const& var_name_in );
 
         private:
-	 static time_point_type stringToTimePoint(std::string const& datetime_str, 
-			                         std::string const& format_str);
+         static time_point_type stringToTimePoint(std::string const& datetime_str, 
+                                                 std::string const& format_str);
     };//TidalMeshPolicy
 }
-#endif //#ifndef TIDALMETHPOLICY_H
+#endif //#ifndef TIDALMESHPOLICY_H

--- a/include/forcing/TidalMeshPolicy.h
+++ b/include/forcing/TidalMeshPolicy.h
@@ -1,0 +1,53 @@
+#ifndef TIDALMETHPOLICY_H
+#define TIDALMETHPOLICY_H
+
+#include <string>
+#include <algorithm>
+#include <map>
+#include <memory>
+#include <string>
+#include <exception>
+#include <chrono>
+#include "GenericDataProvider.hpp"
+#include "DataProviderSelectors.hpp"
+#include "DataProvider.hpp"
+
+namespace data_access {
+    class TidalMeshPolicy
+    {//TidalMeshPolicy
+        using time_point_type = std::chrono::time_point<std::chrono::system_clock>;
+        public:
+                static void getTimes( netCDF::NcFile const& nc_file,
+		             time_point_type const& start_time,
+		             std::vector< time_point_type >& times,
+                             std::chrono::seconds& stride );
+
+                static std::vector< std::string > getVarNames( netCDF::NcFile const& nc_file );
+
+                static void get_values( netCDF::NcFile const& nc_file,
+		                     MeshPointsSelector const& selector,
+					      boost::span<double> data,
+			                      size_t const& time_index,
+					      netCDF::NcVar const& ncvar,
+	                                      std::string const& source_units,
+					      double const& scale_factor,
+					      double const& offset );
+
+            static  double get_value( netCDF::NcFile const& nc_file,
+			               MeshPointsSelector const& selector, 
+			                data_access::ReSampleMethod m,
+			      size_t const& pt_index,
+	                      size_t const& time_index,
+			netCDF::NcVar const& ncvar,
+	                std::string const& source_units,
+			double const& scale_factor,
+			double const& offset );
+
+         static std::string convertVarName( std::string const& var_name_in );
+
+        private:
+	 static time_point_type stringToTimePoint(std::string const& datetime_str, 
+			                         std::string const& format_str);
+    };//TidalMeshPolicy
+}
+#endif //#ifndef TIDALMETHPOLICY_H

--- a/include/realizations/coastal/SchismCreator.h
+++ b/include/realizations/coastal/SchismCreator.h
@@ -8,11 +8,11 @@ class SchismCreator : public ModelCreator {
 public:
     std::unique_ptr<CoastalFormulation>
                     createCoastalFormulation( coastal_config_params const&,
-				              Simulation_Time const&  ) const override;
+                                              Simulation_Time const&  ) const override;
     SchismCreator* clone() const override;
 private:
     void writeInitConfig(coastal_config_params const&,
-		         Simulation_Time const& ) const;
+                         Simulation_Time const& ) const;
 };
 
 #endif // #ifndef SCHISM_CREATOR_HEADER

--- a/include/realizations/coastal/SchismFormulation.hpp
+++ b/include/realizations/coastal/SchismFormulation.hpp
@@ -15,8 +15,6 @@ class SchismFormulation final : public CoastalFormulation
 public:
     using ProviderType = data_access::MeshPointsDataProvider;
 
-    static void check_forcing_provider( ProviderType const& provider );
-
     SchismFormulation(
                       std::string const& id
                       , std::string const& library_path
@@ -55,6 +53,10 @@ public:
     enum ForcingSelector { METEO, OFFSHORE, CHANNEL_FLOW };
     struct InputMapping { ForcingSelector selector; std::string name; };
     static std::map<std::string, InputMapping> expected_input_variables_;
+
+    static void check_forcing_provider( ProviderType const& provider, 
+		                    SchismFormulation::ForcingSelector selector );
+
 
 protected:
     size_t mesh_size(std::string const& variable_name) override;

--- a/src/forcing/CMakeLists.txt
+++ b/src/forcing/CMakeLists.txt
@@ -21,6 +21,8 @@ target_link_libraries(forcing PUBLIC
 )
 
 target_sources(forcing PRIVATE "${CMAKE_CURRENT_LIST_DIR}/NullForcingProvider.cpp")
+target_sources(forcing PRIVATE "${CMAKE_CURRENT_LIST_DIR}/MetMeshPolicy.cpp")
+target_sources(forcing PRIVATE "${CMAKE_CURRENT_LIST_DIR}/FlowMeshPolicy.cpp")
 
 if(NGEN_WITH_NETCDF)
     target_sources(forcing PRIVATE

--- a/src/forcing/CMakeLists.txt
+++ b/src/forcing/CMakeLists.txt
@@ -23,6 +23,7 @@ target_link_libraries(forcing PUBLIC
 target_sources(forcing PRIVATE "${CMAKE_CURRENT_LIST_DIR}/NullForcingProvider.cpp")
 target_sources(forcing PRIVATE "${CMAKE_CURRENT_LIST_DIR}/MetMeshPolicy.cpp")
 target_sources(forcing PRIVATE "${CMAKE_CURRENT_LIST_DIR}/FlowMeshPolicy.cpp")
+target_sources(forcing PRIVATE "${CMAKE_CURRENT_LIST_DIR}/TidalMeshPolicy.cpp")
 
 if(NGEN_WITH_NETCDF)
     target_sources(forcing PRIVATE

--- a/src/forcing/FlowMeshPolicy.cpp
+++ b/src/forcing/FlowMeshPolicy.cpp
@@ -1,0 +1,201 @@
+#include <iostream>
+#include <vector>
+#include <netcdf>
+#include <UnitsHelper.hpp>
+#include "forcing/FlowMeshPolicy.h"
+#include "forcing/NetCDFMeshPointsDataProvider.hpp"
+
+void data_access::FlowMeshPolicy::getTimes( netCDF::NcFile const& nc_file,
+		             time_point_type const& start_time,
+		             std::vector< time_point_type >& times,
+                             std::chrono::seconds& stride )
+{
+    auto source_num_times = nc_file.getDim("time_vsource").getSize();
+    auto sink_num_times = nc_file.getDim("time_vsink").getSize();
+    if ( source_num_times != sink_num_times ) {
+        throw std::runtime_error("'time_vsource' and 'time_vsink' have different dimensions!");
+    }
+
+    auto source_time_var = nc_file.getVar("time_vsource");
+
+    if (source_time_var.getDimCount() != 1) {
+        throw std::runtime_error("'time_vsource' variable has dimension other than 1");
+    }
+
+    auto sink_time_var = nc_file.getVar("time_vsink");
+
+    if (sink_time_var.getDimCount() != 1) {
+        throw std::runtime_error("'time_vink' variable has dimension other than 1");
+    }
+
+    std::vector<std::chrono::duration<double>> raw_time(source_num_times);
+
+    source_time_var.getVar(raw_time.data());
+
+    times.reserve(source_num_times);
+    for (int i = 0; i < source_num_times; ++i) {
+        // Assume that the system clock's epoch matches Unix time.
+        // This is guaranteed from C++20 onwards
+        times.push_back(time_point_type(
+		start_time + std::chrono::duration_cast<time_point_type::duration>(raw_time[i])));
+    }
+
+    stride = std::chrono::duration_cast<std::chrono::seconds>(times[1] - times[0]);
+
+    // verify the time stride
+    for( size_t i = 1; i < times.size() -1; ++i)
+    {
+        auto tinterval = times[i+1] - times[i];
+
+        if ( tinterval - stride > std::chrono::microseconds(1) ||
+             stride - tinterval > std::chrono::microseconds(1) )
+        {
+            throw std::runtime_error("Time intervals in forcing file are not constant");
+        }
+    }
+}
+
+std::vector< std::string > data_access::FlowMeshPolicy::getVarNames( netCDF::NcFile const& nc_file )
+{
+    std::vector< std::string > varnames;
+    std::multimap< std::string, netCDF::NcVar > vars = nc_file.getVars();
+    std::transform(vars.begin(), vars.end(), 
+		    std::back_inserter(varnames),
+          [](const std::pair< std::string, netCDF::NcVar >& pair) { 
+	         if ( pair.first == "vsource" )
+		 {
+		     return std::string( "Q_bnd_source" );
+		 }
+	         if ( pair.first == "vsink" )
+		 {
+		     return std::string( "Q_bnd_sink" );
+		 }
+	         return pair.first; });
+#ifdef DEBUG_NETCDFMESH
+    std::cerr << "var names: " << std::endl;
+    std::copy( varnames.begin(), varnames.end(),
+          std::ostream_iterator< std::string > ( std::cerr, " \n" ) );
+#endif //#ifdef DEBUG_NETCDFMESH
+    return varnames;
+}
+
+void data_access::FlowMeshPolicy::get_values( netCDF::NcFile const& nc_file,
+		                              MeshPointsSelector const& selector,
+					      boost::span<double> data,
+	                                      size_t const& time_index,
+					      netCDF::NcVar const& ncvar,
+	                                      std::string const& source_units,
+					      double const& scale_factor,
+					      double const& offset
+	                                      	)
+{
+#ifdef DEBUG_NETCDFMESH
+    std::cerr << "time_index = " << time_index << std::endl;
+#endif //#ifdef DEBUG_NETCDFMESH
+
+    // XXX: Ignores the point selection in `selector`
+    // Possibly assert somewhere (at startup) that dimensions are actually (Time, Index)
+    //
+    ncvar.getVar({time_index, 0}, {1, data.size()}, data.data());
+
+    for (auto& value : data) {
+        value = value * scale_factor + offset;
+#ifdef DEBUG_NETCDFMESH
+    std::cerr << selector. variable_name << ": value = " << value << std::endl;
+#endif //#ifdef DEBUG_NETCDFMESH
+    }
+
+}
+
+double data_access::FlowMeshPolicy::get_value( netCDF::NcFile const& nc_file,
+		              MeshPointsSelector const& selector, data_access::ReSampleMethod m,
+			      size_t const& pt_index,
+	                      size_t const& time_index,
+			netCDF::NcVar const& ncvar,
+	                std::string const& source_units,
+			double const& scale_factor,
+			double const& offset
+	       	)
+{
+    size_t n_elem = nc_file.getDim( "nsources" ).getSize();
+
+    if ( pt_index >= n_elem && selector.variable_name == "vsource" ) {
+        throw std::out_of_range("Point index exceeds available dimension size - nsources");
+    }
+
+    n_elem = nc_file.getDim( "nsinks" ).getSize();
+    if ( pt_index >= n_elem && selector.variable_name == "vsink" ) {
+        throw std::out_of_range("Point index exceeds available dimension size - nsinks");
+    }
+
+    // Read raw value from NetCDF variable
+    nc_type vartype = ncvar.getType().getId();
+    double raw_value = 0.0;
+
+    if (vartype == NC_FLOAT) {
+        float tmp;
+        ncvar.getVar({time_index, pt_index}, {1, 1}, &tmp);
+        raw_value = static_cast<double>(tmp);
+    }
+    else if (vartype == NC_DOUBLE) {
+        double tmp;
+        ncvar.getVar({time_index, pt_index}, {1, 1}, &tmp);
+        raw_value = static_cast<double>(tmp);
+    }
+    else if (vartype == NC_INT || vartype == NC_SHORT || vartype == NC_BYTE) {
+        int tmp;
+        ncvar.getVar({time_index, pt_index}, {1, 1}, &tmp);
+        raw_value = static_cast<double>(tmp);
+    }
+    else {
+        throw std::runtime_error("Unsupported NetCDF variable type in get_value()");
+    }
+
+    // Check for _FillValue (missing data)
+    try {
+        if (!ncvar.getAtt("_FillValue").isNull()) {
+            if (vartype == NC_FLOAT) {
+                float fv;
+                ncvar.getAtt("_FillValue").getValues(&fv);
+                if (static_cast<float>(raw_value) == fv)
+                    throw std::runtime_error("Encountered _FillValue (missing data)");
+	    } else if (vartype == NC_DOUBLE) {
+                double fv; 
+		ncvar.getAtt("_FillValue").getValues(&fv);
+                if (static_cast<double>(raw_value) == fv)
+                    throw std::runtime_error("Encountered _FillValue (missing data).");
+            } else if (vartype == NC_INT || vartype == NC_SHORT || vartype == NC_BYTE) {
+                int fv;
+                ncvar.getAtt("_FillValue").getValues(&fv);
+                if (static_cast<int>(raw_value) == fv)
+                    throw std::runtime_error("Encountered _FillValue (missing data)");
+            }
+	} else {
+            // No _FillValue attribute — use NetCDF library defaults
+            if (vartype == NC_DOUBLE && raw_value == static_cast<double>(NC_FILL_DOUBLE))
+                throw std::runtime_error("Encountered default NC_FILL_DOUBLE missing data.");
+            if (vartype == NC_FLOAT && raw_value == static_cast<double>(NC_FILL_FLOAT))
+                throw std::runtime_error("Encountered default NC_FILL_FLOAT missing data.");
+        }
+    } catch (...) {
+        // Safe to ignore if _FillValue attribute is missing
+    }
+
+    // Apply scale and offset
+    double value = raw_value * scale_factor + offset;
+
+    return value;
+}
+
+std::string data_access::FlowMeshPolicy::convertVarName( std::string const& var_name_in )
+{
+      if ( var_name_in == std::string( "Q_bnd_source" ) )
+      {
+	 return std::string( "vsource" );
+      }
+      if ( var_name_in == std::string( "Q_bnd_sink" ) )
+      {
+	 return std::string( "vsink" );
+      }
+      return std::string();
+}

--- a/src/forcing/FlowMeshPolicy.cpp
+++ b/src/forcing/FlowMeshPolicy.cpp
@@ -1,13 +1,13 @@
 #include <iostream>
 #include <vector>
+#include <algorithm>
 #include <netcdf>
 #include <UnitsHelper.hpp>
 #include "forcing/FlowMeshPolicy.h"
-#include "forcing/NetCDFMeshPointsDataProvider.hpp"
 
 void data_access::FlowMeshPolicy::getTimes( netCDF::NcFile const& nc_file,
-		             time_point_type const& start_time,
-		             std::vector< time_point_type >& times,
+                             time_point_type const& start_time,
+                             std::vector< time_point_type >& times,
                              std::chrono::seconds& stride )
 {
 #ifdef DEBUG_NETCDFMESH
@@ -49,7 +49,7 @@ void data_access::FlowMeshPolicy::getTimes( netCDF::NcFile const& nc_file,
         // Assume that the system clock's epoch matches Unix time.
         // This is guaranteed from C++20 onwards
         times.push_back(time_point_type(
-		start_time + std::chrono::duration_cast<time_point_type::duration>(raw_time[i])));
+                start_time + std::chrono::duration_cast<time_point_type::duration>(raw_time[i])));
     }
 
     stride = std::chrono::duration_cast<std::chrono::seconds>(times[1] - times[0]);
@@ -75,17 +75,17 @@ std::vector< std::string > data_access::FlowMeshPolicy::getVarNames( netCDF::NcF
     std::vector< std::string > varnames;
     std::multimap< std::string, netCDF::NcVar > vars = nc_file.getVars();
     std::transform(vars.begin(), vars.end(), 
-		    std::back_inserter(varnames),
+                    std::back_inserter(varnames),
           [](const std::pair< std::string, netCDF::NcVar >& pair) { 
-	         if ( pair.first == "vsource" )
-		 {
-		     return std::string( "Q_bnd_source" );
-		 }
-	         if ( pair.first == "vsink" )
-		 {
-		     return std::string( "Q_bnd_sink" );
-		 }
-	         return pair.first; });
+                 if ( pair.first == "vsource" )
+                 {
+                     return std::string( "Q_bnd_source" );
+                 }
+                 if ( pair.first == "vsink" )
+                 {
+                     return std::string( "Q_bnd_sink" );
+                 }
+                 return pair.first; });
 #ifdef DEBUG_NETCDFMESH
     std::cerr << "var names: " << std::endl;
     std::copy( varnames.begin(), varnames.end(),
@@ -95,14 +95,14 @@ std::vector< std::string > data_access::FlowMeshPolicy::getVarNames( netCDF::NcF
 }
 
 void data_access::FlowMeshPolicy::get_values( netCDF::NcFile const& nc_file,
-		                              MeshPointsSelector const& selector,
-					      boost::span<double> data,
-	                                      size_t const& time_index,
-					      netCDF::NcVar const& ncvar,
-	                                      std::string const& source_units,
-					      double const& scale_factor,
-					      double const& offset
-	                                      	)
+                                              MeshPointsSelector const& selector,
+                                              boost::span<double> data,
+                                              size_t const& time_index,
+                                              netCDF::NcVar const& ncvar,
+                                              std::string const& source_units,
+                                              double const& scale_factor,
+                                              double const& offset
+                                                      )
 {
 #ifdef DEBUG_NETCDFMESH
     std::cerr << "time_index = " << time_index << std::endl;
@@ -123,14 +123,14 @@ void data_access::FlowMeshPolicy::get_values( netCDF::NcFile const& nc_file,
 }
 
 double data_access::FlowMeshPolicy::get_value( netCDF::NcFile const& nc_file,
-		              MeshPointsSelector const& selector, data_access::ReSampleMethod m,
-			      size_t const& pt_index,
-	                      size_t const& time_index,
-			netCDF::NcVar const& ncvar,
-	                std::string const& source_units,
-			double const& scale_factor,
-			double const& offset
-	       	)
+                              MeshPointsSelector const& selector, data_access::ReSampleMethod m,
+                              size_t const& pt_index,
+                              size_t const& time_index,
+                        netCDF::NcVar const& ncvar,
+                        std::string const& source_units,
+                        double const& scale_factor,
+                        double const& offset
+                       )
 {
     size_t n_elem = nc_file.getDim( "nsources" ).getSize();
 
@@ -174,9 +174,9 @@ double data_access::FlowMeshPolicy::get_value( netCDF::NcFile const& nc_file,
                 ncvar.getAtt("_FillValue").getValues(&fv);
                 if (static_cast<float>(raw_value) == fv)
                     throw std::runtime_error("Encountered _FillValue (missing data)");
-	    } else if (vartype == NC_DOUBLE) {
+            } else if (vartype == NC_DOUBLE) {
                 double fv; 
-		ncvar.getAtt("_FillValue").getValues(&fv);
+                ncvar.getAtt("_FillValue").getValues(&fv);
                 if (static_cast<double>(raw_value) == fv)
                     throw std::runtime_error("Encountered _FillValue (missing data).");
             } else if (vartype == NC_INT || vartype == NC_SHORT || vartype == NC_BYTE) {
@@ -185,7 +185,7 @@ double data_access::FlowMeshPolicy::get_value( netCDF::NcFile const& nc_file,
                 if (static_cast<int>(raw_value) == fv)
                     throw std::runtime_error("Encountered _FillValue (missing data)");
             }
-	} else {
+        } else {
             // No _FillValue attribute — use NetCDF library defaults
             if (vartype == NC_DOUBLE && raw_value == static_cast<double>(NC_FILL_DOUBLE))
                 throw std::runtime_error("Encountered default NC_FILL_DOUBLE missing data.");
@@ -206,11 +206,11 @@ std::string data_access::FlowMeshPolicy::convertVarName( std::string const& var_
 {
       if ( var_name_in == std::string( "Q_bnd_source" ) )
       {
-	 return std::string( "vsource" );
+         return std::string( "vsource" );
       }
       if ( var_name_in == std::string( "Q_bnd_sink" ) )
       {
-	 return std::string( "vsink" );
+         return std::string( "vsink" );
       }
       return std::string();
 }

--- a/src/forcing/MetMeshPolicy.cpp
+++ b/src/forcing/MetMeshPolicy.cpp
@@ -1,13 +1,13 @@
 #include <iostream>
 #include <vector>
+#include <algorithm>
 #include <netcdf>
 #include <UnitsHelper.hpp>
 #include "forcing/MetMeshPolicy.h"
-#include "forcing/NetCDFMeshPointsDataProvider.hpp"
 
 void data_access::MetMeshPolicy::getTimes( netCDF::NcFile const& nc_file,
-		             time_point_type const& start_time,
-		             std::vector< time_point_type >& times,
+                             time_point_type const& start_time,
+                             std::vector< time_point_type >& times,
                              std::chrono::seconds& stride )
 {
     auto num_times = nc_file.getDim("time").getSize();
@@ -55,7 +55,7 @@ std::vector< std::string > data_access::MetMeshPolicy::getVarNames( netCDF::NcFi
     std::vector< std::string > varnames;
     std::multimap< std::string, netCDF::NcVar > vars = nc_file.getVars();
     std::transform(vars.begin(), vars.end(), 
-		    std::back_inserter(varnames),
+                    std::back_inserter(varnames),
           [](const std::pair< std::string, netCDF::NcVar >& pair) { return pair.first; });
 #ifdef DEBUG_NETCDFMESH
     std::cerr << "var names: " << std::endl;
@@ -66,14 +66,14 @@ std::vector< std::string > data_access::MetMeshPolicy::getVarNames( netCDF::NcFi
 }
 
 void data_access::MetMeshPolicy::get_values( netCDF::NcFile const& nc_file,
-		                              MeshPointsSelector const& selector,
-					      boost::span<double> data,
-	                                      size_t const& time_index,
-					      netCDF::NcVar const& ncvar,
-	                                      std::string const& source_units,
-					      double const& scale_factor,
-					      double const& offset
-	                                      	)
+                                              MeshPointsSelector const& selector,
+                                              boost::span<double> data,
+                                              size_t const& time_index,
+                                              netCDF::NcVar const& ncvar,
+                                              std::string const& source_units,
+                                              double const& scale_factor,
+                                              double const& offset
+                                                      )
 {
 
     // XXX: Ignores the point selection in `selector`
@@ -99,14 +99,14 @@ void data_access::MetMeshPolicy::get_values( netCDF::NcFile const& nc_file,
 }
 
 double data_access::MetMeshPolicy::get_value( netCDF::NcFile const& nc_file,
-		              MeshPointsSelector const& selector, data_access::ReSampleMethod m,
-			      size_t const& pt_index,
-	                      size_t const& time_index,
-			netCDF::NcVar const& ncvar,
-	                std::string const& source_units,
-			double const& scale_factor,
-			double const& offset
-	       	)
+                              MeshPointsSelector const& selector, data_access::ReSampleMethod m,
+                              size_t const& pt_index,
+                              size_t const& time_index,
+                        netCDF::NcVar const& ncvar,
+                        std::string const& source_units,
+                        double const& scale_factor,
+                        double const& offset
+                       )
 {
     size_t n_elem = nc_file.getDim( "element-id" ).getSize();
 
@@ -145,9 +145,9 @@ double data_access::MetMeshPolicy::get_value( netCDF::NcFile const& nc_file,
                 ncvar.getAtt("_FillValue").getValues(&fv);
                 if (static_cast<float>(raw_value) == fv)
                     throw std::runtime_error("Encountered _FillValue (missing data)");
-	    } else if (vartype == NC_DOUBLE) {
+            } else if (vartype == NC_DOUBLE) {
                 double fv; 
-		ncvar.getAtt("_FillValue").getValues(&fv);
+                ncvar.getAtt("_FillValue").getValues(&fv);
                 if (static_cast<double>(raw_value) == fv)
                     throw std::runtime_error("Encountered _FillValue (missing data).");
             } else if (vartype == NC_INT || vartype == NC_SHORT || vartype == NC_BYTE) {
@@ -156,7 +156,7 @@ double data_access::MetMeshPolicy::get_value( netCDF::NcFile const& nc_file,
                 if (static_cast<int>(raw_value) == fv)
                     throw std::runtime_error("Encountered _FillValue (missing data)");
             }
-	} else {
+        } else {
             // No _FillValue attribute — use NetCDF library defaults
             if (vartype == NC_DOUBLE && raw_value == static_cast<double>(NC_FILL_DOUBLE))
                 throw std::runtime_error("Encountered default NC_FILL_DOUBLE missing data.");
@@ -185,5 +185,5 @@ double data_access::MetMeshPolicy::get_value( netCDF::NcFile const& nc_file,
 
 std::string data_access::MetMeshPolicy::convertVarName( std::string const& var_name_in )
 {
-	return var_name_in;
+        return var_name_in;
 }

--- a/src/forcing/MetMeshPolicy.cpp
+++ b/src/forcing/MetMeshPolicy.cpp
@@ -1,0 +1,189 @@
+#include <iostream>
+#include <vector>
+#include <netcdf>
+#include <UnitsHelper.hpp>
+#include "forcing/MetMeshPolicy.h"
+#include "forcing/NetCDFMeshPointsDataProvider.hpp"
+
+void data_access::MetMeshPolicy::getTimes( netCDF::NcFile const& nc_file,
+		             time_point_type const& start_time,
+		             std::vector< time_point_type >& times,
+                             std::chrono::seconds& stride )
+{
+    auto num_times = nc_file.getDim("time").getSize();
+    auto time_var = nc_file.getVar("Time");
+
+    if (time_var.getDimCount() != 1) {
+        throw std::runtime_error("'Time' variable has dimension other than 1");
+    }
+
+    auto time_unit_att = time_var.getAtt("units");
+    std::string time_unit_str;
+
+    time_unit_att.getValues(time_unit_str);
+    if (time_unit_str != "minutes since 1970-01-01 00:00:00 UTC") {
+        throw std::runtime_error("Time units not exactly as expected");
+    }
+
+    std::vector<std::chrono::duration<double, std::ratio<60>>> raw_time(num_times);
+    time_var.getVar(raw_time.data());
+
+    times.reserve(num_times);
+    for (int i = 0; i < num_times; ++i) {
+        // Assume that the system clock's epoch matches Unix time.
+        // This is guaranteed from C++20 onwards
+        times.push_back(time_point_type(std::chrono::duration_cast<time_point_type::duration>(raw_time[i])));
+    }
+
+    stride = std::chrono::duration_cast<std::chrono::seconds>(times[1] - times[0]);
+
+    // verify the time stride
+    for( size_t i = 1; i < times.size() -1; ++i)
+    {
+        auto tinterval = times[i+1] - times[i];
+
+        if ( tinterval - stride > std::chrono::microseconds(1) ||
+             stride - tinterval > std::chrono::microseconds(1) )
+        {
+            throw std::runtime_error("Time intervals in forcing file are not constant");
+        }
+    }
+}
+
+std::vector< std::string > data_access::MetMeshPolicy::getVarNames( netCDF::NcFile const& nc_file )
+{
+    std::vector< std::string > varnames;
+    std::multimap< std::string, netCDF::NcVar > vars = nc_file.getVars();
+    std::transform(vars.begin(), vars.end(), 
+		    std::back_inserter(varnames),
+          [](const std::pair< std::string, netCDF::NcVar >& pair) { return pair.first; });
+#ifdef DEBUG_NETCDFMESH
+    std::cerr << "var names: " << std::endl;
+    std::copy( varnames.begin(), varnames.end(),
+          std::ostream_iterator< std::string > ( std::cerr, " \n" ) );
+#endif //#ifdef DEBUG_NETCDFMESH
+    return varnames;
+}
+
+void data_access::MetMeshPolicy::get_values( netCDF::NcFile const& nc_file,
+		                              MeshPointsSelector const& selector,
+					      boost::span<double> data,
+	                                      size_t const& time_index,
+					      netCDF::NcVar const& ncvar,
+	                                      std::string const& source_units,
+					      double const& scale_factor,
+					      double const& offset
+	                                      	)
+{
+
+    // XXX: Ignores the point selection in `selector`
+    // Possibly assert somewhere (at startup) that dimensions are actually (Time, Index)
+    ncvar.getVar({time_index, 0}, {1, data.size()}, data.data());
+
+    for (auto& value : data) {
+        value = value * scale_factor + offset;
+    }
+
+    // These mass and and volume flux density units are very close to
+    // numerically identical for liquid water at atmospheric
+    // conditions, and so we currently treat them as interchangeable
+    bool RAINRATE_equivalence =
+        selector.variable_name == "RAINRATE" &&
+        source_units == "mm s^-1" &&
+        selector.output_units == "kg m-2 s-1";
+
+    if (!RAINRATE_equivalence) {
+        UnitsHelper::convert_values(source_units, data.data(), selector.output_units, data.data(), data.size());
+    }
+
+}
+
+double data_access::MetMeshPolicy::get_value( netCDF::NcFile const& nc_file,
+		              MeshPointsSelector const& selector, data_access::ReSampleMethod m,
+			      size_t const& pt_index,
+	                      size_t const& time_index,
+			netCDF::NcVar const& ncvar,
+	                std::string const& source_units,
+			double const& scale_factor,
+			double const& offset
+	       	)
+{
+    size_t n_elem = nc_file.getDim( "element-id" ).getSize();
+
+    if ( pt_index >= n_elem ) {
+        throw std::out_of_range("Point index exceeds available spatial dimension size (y * x).");
+    }
+
+    // Read raw value from NetCDF variable
+    nc_type vartype = ncvar.getType().getId();
+    double raw_value = 0.0;
+
+    if (vartype == NC_FLOAT) {
+        float tmp;
+        ncvar.getVar({time_index, pt_index}, {1, 1}, &tmp);
+        raw_value = static_cast<double>(tmp);
+    }
+    else if (vartype == NC_DOUBLE) {
+        double tmp;
+        ncvar.getVar({time_index, pt_index}, {1, 1}, &tmp);
+        raw_value = static_cast<double>(tmp);
+    }
+    else if (vartype == NC_INT || vartype == NC_SHORT || vartype == NC_BYTE) {
+        int tmp;
+        ncvar.getVar({time_index, pt_index}, {1, 1}, &tmp);
+        raw_value = static_cast<double>(tmp);
+    }
+    else {
+        throw std::runtime_error("Unsupported NetCDF variable type in get_value()");
+    }
+
+    // Check for _FillValue (missing data)
+    try {
+        if (!ncvar.getAtt("_FillValue").isNull()) {
+            if (vartype == NC_FLOAT) {
+                float fv;
+                ncvar.getAtt("_FillValue").getValues(&fv);
+                if (static_cast<float>(raw_value) == fv)
+                    throw std::runtime_error("Encountered _FillValue (missing data)");
+	    } else if (vartype == NC_DOUBLE) {
+                double fv; 
+		ncvar.getAtt("_FillValue").getValues(&fv);
+                if (static_cast<double>(raw_value) == fv)
+                    throw std::runtime_error("Encountered _FillValue (missing data).");
+            } else if (vartype == NC_INT || vartype == NC_SHORT || vartype == NC_BYTE) {
+                int fv;
+                ncvar.getAtt("_FillValue").getValues(&fv);
+                if (static_cast<int>(raw_value) == fv)
+                    throw std::runtime_error("Encountered _FillValue (missing data)");
+            }
+	} else {
+            // No _FillValue attribute — use NetCDF library defaults
+            if (vartype == NC_DOUBLE && raw_value == static_cast<double>(NC_FILL_DOUBLE))
+                throw std::runtime_error("Encountered default NC_FILL_DOUBLE missing data.");
+            if (vartype == NC_FLOAT && raw_value == static_cast<double>(NC_FILL_FLOAT))
+                throw std::runtime_error("Encountered default NC_FILL_FLOAT missing data.");
+        }
+    } catch (...) {
+        // Safe to ignore if _FillValue attribute is missing
+    }
+
+    // Apply scale and offset
+    double value = raw_value * scale_factor + offset;
+
+    // Handle RAINRATE unit fix if needed
+    bool RAINRATE_equivalence =
+        selector.variable_name == "RAINRATE" &&
+        source_units == "mm s^-1" &&
+        selector.output_units == "kg m-2 s-1";
+
+    if (!RAINRATE_equivalence) {
+        UnitsHelper::convert_values(source_units, &value, selector.output_units, &value, 1);
+    }
+
+    return value;
+}
+
+std::string data_access::MetMeshPolicy::convertVarName( std::string const& var_name_in )
+{
+	return var_name_in;
+}

--- a/src/forcing/NetCDFMeshPointsDataProvider.cpp
+++ b/src/forcing/NetCDFMeshPointsDataProvider.cpp
@@ -13,6 +13,7 @@
 
 #include "forcing/MetMeshPolicy.h"
 #include "forcing/FlowMeshPolicy.h"
+#include "forcing/TidalMeshPolicy.h"
 
 namespace data_access {
 
@@ -32,6 +33,10 @@ NetCDFMeshPointsDataProvider<MeshPolicy>::NetCDFMeshPointsDataProvider(std::stri
     : sim_start_date_time_epoch(sim_start)
     , sim_end_date_time_epoch(sim_end)
 {
+#ifdef DEBUG_NETCDFMESH
+	std::cerr << "ncfile = " << input_path << std::endl;
+#endif //#ifdef DEBUG_NETCDFMESH
+
     nc_file = std::make_shared<netCDF::NcFile>(input_path, netCDF::NcFile::read);
 
     MeshPolicy::getTimes( *nc_file, sim_start, this->time_vals, this->time_stride );
@@ -110,6 +115,14 @@ size_t NetCDFMeshPointsDataProvider<MeshPolicy>::get_ts_index_for_time(const tim
     {
         auto offset = epoch_time - start_time;
         auto index = offset / time_stride;
+#ifdef DEBUG_NETCDFMESH
+    std::cerr << "NetCDFMeshPointsDataProvider::get_ts_index_for_time: offset = "
+	    << offset.count() << std::endl;
+    std::cerr << "NetCDFMeshPointsDataProvider::get_ts_index_for_time: time_stride = "
+	    << time_stride.count() << std::endl;
+    std::cerr << "NetCDFMeshPointsDataProvider::get_ts_index_for_time: index = "
+	    << index << std::endl;
+#endif //#ifdef DEBUG_NETCDFMESH
         return index;
     }
     else
@@ -221,6 +234,7 @@ void NetCDFMeshPointsDataProvider<MeshPolicy>::cache_variable(std::string const&
 //Explicitly instantiate the needed types.
 template class NetCDFMeshPointsDataProvider< MetMeshPolicy >; 
 template class NetCDFMeshPointsDataProvider< FlowMeshPolicy >; 
+template class NetCDFMeshPointsDataProvider< TidalMeshPolicy >; 
 
 }
 

--- a/src/forcing/NetCDFMeshPointsDataProvider.cpp
+++ b/src/forcing/NetCDFMeshPointsDataProvider.cpp
@@ -11,77 +11,40 @@
 #include <iostream>
 #include <iterator>
 
+#include "forcing/MetMeshPolicy.h"
+#include "forcing/FlowMeshPolicy.h"
+
 namespace data_access {
 
 // Out-of-line class definition after forward-declaration so that the
 // header doesn't need #include <netcdf> for NcVar to be a complete
 // type there
-struct NetCDFMeshPointsDataProvider::metadata_cache_entry {
+template <typename MeshPolicy>
+struct NetCDFMeshPointsDataProvider<MeshPolicy>::metadata_cache_entry {
     netCDF::NcVar ncVar;
     std::string units;
     double scale_factor;
     double offset;
 };
 
-NetCDFMeshPointsDataProvider::NetCDFMeshPointsDataProvider(std::string input_path, time_point_type sim_start, time_point_type sim_end)
+template <typename MeshPolicy>
+NetCDFMeshPointsDataProvider<MeshPolicy>::NetCDFMeshPointsDataProvider(std::string input_path, time_point_type sim_start, time_point_type sim_end)
     : sim_start_date_time_epoch(sim_start)
     , sim_end_date_time_epoch(sim_end)
 {
     nc_file = std::make_shared<netCDF::NcFile>(input_path, netCDF::NcFile::read);
 
-    auto num_times = nc_file->getDim("time").getSize();
-    auto time_var = nc_file->getVar("Time");
+    MeshPolicy::getTimes( *nc_file, sim_start, this->time_vals, this->time_stride );
 
-    if (time_var.getDimCount() != 1) {
-        throw std::runtime_error("'Time' variable has dimension other than 1");
-    }
+    this->variable_names = MeshPolicy::getVarNames( *nc_file );
 
-    auto time_unit_att = time_var.getAtt("units");
-    std::string time_unit_str;
-
-    time_unit_att.getValues(time_unit_str);
-    if (time_unit_str != "minutes since 1970-01-01 00:00:00 UTC") {
-        throw std::runtime_error("Time units not exactly as expected");
-    }
-
-    std::vector<std::chrono::duration<double, std::ratio<60>>> raw_time(num_times);
-    time_var.getVar(raw_time.data());
-
-    time_vals.reserve(num_times);
-    for (int i = 0; i < num_times; ++i) {
-        // Assume that the system clock's epoch matches Unix time.
-        // This is guaranteed from C++20 onwards
-        time_vals.push_back(time_point_type(std::chrono::duration_cast<time_point_type::duration>(raw_time[i])));
-    }
-
-    time_stride = std::chrono::duration_cast<std::chrono::seconds>(time_vals[1] - time_vals[0]);
-
-    // verify the time stride
-    for( size_t i = 1; i < time_vals.size() -1; ++i)
-    {
-        auto tinterval = time_vals[i+1] - time_vals[i];
-
-        if ( tinterval - time_stride > std::chrono::microseconds(1) ||
-             time_stride - tinterval > std::chrono::microseconds(1) )
-        {
-            throw std::runtime_error("Time intervals in forcing file are not constant");
-        }
-    }
-
-    std::multimap< std::string, netCDF::NcVar > vars = nc_file->getVars();
-    std::transform(vars.begin(), vars.end(), 
-		    std::back_inserter(variable_names),
-          [](const std::pair< std::string, netCDF::NcVar >& pair) { return pair.first; });
-#ifdef DEBUG_NETCDFMESH
-    std::cerr << "var names: " << std::endl;
-    std::copy( variable_names.begin(), variable_names.end(),
-          std::ostream_iterator< std::string > ( std::cerr, " \n" ) );
-#endif //#ifdef DEBUG_NETCDFMESH
 }
 
-NetCDFMeshPointsDataProvider::~NetCDFMeshPointsDataProvider() = default;
+template <typename MeshPolicy>
+NetCDFMeshPointsDataProvider<MeshPolicy>::~NetCDFMeshPointsDataProvider() = default;
 
-void NetCDFMeshPointsDataProvider::finalize()
+template <typename MeshPolicy>
+void NetCDFMeshPointsDataProvider<MeshPolicy>::finalize()
 {
     ncvar_cache.clear();
 
@@ -91,12 +54,14 @@ void NetCDFMeshPointsDataProvider::finalize()
     nc_file = nullptr;
 }
 
-boost::span<const std::string> NetCDFMeshPointsDataProvider::get_available_variable_names() const
+template <typename MeshPolicy>
+boost::span<const std::string> NetCDFMeshPointsDataProvider<MeshPolicy>::get_available_variable_names() const
 {
     return variable_names;
 }
 
-long NetCDFMeshPointsDataProvider::get_data_start_time() const
+template <typename MeshPolicy>
+long NetCDFMeshPointsDataProvider<MeshPolicy>::get_data_start_time() const
 {
     return std::chrono::system_clock::to_time_t(time_vals[0]);
 #if 0
@@ -106,7 +71,8 @@ long NetCDFMeshPointsDataProvider::get_data_start_time() const
 #endif
 }
 
-long NetCDFMeshPointsDataProvider::get_data_stop_time() const
+template <typename MeshPolicy>
+long NetCDFMeshPointsDataProvider<MeshPolicy>::get_data_stop_time() const
 {
     return std::chrono::system_clock::to_time_t(time_vals.back() + time_stride);
 #if 0
@@ -116,12 +82,14 @@ long NetCDFMeshPointsDataProvider::get_data_stop_time() const
 #endif
 }
 
-long NetCDFMeshPointsDataProvider::record_duration() const
+template <typename MeshPolicy>
+long NetCDFMeshPointsDataProvider<MeshPolicy>::record_duration() const
 {
     return std::chrono::duration_cast<std::chrono::seconds>(time_stride).count();
 }
 
-size_t NetCDFMeshPointsDataProvider::get_ts_index_for_time(const time_t &epoch_time_in) const
+template <typename MeshPolicy>
+size_t NetCDFMeshPointsDataProvider<MeshPolicy>::get_ts_index_for_time(const time_t &epoch_time_in) const
 {
     // time_t in simulation engine's time frame - i.e. seconds, starting at 0
     auto epoch_time = sim_start_date_time_epoch + std::chrono::seconds(epoch_time_in);
@@ -156,7 +124,8 @@ size_t NetCDFMeshPointsDataProvider::get_ts_index_for_time(const time_t &epoch_t
     }
 }
 
-void NetCDFMeshPointsDataProvider::get_values(const selection_type& selector, boost::span<data_type> data)
+template <typename MeshPolicy>
+void NetCDFMeshPointsDataProvider<MeshPolicy>::get_values(const selection_type& selector, boost::span<data_type> data)
 {
     if (!boost::get<AllPoints>(&selector.points)) throw std::runtime_error("Not implemented - only all_points");
 
@@ -167,28 +136,22 @@ void NetCDFMeshPointsDataProvider::get_values(const selection_type& selector, bo
 
     size_t time_index = get_ts_index_for_time(std::chrono::system_clock::to_time_t(selector.init_time));
 
-    // XXX: Ignores the point selection in `selector`
-    // Possibly assert somewhere (at startup) that dimensions are actually (Time, Index)
-    metadata.ncVar.getVar({time_index, 0}, {1, data.size()}, data.data());
+#ifdef DEBUG_NETCDFMESH
+    std::cerr << "NetCDFMeshPointsDataProvider::get_values: var = "
+	    << selector.variable_name << std::endl;
+#endif //#ifdef DEBUG_NETCDFMESH
 
-    for (auto& value : data) {
-        value = value * metadata.scale_factor + metadata.offset;
-    }
+    MeshPolicy::get_values( *(this->nc_file), selector, data,
+	                                      time_index,
+					       metadata.ncVar,
+	                                       source_units,
+		                               metadata.scale_factor,
+		                               metadata.offset );
 
-    // These mass and and volume flux density units are very close to
-    // numerically identical for liquid water at atmospheric
-    // conditions, and so we currently treat them as interchangeable
-    bool RAINRATE_equivalence =
-        selector.variable_name == "RAINRATE" &&
-        source_units == "mm s^-1" &&
-        selector.output_units == "kg m-2 s-1";
-
-    if (!RAINRATE_equivalence) {
-        UnitsHelper::convert_values(source_units, data.data(), selector.output_units, data.data(), data.size());
-    }
 }
 
-NetCDFMeshPointsDataProvider::data_type NetCDFMeshPointsDataProvider::get_value(const selection_type& selector, ReSampleMethod m)
+template <typename MeshPolicy>
+typename NetCDFMeshPointsDataProvider<MeshPolicy>::data_type NetCDFMeshPointsDataProvider<MeshPolicy>::get_value(const selection_type& selector, ReSampleMethod m)
 {
     // Check selector only supports exactly one point index
     const auto* pvec = boost::get<std::vector<int>>(&selector.points);
@@ -204,90 +167,33 @@ NetCDFMeshPointsDataProvider::data_type NetCDFMeshPointsDataProvider::get_value(
     // Map the init_time to time_index
     size_t time_index = get_ts_index_for_time(std::chrono::system_clock::to_time_t(selector.init_time));
 
-    size_t n_elem = nc_file->getDim( "element-id" ).getSize();
-
-    if ( pt_index >= n_elem ) {
-        throw std::out_of_range("Point index exceeds available spatial dimension size (y * x).");
-    }
-
-    // Read raw value from NetCDF variable
-    nc_type vartype = metadata.ncVar.getType().getId();
-    data_type raw_value = 0.0;
-
-    if (vartype == NC_FLOAT) {
-        float tmp;
-        metadata.ncVar.getVar({time_index, pt_index}, {1, 1}, &tmp);
-        raw_value = static_cast<data_type>(tmp);
-    }
-    else if (vartype == NC_DOUBLE) {
-        double tmp;
-        metadata.ncVar.getVar({time_index, pt_index}, {1, 1}, &tmp);
-        raw_value = static_cast<data_type>(tmp);
-    }
-    else if (vartype == NC_INT || vartype == NC_SHORT || vartype == NC_BYTE) {
-        int tmp;
-        metadata.ncVar.getVar({time_index, pt_index}, {1, 1}, &tmp);
-        raw_value = static_cast<data_type>(tmp);
-    }
-    else {
-        throw std::runtime_error("Unsupported NetCDF variable type in get_value()");
-    }
-
-    // Check for _FillValue (missing data)
-    try {
-        if (!metadata.ncVar.getAtt("_FillValue").isNull()) {
-            if (vartype == NC_FLOAT) {
-                float fv;
-                metadata.ncVar.getAtt("_FillValue").getValues(&fv);
-                if (static_cast<float>(raw_value) == fv)
-                    throw std::runtime_error("Encountered _FillValue (missing data)");
-	    } else if (vartype == NC_DOUBLE) {
-                double fv; 
-		metadata.ncVar.getAtt("_FillValue").getValues(&fv);
-                if (static_cast<double>(raw_value) == fv)
-                    throw std::runtime_error("Encountered _FillValue (missing data).");
-            } else if (vartype == NC_INT || vartype == NC_SHORT || vartype == NC_BYTE) {
-                int fv;
-                metadata.ncVar.getAtt("_FillValue").getValues(&fv);
-                if (static_cast<int>(raw_value) == fv)
-                    throw std::runtime_error("Encountered _FillValue (missing data)");
-            }
-	} else {
-            // No _FillValue attribute — use NetCDF library defaults
-            if (vartype == NC_DOUBLE && raw_value == static_cast<data_type>(NC_FILL_DOUBLE))
-                throw std::runtime_error("Encountered default NC_FILL_DOUBLE missing data.");
-            if (vartype == NC_FLOAT && raw_value == static_cast<data_type>(NC_FILL_FLOAT))
-                throw std::runtime_error("Encountered default NC_FILL_FLOAT missing data.");
-        }
-    } catch (...) {
-        // Safe to ignore if _FillValue attribute is missing
-    }
-
-    // Apply scale and offset
-    data_type value = raw_value * metadata.scale_factor + metadata.offset;
-
-    // Handle RAINRATE unit fix if needed
-    bool RAINRATE_equivalence =
-        selector.variable_name == "RAINRATE" &&
-        metadata.units == "mm s^-1" &&
-        selector.output_units == "kg m-2 s-1";
-
-    if (!RAINRATE_equivalence) {
-        UnitsHelper::convert_values(metadata.units, &value, selector.output_units, &value, 1);
-    }
+    double value = MeshPolicy::get_value( *(this->nc_file), selector, m,
+		                              pt_index,
+	                                      time_index,
+					       metadata.ncVar,
+	                                       metadata.units,
+		                               metadata.scale_factor,
+		                               metadata.offset );
 
     return value;
 }
 
-void NetCDFMeshPointsDataProvider::cache_variable(std::string const& var_name)
+template <typename MeshPolicy>
+void NetCDFMeshPointsDataProvider<MeshPolicy>::cache_variable(std::string const& var_name_in)
 {
+    std::string var_name = MeshPolicy::convertVarName( var_name_in );
+
     if (ncvar_cache.find(var_name) != ncvar_cache.end()) return;
 
     auto ncvar = nc_file->getVar(var_name);
 
-    std::string native_units;
-    auto units_att = ncvar.getAtt("units");
-    units_att.getValues(native_units);
+    std::string native_units = "N/A";
+    try {
+       auto units_att = ncvar.getAtt("units");
+       units_att.getValues(native_units);
+    } catch (...) {
+        // Assume it's just not present, and so keeps the default value
+    }
 
     double scale_factor = 1.0;
     try {
@@ -309,8 +215,12 @@ void NetCDFMeshPointsDataProvider::cache_variable(std::string const& var_name)
         // Assume it's just not present, and so keeps the default value
     }
 
-    ncvar_cache[var_name] = {ncvar, native_units, scale_factor, offset};
+    ncvar_cache[var_name_in] = {ncvar, native_units, scale_factor, offset};
 }
+
+//Explicitly instantiate the needed types.
+template class NetCDFMeshPointsDataProvider< MetMeshPolicy >; 
+template class NetCDFMeshPointsDataProvider< FlowMeshPolicy >; 
 
 }
 

--- a/src/forcing/TidalMeshPolicy.cpp
+++ b/src/forcing/TidalMeshPolicy.cpp
@@ -7,11 +7,10 @@
 #include <netcdf>
 #include <UnitsHelper.hpp>
 #include "forcing/TidalMeshPolicy.h"
-#include "forcing/NetCDFMeshPointsDataProvider.hpp"
 
 void data_access::TidalMeshPolicy::getTimes( netCDF::NcFile const& nc_file,
-		             time_point_type const& start_time,
-		             std::vector< time_point_type >& times,
+                             time_point_type const& start_time,
+                             std::vector< time_point_type >& times,
                              std::chrono::seconds& stride )
 {
     auto num_times = nc_file.getDim("time").getSize();
@@ -25,8 +24,8 @@ void data_access::TidalMeshPolicy::getTimes( netCDF::NcFile const& nc_file,
     std::string time_unit_str;
 
     std::regex time_unit_pattern( "^seconds since "
-		    "(19|20)\\d{2}\\-(0[1-9]|1[1,2])\\-(0[1-9]|[12][0-9]|3[01]) "
-		    "([01]\\d|2[0-3]):([0-5]\\d):([0-5]\\d)        \\! NCDASE - BASE_DAT$");
+                    "(19|20)\\d{2}\\-(0[1-9]|1[1,2])\\-(0[1-9]|[12][0-9]|3[01]) "
+                    "([01]\\d|2[0-3]):([0-5]\\d):([0-5]\\d)        \\! NCDASE - BASE_DAT$");
 
     time_unit_att.getValues(time_unit_str);
 
@@ -35,9 +34,9 @@ void data_access::TidalMeshPolicy::getTimes( netCDF::NcFile const& nc_file,
     }
 
     time_point_type basetime = stringToTimePoint(time_unit_str, 
-		    std::string( "seconds since "
-			    "%Y-%m-%d %H:%M:%S        "
-			    "! NCDASE - BASE_DAT"  ));
+                    std::string( "seconds since "
+                            "%Y-%m-%d %H:%M:%S        "
+                            "! NCDASE - BASE_DAT"  ));
 
     auto start_time_att = time_var.getAtt("start_time");
     double start_time_att_val;
@@ -52,9 +51,9 @@ void data_access::TidalMeshPolicy::getTimes( netCDF::NcFile const& nc_file,
         // Assume that the system clock's epoch matches Unix time.
         // This is guaranteed from C++20 onwards
         times.push_back( time_point_type( basetime +
-		std::chrono::duration_cast<time_point_type::duration>( 
-			std::chrono::duration<double>( start_time_att_val ) )
-	 	+ std::chrono::duration_cast<time_point_type::duration>(raw_time[i])));
+                std::chrono::duration_cast<time_point_type::duration>( 
+                        std::chrono::duration<double>( start_time_att_val ) )
+                 + std::chrono::duration_cast<time_point_type::duration>(raw_time[i])));
     }
 
     stride = std::chrono::duration_cast<std::chrono::seconds>(times[1] - times[0]);
@@ -77,13 +76,13 @@ std::vector< std::string > data_access::TidalMeshPolicy::getVarNames( netCDF::Nc
     std::vector< std::string > varnames;
     std::multimap< std::string, netCDF::NcVar > vars = nc_file.getVars();
     std::transform(vars.begin(), vars.end(), 
-		    std::back_inserter(varnames),
+                    std::back_inserter(varnames),
           [](const std::pair< std::string, netCDF::NcVar >& pair) { 
-	         if ( pair.first == "time_series" )
-		 {
-		     return std::string( "ETA2_bnd" );
-		 }
-	         return pair.first; });
+                 if ( pair.first == "time_series" )
+                 {
+                     return std::string( "ETA2_bnd" );
+                 }
+                 return pair.first; });
 #ifdef DEBUG_NETCDFMESH
     std::cerr << "var names: " << std::endl;
     std::copy( varnames.begin(), varnames.end(),
@@ -93,14 +92,14 @@ std::vector< std::string > data_access::TidalMeshPolicy::getVarNames( netCDF::Nc
 }
 
 void data_access::TidalMeshPolicy::get_values( netCDF::NcFile const& nc_file,
-		                              MeshPointsSelector const& selector,
-					      boost::span<double> data,
-	                                      size_t const& time_index,
-					      netCDF::NcVar const& ncvar,
-	                                      std::string const& source_units,
-					      double const& scale_factor,
-					      double const& offset
-	                                      	)
+                                              MeshPointsSelector const& selector,
+                                              boost::span<double> data,
+                                              size_t const& time_index,
+                                              netCDF::NcVar const& ncvar,
+                                              std::string const& source_units,
+                                              double const& scale_factor,
+                                              double const& offset
+                                                      )
 {
     //check dimesnions for nLevels and nComponents
     size_t nLevels = ncvar.getDim( 2 ).getSize();
@@ -122,14 +121,14 @@ void data_access::TidalMeshPolicy::get_values( netCDF::NcFile const& nc_file,
 }
 
 double data_access::TidalMeshPolicy::get_value( netCDF::NcFile const& nc_file,
-		              MeshPointsSelector const& selector, data_access::ReSampleMethod m,
-			      size_t const& pt_index,
-	                      size_t const& time_index,
-			netCDF::NcVar const& ncvar,
-	                std::string const& source_units,
-			double const& scale_factor,
-			double const& offset
-	       	)
+                              MeshPointsSelector const& selector, data_access::ReSampleMethod m,
+                              size_t const& pt_index,
+                              size_t const& time_index,
+                        netCDF::NcVar const& ncvar,
+                        std::string const& source_units,
+                        double const& scale_factor,
+                        double const& offset
+                       )
 {
     size_t n_elem = nc_file.getDim( "nOpenBndNodes" ).getSize();
 
@@ -168,9 +167,9 @@ double data_access::TidalMeshPolicy::get_value( netCDF::NcFile const& nc_file,
                 ncvar.getAtt("_FillValue").getValues(&fv);
                 if (static_cast<float>(raw_value) == fv)
                     throw std::runtime_error("Encountered _FillValue (missing data)");
-	    } else if (vartype == NC_DOUBLE) {
+            } else if (vartype == NC_DOUBLE) {
                 double fv; 
-		ncvar.getAtt("_FillValue").getValues(&fv);
+                ncvar.getAtt("_FillValue").getValues(&fv);
                 if (static_cast<double>(raw_value) == fv)
                     throw std::runtime_error("Encountered _FillValue (missing data).");
             } else if (vartype == NC_INT || vartype == NC_SHORT || vartype == NC_BYTE) {
@@ -179,7 +178,7 @@ double data_access::TidalMeshPolicy::get_value( netCDF::NcFile const& nc_file,
                 if (static_cast<int>(raw_value) == fv)
                     throw std::runtime_error("Encountered _FillValue (missing data)");
             }
-	} else {
+        } else {
             // No _FillValue attribute — use NetCDF library defaults
             if (vartype == NC_DOUBLE && raw_value == static_cast<double>(NC_FILL_DOUBLE))
                 throw std::runtime_error("Encountered default NC_FILL_DOUBLE missing data.");
@@ -200,14 +199,14 @@ std::string data_access::TidalMeshPolicy::convertVarName( std::string const& var
 {
       if ( var_name_in == std::string( "ETA2_bnd" ) )
       {
-	 return std::string( "time_series" );
+         return std::string( "time_series" );
       }
       return std::string();
 }
 
 typename data_access::TidalMeshPolicy::time_point_type 
                               data_access::TidalMeshPolicy::stringToTimePoint(
-		std::string const& datetime_str, std::string const& format_str) {
+                std::string const& datetime_str, std::string const& format_str) {
     std::tm t = {};
     std::istringstream ss(datetime_str);
     ss >> std::get_time(&t, format_str.c_str());

--- a/src/forcing/TidalMeshPolicy.cpp
+++ b/src/forcing/TidalMeshPolicy.cpp
@@ -1,55 +1,60 @@
 #include <iostream>
 #include <vector>
+#include <regex>
+#include <ctime>
+#include <iomanip>
+#include <sstream>
 #include <netcdf>
 #include <UnitsHelper.hpp>
-#include "forcing/FlowMeshPolicy.h"
+#include "forcing/TidalMeshPolicy.h"
 #include "forcing/NetCDFMeshPointsDataProvider.hpp"
 
-void data_access::FlowMeshPolicy::getTimes( netCDF::NcFile const& nc_file,
+void data_access::TidalMeshPolicy::getTimes( netCDF::NcFile const& nc_file,
 		             time_point_type const& start_time,
 		             std::vector< time_point_type >& times,
                              std::chrono::seconds& stride )
 {
-#ifdef DEBUG_NETCDFMESH
-    std::cerr << "FlowMeshPolicy::getTimes: " << std::endl;
-#endif //#ifdef DEBUG_NETCDFMESH
-    auto source_num_times = nc_file.getDim("time_vsource").getSize();
-#ifdef DEBUG_NETCDFMESH
-    std::cerr << "FlowMeshPolicy::getTimes: get time_vsink" << std::endl;
-#endif //#ifdef DEBUG_NETCDFMESH
-    auto sink_num_times = nc_file.getDim("time_vsink").getSize();
-    if ( source_num_times != sink_num_times ) {
-        throw std::runtime_error("'time_vsource' and 'time_vsink' have different dimensions!");
+    auto num_times = nc_file.getDim("time").getSize();
+    auto time_var = nc_file.getVar("time");
+
+    if (time_var.getDimCount() != 1) {
+        throw std::runtime_error("'time' variable has dimension other than 1");
     }
 
-#ifdef DEBUG_NETCDFMESH
-    std::cerr << "FlowMeshPolicy::getTimes: get time_vsource" << std::endl;
-#endif //#ifdef DEBUG_NETCDFMESH
-    auto source_time_var = nc_file.getVar("time_vsource");
+    auto time_unit_att = time_var.getAtt("units");
+    std::string time_unit_str;
 
-    if (source_time_var.getDimCount() != 1) {
-        throw std::runtime_error("'time_vsource' variable has dimension other than 1");
+    std::regex time_unit_pattern( "^seconds since "
+		    "(19|20)\\d{2}\\-(0[1-9]|1[1,2])\\-(0[1-9]|[12][0-9]|3[01]) "
+		    "([01]\\d|2[0-3]):([0-5]\\d):([0-5]\\d)        \\! NCDASE - BASE_DAT$");
+
+    time_unit_att.getValues(time_unit_str);
+
+    if ( ! regex_match(time_unit_str, time_unit_pattern) ) {
+        throw std::runtime_error("Time units not exactly as expected");
     }
 
-#ifdef DEBUG_NETCDFMESH
-    std::cerr << "FlowMeshPolicy::getTimes: get var vsink" << std::endl;
-#endif //#ifdef DEBUG_NETCDFMESH
-    auto sink_time_var = nc_file.getVar("time_vsink");
+    time_point_type basetime = stringToTimePoint(time_unit_str, 
+		    std::string( "seconds since "
+			    "%Y-%m-%d %H:%M:%S        "
+			    "! NCDASE - BASE_DAT"  ));
 
-    if (sink_time_var.getDimCount() != 1) {
-        throw std::runtime_error("'time_vink' variable has dimension other than 1");
-    }
+    auto start_time_att = time_var.getAtt("start_time");
+    double start_time_att_val;
+    start_time_att.getValues( &start_time_att_val );
 
-    std::vector<std::chrono::duration<double>> raw_time(source_num_times);
 
-    source_time_var.getVar(raw_time.data());
+    std::vector<std::chrono::duration<double>> raw_time(num_times);
+    time_var.getVar(raw_time.data());
 
-    times.reserve(source_num_times);
-    for (int i = 0; i < source_num_times; ++i) {
+    times.reserve(num_times);
+    for (int i = 0; i < num_times; ++i) {
         // Assume that the system clock's epoch matches Unix time.
         // This is guaranteed from C++20 onwards
-        times.push_back(time_point_type(
-		start_time + std::chrono::duration_cast<time_point_type::duration>(raw_time[i])));
+        times.push_back( time_point_type( basetime +
+		std::chrono::duration_cast<time_point_type::duration>( 
+			std::chrono::duration<double>( start_time_att_val ) )
+	 	+ std::chrono::duration_cast<time_point_type::duration>(raw_time[i])));
     }
 
     stride = std::chrono::duration_cast<std::chrono::seconds>(times[1] - times[0]);
@@ -62,28 +67,21 @@ void data_access::FlowMeshPolicy::getTimes( netCDF::NcFile const& nc_file,
         if ( tinterval - stride > std::chrono::microseconds(1) ||
              stride - tinterval > std::chrono::microseconds(1) )
         {
-            throw std::runtime_error("Time intervals in forcing file are not constant");
+            throw std::runtime_error("Time intervals in offshore boundary file are not constant");
         }
     }
-#ifdef DEBUG_NETCDFMESH
-    std::cerr << "leaving FlowMeshPolicy::getTimes: " << std::endl;
-#endif //#ifdef DEBUG_NETCDFMESH
 }
 
-std::vector< std::string > data_access::FlowMeshPolicy::getVarNames( netCDF::NcFile const& nc_file )
+std::vector< std::string > data_access::TidalMeshPolicy::getVarNames( netCDF::NcFile const& nc_file )
 {
     std::vector< std::string > varnames;
     std::multimap< std::string, netCDF::NcVar > vars = nc_file.getVars();
     std::transform(vars.begin(), vars.end(), 
 		    std::back_inserter(varnames),
           [](const std::pair< std::string, netCDF::NcVar >& pair) { 
-	         if ( pair.first == "vsource" )
+	         if ( pair.first == "time_series" )
 		 {
-		     return std::string( "Q_bnd_source" );
-		 }
-	         if ( pair.first == "vsink" )
-		 {
-		     return std::string( "Q_bnd_sink" );
+		     return std::string( "ETA2_bnd" );
 		 }
 	         return pair.first; });
 #ifdef DEBUG_NETCDFMESH
@@ -94,7 +92,7 @@ std::vector< std::string > data_access::FlowMeshPolicy::getVarNames( netCDF::NcF
     return varnames;
 }
 
-void data_access::FlowMeshPolicy::get_values( netCDF::NcFile const& nc_file,
+void data_access::TidalMeshPolicy::get_values( netCDF::NcFile const& nc_file,
 		                              MeshPointsSelector const& selector,
 					      boost::span<double> data,
 	                                      size_t const& time_index,
@@ -104,25 +102,26 @@ void data_access::FlowMeshPolicy::get_values( netCDF::NcFile const& nc_file,
 					      double const& offset
 	                                      	)
 {
-#ifdef DEBUG_NETCDFMESH
-    std::cerr << "time_index = " << time_index << std::endl;
-#endif //#ifdef DEBUG_NETCDFMESH
+    //check dimesnions for nLevels and nComponents
+    size_t nLevels = ncvar.getDim( 2 ).getSize();
+    if ( nLevels != 1 )
+    {
+        throw std::runtime_error("'nLevels' dimension has value other than 1");
+    }
+    size_t nComponents = ncvar.getDim( 3 ).getSize();
+    if ( nComponents != 1 )
+    {
+        throw std::runtime_error("'nComponents' dimension has value other than 1");
+    }
 
-    // XXX: Ignores the point selection in `selector`
-    // Possibly assert somewhere (at startup) that dimensions are actually (Time, Index)
-    //
-    ncvar.getVar({time_index, 0}, {1, data.size()}, data.data());
+    ncvar.getVar({time_index, 0, 0, 0}, {1, data.size(), 1, 1}, data.data());
 
     for (auto& value : data) {
         value = value * scale_factor + offset;
-#ifdef DEBUG_NETCDFMESH
-    std::cerr << selector. variable_name << ": value = " << value << std::endl;
-#endif //#ifdef DEBUG_NETCDFMESH
     }
-
 }
 
-double data_access::FlowMeshPolicy::get_value( netCDF::NcFile const& nc_file,
+double data_access::TidalMeshPolicy::get_value( netCDF::NcFile const& nc_file,
 		              MeshPointsSelector const& selector, data_access::ReSampleMethod m,
 			      size_t const& pt_index,
 	                      size_t const& time_index,
@@ -132,15 +131,10 @@ double data_access::FlowMeshPolicy::get_value( netCDF::NcFile const& nc_file,
 			double const& offset
 	       	)
 {
-    size_t n_elem = nc_file.getDim( "nsources" ).getSize();
+    size_t n_elem = nc_file.getDim( "nOpenBndNodes" ).getSize();
 
-    if ( pt_index >= n_elem && selector.variable_name == "vsource" ) {
-        throw std::out_of_range("Point index exceeds available dimension size - nsources");
-    }
-
-    n_elem = nc_file.getDim( "nsinks" ).getSize();
-    if ( pt_index >= n_elem && selector.variable_name == "vsink" ) {
-        throw std::out_of_range("Point index exceeds available dimension size - nsinks");
+    if ( pt_index >= n_elem ) {
+        throw std::out_of_range("Point index exceeds available open boundary node dimension.");
     }
 
     // Read raw value from NetCDF variable
@@ -149,17 +143,17 @@ double data_access::FlowMeshPolicy::get_value( netCDF::NcFile const& nc_file,
 
     if (vartype == NC_FLOAT) {
         float tmp;
-        ncvar.getVar({time_index, pt_index}, {1, 1}, &tmp);
+        ncvar.getVar({time_index, pt_index, 0, 0}, {1, 1, 1, 1}, &tmp);
         raw_value = static_cast<double>(tmp);
     }
     else if (vartype == NC_DOUBLE) {
         double tmp;
-        ncvar.getVar({time_index, pt_index}, {1, 1}, &tmp);
+        ncvar.getVar({time_index, pt_index, 0, 0}, {1, 1, 1, 1}, &tmp);
         raw_value = static_cast<double>(tmp);
     }
     else if (vartype == NC_INT || vartype == NC_SHORT || vartype == NC_BYTE) {
         int tmp;
-        ncvar.getVar({time_index, pt_index}, {1, 1}, &tmp);
+        ncvar.getVar({time_index, pt_index, 0, 0}, {1, 1, 1, 1}, &tmp);
         raw_value = static_cast<double>(tmp);
     }
     else {
@@ -202,15 +196,26 @@ double data_access::FlowMeshPolicy::get_value( netCDF::NcFile const& nc_file,
     return value;
 }
 
-std::string data_access::FlowMeshPolicy::convertVarName( std::string const& var_name_in )
+std::string data_access::TidalMeshPolicy::convertVarName( std::string const& var_name_in )
 {
-      if ( var_name_in == std::string( "Q_bnd_source" ) )
+      if ( var_name_in == std::string( "ETA2_bnd" ) )
       {
-	 return std::string( "vsource" );
-      }
-      if ( var_name_in == std::string( "Q_bnd_sink" ) )
-      {
-	 return std::string( "vsink" );
+	 return std::string( "time_series" );
       }
       return std::string();
+}
+
+typename data_access::TidalMeshPolicy::time_point_type 
+                              data_access::TidalMeshPolicy::stringToTimePoint(
+		std::string const& datetime_str, std::string const& format_str) {
+    std::tm t = {};
+    std::istringstream ss(datetime_str);
+    ss >> std::get_time(&t, format_str.c_str());
+
+    if (ss.fail()) {
+        throw std::runtime_error("Failed to parse datetime string.");
+    }
+
+    std::time_t tt = std::mktime(&t);
+    return std::chrono::system_clock::from_time_t(tt);
 }

--- a/src/realizations/coastal/SchismCreator.cpp
+++ b/src/realizations/coastal/SchismCreator.cpp
@@ -1,10 +1,8 @@
 #include <unistd.h>
 #include <iostream>
 #include <fstream>
-#include <cassert>
 #include "realizations/coastal/SchismCreator.h"
 #include "realizations/coastal/SchismFormulation.hpp"
-#include "realizations/coastal/MockProvider.h"
 #include "forcing/NetCDFMeshPointsDataProvider.hpp"
 #include "forcing/MetMeshPolicy.h"
 #include "forcing/FlowMeshPolicy.h"
@@ -12,7 +10,7 @@
 
 std::unique_ptr<CoastalFormulation>
       SchismCreator::createCoastalFormulation( coastal_config_params const& config,
-		                               Simulation_Time const& sim_time ) const
+                                               Simulation_Time const& sim_time ) const
 {
 
       auto param_tree=config.params.get_child("params");
@@ -32,49 +30,45 @@ std::unique_ptr<CoastalFormulation>
 
       this->writeInitConfig( config, sim_time );
 
-      size_t meshsize = 552697;
-      auto provider = std::make_shared<MockProvider>( meshsize );
-
       time_t start_time_t = sim_time.get_start_date_time_epoch();
       time_t stop_time_t = sim_time.get_end_date_time_epoch();
 
       auto netcdf_met_provider = 
-	      std::make_shared<data_access::NetCDFMeshPointsDataProvider< 
-	                                                   data_access::MetMeshPolicy > >(
-		      met_forcing_file,
+              std::make_shared<data_access::NetCDFMeshPointsDataProvider< 
+                                                           data_access::MetMeshPolicy > >(
+                      met_forcing_file,
                       std::chrono::system_clock::from_time_t(start_time_t),
                       std::chrono::system_clock::from_time_t(stop_time_t));
 
       SchismFormulation::check_forcing_provider( *netcdf_met_provider, SchismFormulation::METEO );
 
       auto netcdf_streamflow_provider = 
-	      std::make_shared<data_access::NetCDFMeshPointsDataProvider< 
-	                                                   data_access::FlowMeshPolicy > >(
-		      flow_boundary_file,
+              std::make_shared<data_access::NetCDFMeshPointsDataProvider< 
+                                                           data_access::FlowMeshPolicy > >(
+                      flow_boundary_file,
                       std::chrono::system_clock::from_time_t(start_time_t),
                       std::chrono::system_clock::from_time_t(stop_time_t));
 
       SchismFormulation::check_forcing_provider( *netcdf_streamflow_provider, 
-		                                           SchismFormulation::CHANNEL_FLOW );
+                                                           SchismFormulation::CHANNEL_FLOW );
 
       auto netcdf_offshore_provider = 
-	      std::make_shared<data_access::NetCDFMeshPointsDataProvider< 
-	                                                   data_access::TidalMeshPolicy > >(
-		      offshore_boundary_file,
+              std::make_shared<data_access::NetCDFMeshPointsDataProvider< 
+                                                           data_access::TidalMeshPolicy > >(
+                      offshore_boundary_file,
                       std::chrono::system_clock::from_time_t(start_time_t),
                       std::chrono::system_clock::from_time_t(stop_time_t));
 
       SchismFormulation::check_forcing_provider( *netcdf_offshore_provider, 
-		                                           SchismFormulation::OFFSHORE );
+                                                           SchismFormulation::OFFSHORE );
       return std::make_unique<SchismFormulation>( model_id,
                                             library_file,
-					    init_config,
+                                            init_config,
                                             MPI_COMM_SELF,
-					    netcdf_met_provider, 
-                                            //provider,
-					    netcdf_offshore_provider, 
-					    netcdf_streamflow_provider
-		                           );
+                                            netcdf_met_provider, 
+                                            netcdf_offshore_provider, 
+                                            netcdf_streamflow_provider
+                                           );
 }
 
 SchismCreator* SchismCreator::clone() const
@@ -83,7 +77,7 @@ SchismCreator* SchismCreator::clone() const
 }
 
 void SchismCreator::writeInitConfig( coastal_config_params const& config,
-		                     Simulation_Time const& sim_time ) const
+                                     Simulation_Time const& sim_time ) const
 {
       auto param_tree=config.params.get_child("params");
 
@@ -104,26 +98,26 @@ void SchismCreator::writeInitConfig( coastal_config_params const& config,
 
       std::fstream initfile( init_config.c_str(), std::ios::out );
       if (!initfile.is_open()) {
-	std::cerr << "Error: Unable to open file!" << std::endl;
-	throw std::runtime_error( 
-		std::string( "FATAL: Unable to open file - ") + init_config ); 
+        std::cerr << "Error: Unable to open file!" << std::endl;
+        throw std::runtime_error( 
+                std::string( "FATAL: Unable to open file - ") + init_config ); 
       }
       
       initfile << "&schism" << std::endl;
       initfile << "model_start_time = " << model_start_time
-	        << "     !Time start of simulation in seconds" << std::endl;
+                << "     !Time start of simulation in seconds" << std::endl;
       initfile << "model_start_year = " << std::string( buffer ).substr(0, 4 ) << std::endl;
       initfile << "model_start_month = " << std::string( buffer ).substr(4, 2 ) << std::endl;
       initfile << "model_start_day = " << std::string( buffer ).substr(6, 2 ) << std::endl;
       initfile << "model_start_hour = " << std::string( buffer ).substr(8, 2 ) << std::endl;
       initfile << "SCHISM_dir       = " << '"' << working_dir << '"' 
-	      << "   ! SCHISM directory for configuration and forcing files" << std::endl;
+              << "   ! SCHISM directory for configuration and forcing files" << std::endl;
       initfile << "SCHISM_NSCRIBES    = " << nscribs 
-	      <<  "     ! Number of processors to dedicate to I/O methods. "
-	      "In serial mode, this must be 0 and SCHISM \"OLD IO\" option must be selected "
-	      "for compiling. If SCHISM BMI is executed in parallel, then this number can "
-	      "be greater than zero to dedicated and speed up I/O methods. If implemented, "
-	      "then SCHISM \"OLD IO\" option must be turned off." << std::endl;
+              <<  "     ! Number of processors to dedicate to I/O methods. "
+              "In serial mode, this must be 0 and SCHISM \"OLD IO\" option must be selected "
+              "for compiling. If SCHISM BMI is executed in parallel, then this number can "
+              "be greater than zero to dedicated and speed up I/O methods. If implemented, "
+              "then SCHISM \"OLD IO\" option must be turned off." << std::endl;
       initfile << '/' << std::endl;
       initfile.close();
 }

--- a/src/realizations/coastal/SchismCreator.cpp
+++ b/src/realizations/coastal/SchismCreator.cpp
@@ -8,6 +8,7 @@
 #include "forcing/NetCDFMeshPointsDataProvider.hpp"
 #include "forcing/MetMeshPolicy.h"
 #include "forcing/FlowMeshPolicy.h"
+#include "forcing/TidalMeshPolicy.h"
 
 std::unique_ptr<CoastalFormulation>
       SchismCreator::createCoastalFormulation( coastal_config_params const& config,
@@ -44,7 +45,7 @@ std::unique_ptr<CoastalFormulation>
                       std::chrono::system_clock::from_time_t(start_time_t),
                       std::chrono::system_clock::from_time_t(stop_time_t));
 
-      SchismFormulation::check_forcing_provider( *netcdf_met_provider );
+      SchismFormulation::check_forcing_provider( *netcdf_met_provider, SchismFormulation::METEO );
 
       auto netcdf_streamflow_provider = 
 	      std::make_shared<data_access::NetCDFMeshPointsDataProvider< 
@@ -53,12 +54,25 @@ std::unique_ptr<CoastalFormulation>
                       std::chrono::system_clock::from_time_t(start_time_t),
                       std::chrono::system_clock::from_time_t(stop_time_t));
 
+      SchismFormulation::check_forcing_provider( *netcdf_streamflow_provider, 
+		                                           SchismFormulation::CHANNEL_FLOW );
+
+      auto netcdf_offshore_provider = 
+	      std::make_shared<data_access::NetCDFMeshPointsDataProvider< 
+	                                                   data_access::TidalMeshPolicy > >(
+		      offshore_boundary_file,
+                      std::chrono::system_clock::from_time_t(start_time_t),
+                      std::chrono::system_clock::from_time_t(stop_time_t));
+
+      SchismFormulation::check_forcing_provider( *netcdf_offshore_provider, 
+		                                           SchismFormulation::OFFSHORE );
       return std::make_unique<SchismFormulation>( model_id,
                                             library_file,
 					    init_config,
                                             MPI_COMM_SELF,
 					    netcdf_met_provider, 
-                                            provider,
+                                            //provider,
+					    netcdf_offshore_provider, 
 					    netcdf_streamflow_provider
 		                           );
 }

--- a/src/realizations/coastal/SchismCreator.cpp
+++ b/src/realizations/coastal/SchismCreator.cpp
@@ -6,6 +6,8 @@
 #include "realizations/coastal/SchismFormulation.hpp"
 #include "realizations/coastal/MockProvider.h"
 #include "forcing/NetCDFMeshPointsDataProvider.hpp"
+#include "forcing/MetMeshPolicy.h"
+#include "forcing/FlowMeshPolicy.h"
 
 std::unique_ptr<CoastalFormulation>
       SchismCreator::createCoastalFormulation( coastal_config_params const& config,
@@ -35,12 +37,21 @@ std::unique_ptr<CoastalFormulation>
       time_t start_time_t = sim_time.get_start_date_time_epoch();
       time_t stop_time_t = sim_time.get_end_date_time_epoch();
 
-      auto netcdf_met_provider = std::make_shared<data_access::NetCDFMeshPointsDataProvider>(
+      auto netcdf_met_provider = 
+	      std::make_shared<data_access::NetCDFMeshPointsDataProvider< 
+	                                                   data_access::MetMeshPolicy > >(
 		      met_forcing_file,
                       std::chrono::system_clock::from_time_t(start_time_t),
                       std::chrono::system_clock::from_time_t(stop_time_t));
 
       SchismFormulation::check_forcing_provider( *netcdf_met_provider );
+
+      auto netcdf_streamflow_provider = 
+	      std::make_shared<data_access::NetCDFMeshPointsDataProvider< 
+	                                                   data_access::FlowMeshPolicy > >(
+		      flow_boundary_file,
+                      std::chrono::system_clock::from_time_t(start_time_t),
+                      std::chrono::system_clock::from_time_t(stop_time_t));
 
       return std::make_unique<SchismFormulation>( model_id,
                                             library_file,
@@ -48,7 +59,7 @@ std::unique_ptr<CoastalFormulation>
                                             MPI_COMM_SELF,
 					    netcdf_met_provider, 
                                             provider,
-                                            provider
+					    netcdf_streamflow_provider
 		                           );
 }
 

--- a/src/realizations/coastal/SchismFormulation.cpp
+++ b/src/realizations/coastal/SchismFormulation.cpp
@@ -45,12 +45,13 @@ std::vector<std::string> SchismFormulation::exported_output_variable_names_ =
     };
 
 
-void SchismFormulation::check_forcing_provider( ProviderType const& provider )
+void SchismFormulation::check_forcing_provider( ProviderType const& provider, 
+		SchismFormulation::ForcingSelector selector )
 {
           auto available_variables = provider.get_available_variable_names();
           for (auto const& expected : SchismFormulation::expected_input_variables_) {
               SchismFormulation::InputMapping const& mapping = expected.second;
-              if (mapping.selector == SchismFormulation::METEO ) {
+              if (mapping.selector == selector ) {
                 auto pos = std::find(available_variables.begin(), available_variables.end(), 
 				  mapping.name);
 #ifdef DEBUG_NETCDFMESH

--- a/src/realizations/coastal/SchismFormulation.cpp
+++ b/src/realizations/coastal/SchismFormulation.cpp
@@ -50,9 +50,12 @@ void SchismFormulation::check_forcing_provider( ProviderType const& provider )
           auto available_variables = provider.get_available_variable_names();
           for (auto const& expected : SchismFormulation::expected_input_variables_) {
               SchismFormulation::InputMapping const& mapping = expected.second;
-              if (mapping.selector == SchismFormulation::METEO) {
+              if (mapping.selector == SchismFormulation::METEO ) {
                 auto pos = std::find(available_variables.begin(), available_variables.end(), 
 				  mapping.name);
+#ifdef DEBUG_NETCDFMESH
+		std::cerr << "checking variable: " << mapping.name << std::endl;
+#endif 
 		assert( pos != available_variables.end() );
               }
 	  }
@@ -250,13 +253,11 @@ size_t SchismFormulation::mesh_size(std::string const& variable_name)
 void SchismFormulation::update_until( double const& time )
 {
        double current = this->get_current_time();
-       std::cerr << "current = " << current << std::endl;
        while ( current <= time )
        {
            set_inputs();
            bmi_->Update();
            current = this->get_current_time();
-           std::cerr << "current = " << current << ", time = " << time << std::endl;
            current_time_ += time_step_length_;
        }
 }

--- a/test/coastal/SchismFormulation_Test.cpp
+++ b/test/coastal/SchismFormulation_Test.cpp
@@ -6,10 +6,11 @@
 #include <limits>
 #include <iostream>
 #include <NetCDFMeshPointsDataProvider.hpp>
+#include "forcing/MetMeshPolicy.h"
 
 const static std::string library_path = "/contrib/Zhengtao.Cui/home/ngwpc/schism/build/lib/libschism_bmi.so";
-const static std::string init_config_path = "/contrib/Zhengtao.Cui/home/ngwpc/coastal/SCHISM_Lake_Champlain_BMI_Driver_Test/namelist.input";
-const static std::string met_forcing_netcdf_path = "/mnt/SCHISM_Lake_Champlain_BMI_test/NextGen_Forcings_Engine_MESH_output_201104302300.nc";
+const static std::string init_config_path = "/contrib/Zhengtao.Cui/home/ngwpc/ngen_coastal/data/SCHISM_Lake_Champlain_BMI_Driver_Test/namelist.input";
+const static std::string met_forcing_netcdf_path = "/efs/coastal_testdata/hrrr_scratch/NextGen_Forcings_Engine_MESH_output_202402201200.nc";
 
 #if 0
 struct Schism_Formulation_IT : public ::testing::Test
@@ -71,10 +72,12 @@ struct MockProvider : data_access::DataProvider<double, MeshPointsSelector>
     }
 };
 
-void test_netcdf_met_provider(std::shared_ptr<data_access::NetCDFMeshPointsDataProvider> provider)
+void test_netcdf_met_provider(
+		std::shared_ptr<data_access::NetCDFMeshPointsDataProvider 
+		                                  <data_access::MetMeshPolicy> > provider)
 {
 
-    return;
+ //   return;
     auto available_variables = provider->get_available_variable_names();
     for (auto const& expected : SchismFormulation::expected_input_variables_) {
         SchismFormulation::InputMapping const& mapping = expected.second;
@@ -93,23 +96,25 @@ int main(int argc, char **argv)
     auto provider = std::make_shared<MockProvider>();
 
     std::tm start_time_tm{};
-    start_time_tm.tm_year = 2011 - 1900;
-    start_time_tm.tm_mon = 5 - 1;
-    start_time_tm.tm_mday = 2;
+    start_time_tm.tm_year = 2024 - 1900;
+    start_time_tm.tm_mon = 2 - 1;
+    start_time_tm.tm_mday = 20;
     auto start_time_t = std::mktime(&start_time_tm);
 
     std::tm stop_time_tm{};
-    stop_time_tm.tm_year = 2011 - 1900;
-    stop_time_tm.tm_mon = 5 - 1;
-    stop_time_tm.tm_mday = 3;
+    stop_time_tm.tm_year = 2024 - 1900;
+    stop_time_tm.tm_mon = 2 - 1;
+    stop_time_tm.tm_mday = 21;
     auto stop_time_t = std::mktime(&stop_time_tm);
 
-//    auto netcdf_met_provider = std::make_shared<data_access::NetCDFMeshPointsDataProvider>(met_forcing_netcdf_path,
-//                                                                                           std::chrono::system_clock::from_time_t(start_time_t),
-//                                                                                           std::chrono::system_clock::from_time_t(stop_time_t));
+    auto netcdf_met_provider = 
+	    std::make_shared<data_access::NetCDFMeshPointsDataProvider< data_access::MetMeshPolicy >>
+	    (met_forcing_netcdf_path, std::chrono::system_clock::from_time_t(start_time_t),
+                                     std::chrono::system_clock::from_time_t(stop_time_t));
 
-//    test_netcdf_met_provider(netcdf_met_provider);
+    test_netcdf_met_provider(netcdf_met_provider);
 
+    std::cerr << "create object ..." << std::endl;
     std::unique_ptr<CoastalFormulation> schism =
         std::make_unique<SchismFormulation>(/*id=*/ "test_schism_formulation",
                                             library_path,
@@ -121,6 +126,7 @@ int main(int argc, char **argv)
                                             provider
                                             );
 
+    std::cerr << "initialize .." << std::endl;
     schism->initialize();
 
     for (int i = 0; i < 3; ++i) {


### PR DESCRIPTION
Refactored the NetCDFMeshPointsDataProvider, added MetMeshPolicy and FlowMeshPolicy. Now it can read the source_TRoute.nc as input file.


## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [ ] Linux
