### PR TITLE
NGWPC-7474: Realization catchment grouping

### DIFF
--- a/include/geojson/JSONProperty.hpp
+++ b/include/geojson/JSONProperty.hpp
@@ -165,7 +165,11 @@ namespace geojson {
      */
     class JSONProperty {
         public:
-            
+            /**
+             * @brief Don't use this, but it's necessary for working with functions and classes that expect a default constructor
+             */
+            JSONProperty() = default;    
+
             JSONProperty(std::string value_key, const boost::property_tree::ptree& property_tree):
             key(std::move(value_key)) {
 

--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -140,6 +140,24 @@ namespace realization {
                 #endif //NGEN_WITH_ROUTING
                  }
 
+                std::unordered_map<std::string, realization::config::Formulation> formulation_groups;
+                auto possible_formulation_groups = tree.get_child_optional("formulation_groups");
+                if (possible_formulation_groups) {
+                    for (std::pair<std::string, boost::property_tree::ptree> formulation_config : *possible_formulation_groups) {
+                        realization::config::Formulation formulation(formulation_config.second);
+                        formulation_groups[formulation_config.first] = formulation;
+                    }
+                }
+
+                std::unordered_map<std::string, realization::config::Forcing> forcing_groups;
+                auto possible_forcing_groups = tree.get_child_optional("forcing_groups");
+                if (possible_forcing_groups) {
+                    for (std::pair<std::string, boost::property_tree::ptree> forcing_config : *possible_forcing_groups) {
+                        realization::config::Forcing forcing(forcing_config.second);
+                        forcing_groups[forcing_config.first] = forcing;
+                    }
+                }
+
                 /**
                  * Read catchment configurations from configuration file
                  */      
@@ -158,7 +176,7 @@ namespace realization {
                           #endif
                           continue;
                       }
-                      realization::config::Config catchment_formulation(catchment_config.second);
+                      realization::config::Config catchment_formulation(catchment_config.second, formulation_groups, forcing_groups);
 
                       if(!catchment_formulation.has_formulation()){
                         std::string throw_msg; throw_msg.assign("ERROR: No formulations defined for "+catchment_config.first+".");

--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -144,7 +144,8 @@ namespace realization {
                 auto possible_formulation_groups = tree.get_child_optional("formulation_groups");
                 if (possible_formulation_groups) {
                     for (std::pair<std::string, boost::property_tree::ptree> formulation_config : *possible_formulation_groups) {
-                        realization::config::Formulation formulation(formulation_config.second);
+                        std::cout << formulation_config.first.c_str() << std::endl;
+                        realization::config::Formulation formulation(formulation_config.second.get_child(".")); // "." for first element in list
                         formulation_groups[formulation_config.first] = formulation;
                     }
                 }

--- a/include/realizations/config/config.hpp
+++ b/include/realizations/config/config.hpp
@@ -27,20 +27,19 @@ namespace realization{
          * @param tree 
          */
         Config(const boost::property_tree::ptree& tree){
-            // check if forcing is a string insted of object
-            if (!tree.get_optional<std::string>("forcing")) {
-                auto possible_forcing = tree.get_child_optional("forcing");
-                if (possible_forcing) {
+        
+            auto possible_forcing = tree.get_child_optional("forcing");
+            if (possible_forcing) {
+                // check if forcing is a string to a group
+                if (!possible_forcing->empty()) {
                     forcing = Forcing(*possible_forcing);
                 }
             }
-            // check if formulations is a string instead of object
-            if (!tree.get_optional<std::string>("formulations")) {
-                //get first empty key under formulations (corresponds to first json array element)
-                auto possible_formulation_tree = tree.get_child_optional("formulations..");
-                if(possible_formulation_tree){
-                    formulation = Formulation(*possible_formulation_tree);
-                }   
+
+            //get first empty key under formulations (corresponds to first json array element)
+            auto possible_formulation_tree = tree.get_child_optional("formulations..");
+            if(possible_formulation_tree){
+                formulation = Formulation(*possible_formulation_tree);
             }
         }
         /**

--- a/include/realizations/config/config.hpp
+++ b/include/realizations/config/config.hpp
@@ -27,16 +27,49 @@ namespace realization{
          * @param tree 
          */
         Config(const boost::property_tree::ptree& tree){
-        
-            auto possible_forcing = tree.get_child_optional("forcing");
-
-            if (possible_forcing) {
-                forcing = Forcing(*possible_forcing);
+            // check if forcing is a string insted of object
+            if (!tree.get_optional<std::string>("forcing")) {
+                auto possible_forcing = tree.get_child_optional("forcing");
+                if (possible_forcing) {
+                    forcing = Forcing(*possible_forcing);
+                }
             }
-            //get first empty key under formulations (corresponds to first json array element)
-            auto possible_formulation_tree = tree.get_child_optional("formulations..");
-            if(possible_formulation_tree){
-                formulation = Formulation(*possible_formulation_tree);
+            // check if formulations is a string instead of object
+            if (!tree.get_optional<std::string>("formulations")) {
+                //get first empty key under formulations (corresponds to first json array element)
+                auto possible_formulation_tree = tree.get_child_optional("formulations..");
+                if(possible_formulation_tree){
+                    formulation = Formulation(*possible_formulation_tree);
+                }   
+            }
+        }
+        /**
+         * @brief Construct a new Config object from property tree with formulation and forcing groups as alternatives
+         * 
+         * @param tree JSON object with parameters for the configuration
+         * @param formulation_groups Map between formulation group names and the Formulation templates. Clones of the Formulations will be stored on the Config
+         * @param forcing_groups Map between the forcing group name and the Forcing templates. Clones of the Forcings will be stored on the Config.
+         */
+        Config(const boost::property_tree::ptree& tree,
+               std::unordered_map<std::string, Formulation> &formulation_groups,
+               std::unordered_map<std::string, Forcing> &forcing_groups)
+                : Config(tree) {
+            if (!this->has_formulation()) {
+                boost::optional<std::string> formulation_group = tree.get_optional<std::string>("formulations");
+                if (formulation_group) {
+                    if (formulation_groups.find(*formulation_group) != formulation_groups.end()) {
+                        this->formulation = formulation_groups[*formulation_group].clone();
+                    }
+                }
+            }
+
+            if (this->forcing.parameters.size() == 0) {
+                boost::optional<std::string> forcing_group = tree.get_optional<std::string>("forcing");
+                if (forcing_group) {
+                    if (forcing_groups.find(*forcing_group) != forcing_groups.end()) {
+                        this->forcing = forcing_groups[*forcing_group].clone();
+                    }
+                }
             }
         }
 

--- a/include/realizations/config/forcing.hpp
+++ b/include/realizations/config/forcing.hpp
@@ -50,6 +50,17 @@ namespace realization{
     bool has_key(const std::string& key) const{
         return parameters.count(key) > 0;
     }
+
+    /**
+     * @brief Create a deep copy of the forcing parameters
+     */
+    Forcing clone() {
+      Forcing clone;
+      for (auto& param : this->parameters) {
+        clone.parameters[param.first] = geojson::JSONProperty(param.second);
+      }
+      return clone;
+    }
   };
 
 

--- a/include/realizations/config/formulation.hpp
+++ b/include/realizations/config/formulation.hpp
@@ -57,6 +57,21 @@ namespace realization{
     }
 
     /**
+     * @brief Create a deep copy of the Formulation and all its properties.
+     */
+    Formulation clone() {
+        geojson::PropertyMap parameters_clone;
+        for (auto& param : this->parameters) {
+            parameters_clone[param.first] = geojson::JSONProperty(param.second);
+        }
+        Formulation clone(this->type, parameters_clone);
+        for (auto& n : this->nested) {
+            clone.nested.push_back(n.clone());
+        }
+        return clone;
+    }
+
+    /**
      * @brief Link formulation parameters to hydrofabric data held in feature
      * 
      * @param feature Hydrofabric feature with properties to assign to formulation


### PR DESCRIPTION
[Short description explaining the high-level reason for the pull request]

## Additions

- Realization configuration can include formulation_groups and forcing_groups. Catchments can use a string for their formulations and forcing properties to subscribe to the formluations and forcings defined in the groups.


## Notes

- All catchments must still have "formulations" and "forcing" properties. For example, if only one forcing should be used for all catchments, a forcing_group must be made for that forcing, and all catchments must have a "forcing" property with the name of the sole forcing group.

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [ ] Linux
