### PR TITLE
Add EWTS message to Bmi_Module_Formulation's get_response on BMI error thrown (NGWPC-7474)

### DIFF
--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -385,7 +385,9 @@ namespace realization {
          * @param t_delta The size of the time step over which the formulation is going to update the model, which might
          *                be different than the model's internal time step.
          */
-        std::string set_model_inputs_prior_to_update(const double &model_init_time, time_step_t t_delta);
+        void set_model_inputs_prior_to_update(const double &model_init_time, time_step_t t_delta);
+
+        void append_model_inputs_error(const double &model_init_time, time_step_t t_delta, std::stringstream &error_message);
 
         template<typename T>
         void append_inputs(std::shared_ptr<void> values, int num_items, std::stringstream &inputs);

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -385,7 +385,15 @@ namespace realization {
          * @param t_delta The size of the time step over which the formulation is going to update the model, which might
          *                be different than the model's internal time step.
          */
-        void set_model_inputs_prior_to_update(const double &model_init_time, time_step_t t_delta);
+        std::string set_model_inputs_prior_to_update(const double &model_init_time, time_step_t t_delta);
+
+        template<typename T>
+        void append_inputs(std::shared_ptr<void> values, int num_items, std::stringstream &inputs);
+
+        void append_inputs(std::string type, std::shared_ptr<void> values, int num_items, std::stringstream &inputs);
+
+        template<typename T>
+        void append_input(std::string type, T value, std::stringstream &inputs);
 
         /** The delta of the last model update execution (typically, this is time step size). */
         time_step_t last_model_response_delta = 0;

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -387,13 +387,45 @@ namespace realization {
          */
         void set_model_inputs_prior_to_update(const double &model_init_time, time_step_t t_delta);
 
-        void append_model_inputs_error(const double &model_init_time, time_step_t t_delta, std::stringstream &error_message);
+        /**
+         * Append `set_model_inputs_prior_to_update` values to an error message. This is intended to be used if the BMI fails to run `update()`.
+         * 
+         * @param model_initial_time The model's time prior to the update, in its internal units and representation.
+         * @param t_delta The size of the time step over which the formulation is going to update the model, which might
+         *                be different than the model's internal time step.
+         * @param inputs Stream the inputs message will be appended to.
+         */
+        void append_model_inputs_to_stream(const double &model_init_time, time_step_t t_delta, std::stringstream &inputs);
 
+        /**
+         * Convert a pointer to an array of data to its correct type, then append these items to a stream. 
+         * The format will appear like a python list, e.g., [0.5, 1.2, 5.8]
+         * 
+         * @param values Raw pointer to data that will be interpreted based on the `type`
+         * @param num_items The number of items expected in the array.
+         * @param inputs Stream the values will be appended to.
+         */
         template<typename T>
         void append_inputs(std::shared_ptr<void> values, int num_items, std::stringstream &inputs);
 
+        /**
+         * Convert a pointer to an array of data to its correct type, then append these items to a stream. 
+         * The format will appear like a python list, e.g., [0.5, 1.2, 5.8]
+         * 
+         * @param type String representing the type of data the pointer is for.
+         * @param values Raw pointer to data that will be interpreted based on the `type`
+         * @param num_items The number of items expected in the array.
+         * @param inputs Stream the values will be appended to.
+         */
         void append_inputs(std::string type, std::shared_ptr<void> values, int num_items, std::stringstream &inputs);
 
+        /**
+         * Convert data to a target data type and append it to an stream.
+         * 
+         * @param type String representing the type of data the pointer is for.
+         * @param value Raw data that will be cast to a value based on the `type`.
+         * @param inputs Stream the interpreted ata will be appeneded to.
+         */
         template<typename T>
         void append_input(std::string type, T value, std::stringstream &inputs);
 

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -61,27 +61,27 @@ namespace realization {
                 }
             }
 
-            std::string update_method;
+            int update_method;
             while (next_time_step_index <= t_index) {
                 double model_initial_time = get_bmi_model()->GetCurrentTime();
                 std::string model_inputs = set_model_inputs_prior_to_update(model_initial_time, t_delta);
                 try {
                     if (t_delta_model_units == get_bmi_model()->GetTimeStep()) {
-                        update_method = "Update";
+                        update_method = 0;
                         get_bmi_model()->Update();
                     }
                     else {
-                        update_method = "UpdateUntil";
+                        update_method = 1;
                         get_bmi_model()->UpdateUntil(model_initial_time + t_delta_model_units);
                     }
                 } catch (const std::exception &e) {
                     std::stringstream error_message;
-                    error_message << "Call to " << update_method
+                    error_message << "Call to " << (update_method == 0 ? "Update" : "UpdateUntil")
                         << " of model " << get_bmi_model()->get_model_name()
                         << " failed for catchment \"" << this->get_catchment_id() << "\""
                            " at t_index = " << t_index << ","
-                           " next_step_index = " << next_time_step_index << "."
-                           "\nInput variables were as follows:\n" << model_inputs;
+                           " next_step_index = " << next_time_step_index << ".\n"
+                        << model_inputs;
                     Logger::Log(LogLevel::SEVERE, error_message.str());
                     throw;
                 }
@@ -749,7 +749,7 @@ namespace realization {
             for (int i = 0; i < num_items; ++i) {
                 if (i != 0)
                     inputs << ", ";
-                inputs << *array[i];
+                inputs << array[i];
             }
             inputs << "]";
         }

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -738,7 +738,7 @@ namespace realization {
         void Bmi_Module_Formulation::append_model_inputs_to_stream(const double &model_init_time, time_step_t t_delta, std::stringstream &inputs) {
             std::vector<std::string> in_var_names = get_bmi_model()->GetInputVarNames();
             time_t model_epoch_time = convert_model_time(model_init_time) + get_bmi_model_start_time_forcing_offset_s();
-            error_message << "Input variables were as follows:";
+            inputs << "Input variables were as follows:";
 
             for (std::string & var_name : in_var_names) {
                 data_access::GenericDataProvider *provider;
@@ -765,20 +765,20 @@ namespace realization {
                 std::string type = get_bmi_model()->get_analogous_cxx_type(get_bmi_model()->GetVarType(var_name),
                                                                            varItemSize);
                 
-                error_message << "\n" << var_map_alias << " = ";
+                inputs << "\n" << var_map_alias << " = ";
                 if (numItems != 1) {
                     //more than a single value needed for var_name
                     auto values = provider->get_values(CatchmentAggrDataSelector(this->get_catchment_id(),var_map_alias, model_epoch_time, t_delta,
                                                    get_bmi_model()->GetVarUnits(var_name)));
                     value_ptr = get_values_as_type( type, values.begin(), values.end() );
                     // array like input: precipitation_mm_per_h = [0.2, 0.8, 1.8]
-                    this->append_inputs(type, value_ptr, numItems, error_message);
+                    this->append_inputs(type, value_ptr, numItems, inputs);
 
                 } else {
                     //scalar value
                     double value = provider->get_value(CatchmentAggrDataSelector(this->get_catchment_id(),var_map_alias, model_epoch_time, t_delta,
                                                    get_bmi_model()->GetVarUnits(var_name)));
-                    this->append_input(type, value, error_message);
+                    this->append_input(type, value, inputs);
                 }
             }
         }

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -76,13 +76,12 @@ namespace realization {
                     }
                 } catch (const std::exception &e) {
                     std::stringstream error_message;
-                    error_message << "Call to " << (update_method == 0 ? "Update" : "UpdateUntil")
-                        << " of model " << get_bmi_model()->get_model_name()
-                        << " failed for catchment \"" << this->get_catchment_id() << "\""
-                           " at t_index = " << t_index << ","
-                           " next_step_index = " << next_time_step_index << ".\n";
+                    error_message << "Model " << (update_method == 0 ? "Update" : "UpdateUntil")
+                        << " failed on catchment " << this->get_catchment_id()
+                        << ". t_index=" << t_index
+                        << ", next_step_index=" << next_time_step_index << "\n";
                     append_model_inputs_to_stream(model_initial_time, t_delta, error_message);
-                    Logger::Log(LogLevel::SEVERE, error_message.str());
+                    Logger::Log(LogLevel::FATAL, error_message.str());
                     throw;
                 }
                 // TODO: again, consider whether we should store any historic response, ts_delta, or other var values

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -61,13 +61,30 @@ namespace realization {
                 }
             }
 
+            std::string update_method;
             while (next_time_step_index <= t_index) {
                 double model_initial_time = get_bmi_model()->GetCurrentTime();
-                set_model_inputs_prior_to_update(model_initial_time, t_delta);
-                if (t_delta_model_units == get_bmi_model()->GetTimeStep())
-                    get_bmi_model()->Update();
-                else
-                    get_bmi_model()->UpdateUntil(model_initial_time + t_delta_model_units);
+                std::string model_inputs = set_model_inputs_prior_to_update(model_initial_time, t_delta);
+                try {
+                    if (t_delta_model_units == get_bmi_model()->GetTimeStep()) {
+                        update_method = "Update";
+                        get_bmi_model()->Update();
+                    }
+                    else {
+                        update_method = "UpdateUntil";
+                        get_bmi_model()->UpdateUntil(model_initial_time + t_delta_model_units);
+                    }
+                } catch (const std::exception &e) {
+                    std::stringstream error_message;
+                    error_message << "Call to " << update_method
+                        << " of model " << get_bmi_model()->get_model_name()
+                        << " failed for catchment \"" << this->get_catchment_id() << "\""
+                           " at t_index = " << t_index << ","
+                           " next_step_index = " << next_time_step_index << "."
+                           "\nInput variables were as follows:\n" << model_inputs;
+                    Logger::Log(LogLevel::SEVERE, error_message.str());
+                    throw;
+                }
                 // TODO: again, consider whether we should store any historic response, ts_delta, or other var values
                 next_time_step_index++;
             }
@@ -655,9 +672,11 @@ namespace realization {
                 "': no logic for converting value to variable's type.");
         }
 
-        void Bmi_Module_Formulation::set_model_inputs_prior_to_update(const double &model_init_time, time_step_t t_delta) {
+        std::string Bmi_Module_Formulation::set_model_inputs_prior_to_update(const double &model_init_time, time_step_t t_delta) {
             std::vector<std::string> in_var_names = get_bmi_model()->GetInputVarNames();
             time_t model_epoch_time = convert_model_time(model_init_time) + get_bmi_model_start_time_forcing_offset_s();
+            std::stringstream model_inputs;
+            model_inputs << "Input variables were as follows:";
 
             for (std::string & var_name : in_var_names) {
                 data_access::GenericDataProvider *provider;
@@ -706,15 +725,102 @@ namespace realization {
 
                     }
                     value_ptr = get_values_as_type( type, values.begin(), values.end() );
+                    // array like input: precipitation_mm_per_h = [0.2, 0.8, 1.8]
+                    model_inputs << "\n" << var_name << " = ";
+                    this->append_inputs(type, value_ptr, numItems, model_inputs);
 
                 } else {
                     //scalar value
                     double value = provider->get_value(CatchmentAggrDataSelector(this->get_catchment_id(),var_map_alias, model_epoch_time, t_delta,
                                                    get_bmi_model()->GetVarUnits(var_name)));
                     value_ptr = get_value_as_type(type, value);
+                    model_inputs << "\n" << var_name << " = ";
+                    this->append_input(type, value, model_inputs);
                 }
                 get_bmi_model()->SetValue(var_name, value_ptr.get());
             }
+            return model_inputs.str();
+        }
+
+        template<typename T>
+        void Bmi_Module_Formulation::append_inputs(std::shared_ptr<void> values, int num_items, std::stringstream &inputs) {
+            T *array = (T*)values.get();
+            inputs << "[";
+            for (int i = 0; i < num_items; ++i) {
+                if (i != 0)
+                    inputs << ", ";
+                inputs << *array[i];
+            }
+            inputs << "]";
+        }
+
+        void Bmi_Module_Formulation::append_inputs(std::string type, std::shared_ptr<void> values, int num_items, std::stringstream &inputs) {
+            
+            if (type == "double" || type == "double precision") 
+                this->append_inputs<double>(values, num_items, inputs);
+
+            else if (type == "float" || type == "real") 
+                this->append_inputs<float>(values, num_items, inputs);
+
+            else if (type == "short" || type == "short int" || type == "signed short" || type == "signed short int")
+                this->append_inputs<short>(values, num_items, inputs);
+
+            else if (type == "unsigned short" || type == "unsigned short int")
+                this->append_inputs<unsigned short>(values, num_items, inputs);
+
+            else if (type == "int" || type == "signed" || type == "signed int" || type == "integer")
+                this->append_inputs<int>(values, num_items, inputs);
+
+            else if (type == "unsigned" || type == "unsigned int")
+                this->append_inputs<unsigned int>(values, num_items, inputs);
+
+            else if (type == "long" || type == "long int" || type == "signed long" || type == "signed long int")
+                this->append_inputs<long>(values, num_items, inputs);
+
+            else if (type == "unsigned long" || type == "unsigned long int")
+                this->append_inputs<unsigned long>(values, num_items, inputs);
+
+            else if (type == "long long" || type == "long long int" || type == "signed long long" || type == "signed long long int")
+                this->append_inputs<long long>(values, num_items, inputs);
+
+            else if (type == "unsigned long long" || type == "unsigned long long int")
+                this->append_inputs<unsigned long long>(values, num_items, inputs);
+
+        }
+
+        template<typename T>
+        void Bmi_Module_Formulation::append_input(std::string type, T value, std::stringstream &inputs) {
+
+            if (type == "double" || type == "double precision")
+                inputs << static_cast<double>(value);
+
+            else if (type == "float" || type == "real")
+                inputs << static_cast<float>(value);
+
+            else if (type == "short" || type == "short int" || type == "signed short" || type == "signed short int")
+                inputs << static_cast<short>(value);
+
+            else if (type == "unsigned short" || type == "unsigned short int")
+                inputs << static_cast<unsigned short>(value);
+
+            else if (type == "int" || type == "signed" || type == "signed int" || type == "integer")
+                inputs << static_cast<int>(value);
+
+            else if (type == "unsigned" || type == "unsigned int")
+                inputs << static_cast<unsigned int>(value);
+
+            else if (type == "long" || type == "long int" || type == "signed long" || type == "signed long int")
+                inputs << static_cast<long>(value);
+
+            else if (type == "unsigned long" || type == "unsigned long int")
+                inputs << static_cast<unsigned long>(value);
+
+            else if (type == "long long" || type == "long long int" || type == "signed long long" || type == "signed long long int")
+                inputs << static_cast<long long>(value);
+
+            else if (type == "unsigned long long" || type == "unsigned long long int")
+                inputs << static_cast<unsigned long long>(value);
+
         }
 
         const boost::span<char> Bmi_Module_Formulation::get_serialization_state() const {

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -726,7 +726,7 @@ namespace realization {
                     }
                     value_ptr = get_values_as_type( type, values.begin(), values.end() );
                     // array like input: precipitation_mm_per_h = [0.2, 0.8, 1.8]
-                    model_inputs << "\n" << var_name << " = ";
+                    model_inputs << "\n" << var_map_alias << " = ";
                     this->append_inputs(type, value_ptr, numItems, model_inputs);
 
                 } else {
@@ -734,7 +734,7 @@ namespace realization {
                     double value = provider->get_value(CatchmentAggrDataSelector(this->get_catchment_id(),var_map_alias, model_epoch_time, t_delta,
                                                    get_bmi_model()->GetVarUnits(var_name)));
                     value_ptr = get_value_as_type(type, value);
-                    model_inputs << "\n" << var_name << " = ";
+                    model_inputs << "\n" << var_map_alias << " = ";
                     this->append_input(type, value, model_inputs);
                 }
                 get_bmi_model()->SetValue(var_name, value_ptr.get());

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -81,7 +81,7 @@ namespace realization {
                         << " failed for catchment \"" << this->get_catchment_id() << "\""
                            " at t_index = " << t_index << ","
                            " next_step_index = " << next_time_step_index << ".\n";
-                    append_model_inputs_error(model_initial_time, t_delta, error_message);
+                    append_model_inputs_to_stream(model_initial_time, t_delta, error_message);
                     Logger::Log(LogLevel::SEVERE, error_message.str());
                     throw;
                 }
@@ -735,7 +735,7 @@ namespace realization {
         }
 
 
-        void Bmi_Module_Formulation::append_model_inputs_error(const double &model_init_time, time_step_t t_delta, std::stringstream &error_message) {
+        void Bmi_Module_Formulation::append_model_inputs_to_stream(const double &model_init_time, time_step_t t_delta, std::stringstream &inputs) {
             std::vector<std::string> in_var_names = get_bmi_model()->GetInputVarNames();
             time_t model_epoch_time = convert_model_time(model_init_time) + get_bmi_model_start_time_forcing_offset_s();
             error_message << "Input variables were as follows:";

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -64,7 +64,7 @@ namespace realization {
             int update_method;
             while (next_time_step_index <= t_index) {
                 double model_initial_time = get_bmi_model()->GetCurrentTime();
-                std::string model_inputs = set_model_inputs_prior_to_update(model_initial_time, t_delta);
+                set_model_inputs_prior_to_update(model_initial_time, t_delta);
                 try {
                     if (t_delta_model_units == get_bmi_model()->GetTimeStep()) {
                         update_method = 0;
@@ -80,8 +80,8 @@ namespace realization {
                         << " of model " << get_bmi_model()->get_model_name()
                         << " failed for catchment \"" << this->get_catchment_id() << "\""
                            " at t_index = " << t_index << ","
-                           " next_step_index = " << next_time_step_index << ".\n"
-                        << model_inputs;
+                           " next_step_index = " << next_time_step_index << ".\n";
+                    append_model_inputs_error(model_initial_time, t_delta, error_message);
                     Logger::Log(LogLevel::SEVERE, error_message.str());
                     throw;
                 }
@@ -672,11 +672,9 @@ namespace realization {
                 "': no logic for converting value to variable's type.");
         }
 
-        std::string Bmi_Module_Formulation::set_model_inputs_prior_to_update(const double &model_init_time, time_step_t t_delta) {
+        void Bmi_Module_Formulation::set_model_inputs_prior_to_update(const double &model_init_time, time_step_t t_delta) {
             std::vector<std::string> in_var_names = get_bmi_model()->GetInputVarNames();
             time_t model_epoch_time = convert_model_time(model_init_time) + get_bmi_model_start_time_forcing_offset_s();
-            std::stringstream model_inputs;
-            model_inputs << "Input variables were as follows:";
 
             for (std::string & var_name : in_var_names) {
                 data_access::GenericDataProvider *provider;
@@ -725,21 +723,64 @@ namespace realization {
 
                     }
                     value_ptr = get_values_as_type( type, values.begin(), values.end() );
-                    // array like input: precipitation_mm_per_h = [0.2, 0.8, 1.8]
-                    model_inputs << "\n" << var_map_alias << " = ";
-                    this->append_inputs(type, value_ptr, numItems, model_inputs);
 
                 } else {
                     //scalar value
                     double value = provider->get_value(CatchmentAggrDataSelector(this->get_catchment_id(),var_map_alias, model_epoch_time, t_delta,
                                                    get_bmi_model()->GetVarUnits(var_name)));
                     value_ptr = get_value_as_type(type, value);
-                    model_inputs << "\n" << var_map_alias << " = ";
-                    this->append_input(type, value, model_inputs);
                 }
                 get_bmi_model()->SetValue(var_name, value_ptr.get());
             }
-            return model_inputs.str();
+        }
+
+
+        void Bmi_Module_Formulation::append_model_inputs_error(const double &model_init_time, time_step_t t_delta, std::stringstream &error_message) {
+            std::vector<std::string> in_var_names = get_bmi_model()->GetInputVarNames();
+            time_t model_epoch_time = convert_model_time(model_init_time) + get_bmi_model_start_time_forcing_offset_s();
+            error_message << "Input variables were as follows:";
+
+            for (std::string & var_name : in_var_names) {
+                data_access::GenericDataProvider *provider;
+                std::string var_map_alias = get_config_mapped_variable_name(var_name);
+                if (input_forcing_providers.find(var_map_alias) != input_forcing_providers.end()) {
+                    provider = input_forcing_providers[var_map_alias].get();
+                }
+                else if (var_map_alias != var_name && input_forcing_providers.find(var_name) != input_forcing_providers.end()) {
+                    provider = input_forcing_providers[var_name].get();
+                }
+                else {
+                    provider = forcing.get();
+                }
+
+                // TODO: probably need to actually allow this by default and warn, but have config option to activate
+                //  this type of behavior
+                // TODO: account for arrays later
+                int nbytes = get_bmi_model()->GetVarNbytes(var_name);
+                int varItemSize = get_bmi_model()->GetVarItemsize(var_name);
+                int numItems = nbytes / varItemSize;
+
+                std::shared_ptr<void> value_ptr;
+                // Finally, use the value obtained to set the model input
+                std::string type = get_bmi_model()->get_analogous_cxx_type(get_bmi_model()->GetVarType(var_name),
+                                                                           varItemSize);
+                
+                error_message << "\n" << var_map_alias << " = ";
+                if (numItems != 1) {
+                    //more than a single value needed for var_name
+                    auto values = provider->get_values(CatchmentAggrDataSelector(this->get_catchment_id(),var_map_alias, model_epoch_time, t_delta,
+                                                   get_bmi_model()->GetVarUnits(var_name)));
+                    value_ptr = get_values_as_type( type, values.begin(), values.end() );
+                    // array like input: precipitation_mm_per_h = [0.2, 0.8, 1.8]
+                    this->append_inputs(type, value_ptr, numItems, error_message);
+
+                } else {
+                    //scalar value
+                    double value = provider->get_value(CatchmentAggrDataSelector(this->get_catchment_id(),var_map_alias, model_epoch_time, t_delta,
+                                                   get_bmi_model()->GetVarUnits(var_name)));
+                    this->append_input(type, value, error_message);
+                }
+            }
         }
 
         template<typename T>


### PR DESCRIPTION
Adds an EWTS log when a formulation model throws an error during the `Update[Until]` call. The message includes information on which formulation and catchment the error occurred on and information injected through `set_model_inputs_prior_to_update`. Logging this information will help debugging errors in data in the future.

## Additions

- Try/Catch block for capturing errors around `Update()` for logging. After the data is captured, the error will be thrown again.
- A function that will convert the inputs in `set_model_inputs_prior_to_update` as a string that will be added to the error message.
- Helper functions for converting BMI data types and appending it to a stringstream.

## Testing

Results of running ngen with one line added that throws an error before running Update to test error handling:
2025-08-26T20:17:33.698 NGEN     INFO    Log File: /home/ian.todd/run-logs/Ian.Todd@nextgenwaterprediction.com/ngen_20250826T201733.log
2025-08-26T20:17:33.698 NGEN     INFO    Log level set to INFO   
2025-08-26T20:17:33.698 NGEN     INFO    NGen Framework 0.3.0
2025-08-26T20:17:33.856 NGEN     INFO    Building Nexus collection
2025-08-26T20:17:33.857 NGEN     INFO    Building Catchment collection
2025-08-26T20:17:33.871 NGEN     INFO    Initializing formulations
2025-08-26T20:17:33.889 NGEN     INFO    Bmi_Adapter: Model name: test_bmi_cpp
2025-08-26T20:17:33.908 NGEN     INFO    Bmi_Adapter: Model name: test_bmi_cpp
2025-08-26T20:17:33.926 NGEN     INFO    Bmi_Adapter: Model name: test_bmi_cpp
2025-08-26T20:17:33.926 NGEN     INFO    Not Using Routing
2025-08-26T20:17:33.926 NGEN     INFO    Building Feature Index
2025-08-26T20:17:33.927 NGEN     INFO    Catchment topology is dendritic.
2025-08-26T20:17:33.927 NGEN     INFO    Running Models
2025-08-26T20:17:33.933 NGEN     SEVERE  Call to Update of model test_bmi_cpp failed for catchment "cat-52" at t_index = 0, next_step_index = 0.
2025-08-26T20:17:33.933 NGEN     SEVERE  Input variables were as follows:
2025-08-26T20:17:33.933 NGEN     SEVERE  precip_rate = 0
2025-08-26T20:17:33.933 NGEN     SEVERE  TMP_2maboveground = 285.9


## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [ ] Linux
