### PR TITLE
Widen collection size variables to size_t to avoid multiplication overflow in large-and-long runs

### DIFF
--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -534,7 +534,7 @@ int main(int argc, char* argv[]) {
     // T-ROUTE data storage
     std::unordered_map<std::string, int> nexus_indexes;
 #if NGEN_WITH_ROUTING
-    int nexus_collection_size = nexus_collection->get_size();
+    size_t nexus_collection_size = nexus_collection->get_size();
     for (int i = 0; i < nexus_collection_size; ++i) {
         auto feature = nexus_collection->get_feature(i);
         std::string feature_id = feature->get_id();
@@ -654,8 +654,9 @@ int main(int argc, char* argv[]) {
     std::unordered_map<std::string, int> catchment_indexes;
     std::vector<double> nexus_downstream_flows;
 #if NGEN_WITH_ROUTING
-    catchment_outflows.resize(catchment_collection->get_size() * num_times);
-    for (int i = 0; i < catchment_collection->get_size(); ++i) {
+    size_t catchment_collection_size = catchment_collection->get_size();
+    catchment_outflows.resize(catchment_collection_size * num_times);
+    for (int i = 0; i < catchment_collection_size; ++i) {
         auto feature = catchment_collection->get_feature(i);
         std::string feature_id = feature->get_id();
         catchment_indexes[feature_id] = i;


### PR DESCRIPTION
See CodeQL remarks about potential overflow here: https://github.com/NGWPC/ngen/pull/6/files

In the CONUS domain with 880,000 catchments and hourly timesteps, a run would have run into the overflow for a run of about 100 days. This is not an implausible configuration.

## Changes

- Store the catchment and nexus collection sizes in `size_t` variables so that multiplication by `num_times` is done in full 64-bit width and doesn't risk overflow

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: