### PR TITLE
Updated GH Actions Files to Specify GH ORG

### DIFF
--- a/.github/workflows/Example_model_run.yml
+++ b/.github/workflows/Example_model_run.yml
@@ -5,17 +5,24 @@ on:
     branches: [ release-* ]
   pull_request:
     branches: [ master, release-* ]
+
+env:
+  ORG: NOAA-OWP
+
 jobs:
     Build_and_Run_Model:
       runs-on: ubuntu-latest
       steps:
       - name: Checkout the code
+        if: ${{ github.repository_owner == env.ORG }}
         uses: actions/checkout@v4
 
       - name: Build the NGEN image
+        if: ${{ github.repository_owner == env.ORG }}
         run: docker build --file ./docker/ngen.dockerfile --tag localbuild/ngen:latest .
-  
+
       - name: Run the NGEN model on example data
+        if: ${{ github.repository_owner == env.ORG }}
         run: |
           docker run --rm -i --mount type=bind,source="$(pwd)"/data,target=/ngen_build/data,readonly \
           localbuild/ngen:latest \

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -10,6 +10,9 @@ on:
   #pull_request:
     #branches: [ master ]
 
+env:
+  ORG: NOAA-OWP
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "document"
@@ -21,42 +24,54 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v4
-    
+      if: ${{ github.repository_owner == env.ORG }}
+
+
     - name: Make sure initial ownership is correct
+      if: ${{ github.repository_owner == env.ORG }}
       run: sudo chown -R runner:docker docs/
 
     # Runs a single command using the runners shell
     - uses: mattnotmitt/doxygen-action@v1
+      if: ${{ github.repository_owner == env.ORG }}
       with:
           working-directory: '.'
-          doxyfile-path: './Doxyfile'       
-    
+          doxyfile-path: './Doxyfile'
+
     - name: Make sure ownership of generated items is correct
+      if: ${{ github.repository_owner == env.ORG }}
       run: sudo chown -R runner:docker docs/
-          
+
     - name: Switch to gh-pages
+      if: ${{ github.repository_owner == env.ORG }}
       uses: actions/checkout@v4
       with:
         ref: gh-pages
         clean: false
 
     - name: Move generated files where git can see them
+      if: ${{ github.repository_owner == env.ORG }}
       run: cp -rp docs/html/* .
-        
+
     - name: Prevent generated docs dir from being committed and overwriting on the next run.
+      if: ${{ github.repository_owner == env.ORG }}
       run: rm -Rf docs/html
 
     - name: Update branch information
+      if: ${{ github.repository_owner == env.ORG }}
       run: git fetch --all; git branch --list -r;
-      
+
     - name: Grab the latest markdown files
+      if: ${{ github.repository_owner == env.ORG }}
       run: git checkout origin/master -- `git ls-tree origin/master -r --name-only | grep ".md"`;
            git add -f .;
 
     - name: Commit files
+      if: ${{ github.repository_owner == env.ORG }}
       run: echo ${{ github.ref }};
         git config --local user.name "GitHub Action";
         git commit -m "Commiting Documentation" -a | exit 0;
-        
+
     - name: Push to gh-pages
+      if: ${{ github.repository_owner == env.ORG }}
       run: git push;

--- a/.github/workflows/module_integration.yml
+++ b/.github/workflows/module_integration.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
-    
+
       - name: Build NGen
         uses: ./.github/actions/ngen-build
         with:
@@ -96,7 +96,7 @@ jobs:
       #This step should come after ngen build???
       - name: Configure Fortran Compiler
         run: |
-          if [ ${{ runner.os }} == 'macOS' ] 
+          if [ ${{ runner.os }} == 'macOS' ]
           then
             sudo ln -s $(which gfortran-11) $(dirname $(which gfortran-11))/gfortran
             export FC=gfortran-11
@@ -114,16 +114,16 @@ jobs:
           pip install -U setuptools
           pip install -r requirements.txt
           pip install deprecated 'pyarrow==11.0.0' tables geopandas numpy
-          if [ ${{ runner.os }} == 'macOS' ] 
+          if [ ${{ runner.os }} == 'macOS' ]
           then
             export LIBRARY_PATH=/usr/local/lib/gcc/11/
             export LD_LIBRARY_PATH=/usr/local/lib/gcc/11/
           fi
           export NETCDFALTERNATIVE=${NETCDF}/include
           export FC=gfortran
-          export F90=gfortran 
+          export F90=gfortran
           ./compiler.sh no-e
-          
+
           deactivate
 
       - name: Run test

--- a/.github/workflows/ngwpc-cicd.yml
+++ b/.github/workflows/ngwpc-cicd.yml
@@ -15,6 +15,7 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
+  ORG: NGWPC
 
 jobs:
   setup:
@@ -28,6 +29,7 @@ jobs:
       test_image_tag: ${{ steps.vars.outputs.test_image_tag }}
     steps:
       - name: Compute image vars
+        if: ${{ github.repository_owner == env.ORG }}
         id: vars
         shell: bash
         run: |
@@ -59,11 +61,13 @@ jobs:
     needs: setup
     steps:
       - uses: actions/checkout@v4
+        if: ${{ github.repository_owner == env.ORG }}
         with:
           submodules: recursive
           fetch-depth: 0
 
       - name: Verify submodules recursively
+        if: ${{ github.repository_owner == env.ORG }}
         run: |
           echo "Checking all submodules recursively..."
           git submodule update --init --recursive
@@ -77,6 +81,7 @@ jobs:
           '
 
       - name: Log in to registry
+        if: ${{ github.repository_owner == env.ORG }}
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -84,6 +89,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build & push image
+        if: ${{ github.repository_owner == env.ORG }}
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -102,6 +108,7 @@ jobs:
       image: ${{ needs.setup.outputs.image_base }}:${{ needs.setup.outputs.test_image_tag }}
     steps:
       - name: Run unit tests
+        if: ${{ github.repository_owner == env.ORG }}
         run: |
           echo "Running unit tests..."
           cd /ngen-app/ngen/cmake_build
@@ -115,7 +122,7 @@ jobs:
   # SonarQube scan (only runs on internal NGWPC self-hosted runners)
   sonarqube-internal:
     name: sonarqube-internal
-    if: (github.event_name == 'pull_request' || github.event_name == 'push') && github.repository_owner == 'NGWPC'
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
     runs-on: self-hosted
     needs: [setup, build, unit-test]
     #TODO: Configure SonarQube Scans
@@ -125,9 +132,11 @@ jobs:
       options: --entrypoint="" --user 0
     steps:
       - uses: actions/checkout@v4
+        if: ${{ github.repository_owner == env.ORG }}
         with:
           fetch-depth: 0
       - name: SonarQube Scan
+        if: ${{ github.repository_owner == env.ORG }}
         env:
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -147,10 +156,12 @@ jobs:
       security-events: write
     steps:
       - uses: actions/checkout@v4
+        if: ${{ github.repository_owner == env.ORG }}
         with:
           submodules: recursive
           fetch-depth: 0
       - name: Install build dependencies
+        if: ${{ github.repository_owner == env.ORG }}
         run: |
           sudo apt-get update
           sudo apt-get install -y cmake g++ mpi-default-bin libopenmpi-dev libboost-all-dev libudunits2-dev libnetcdf-dev libnetcdf-c++4-dev
@@ -159,11 +170,13 @@ jobs:
         #python3 -m pip install -r extern/t-route/requirements.txt
       # Initialize CodeQL (C++ selected)
       - name: Initialize CodeQL
+        if: ${{ github.repository_owner == env.ORG }}
         uses: github/codeql-action/init@v3
         with:
           languages: cpp
       # Build (replicate your CMake build commands from Dockerfile or local builds)
       - name: Build C++ code
+        if: ${{ github.repository_owner == env.ORG }}
         env:
           PYTHONPATH: ${{ env.PYTHONPATH }}
         run: |
@@ -184,6 +197,7 @@ jobs:
             #-DBOOST_ROOT=/opt/boost
           cmake --build cmake_build --target all
       - name: Perform CodeQL Analysis
+        if: ${{ github.repository_owner == env.ORG }}
         uses: github/codeql-action/analyze@v3
 
   container-scanning:
@@ -193,6 +207,7 @@ jobs:
     needs: [setup, build]
     steps:
       - name: Scan container with Trivy
+        if: ${{ github.repository_owner == env.ORG }}
         uses: aquasecurity/trivy-action@0.20.0
         with:
           image-ref: ${{ needs.setup.outputs.image_base }}:${{ needs.setup.outputs.test_image_tag }}
@@ -201,6 +216,7 @@ jobs:
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'
       - name: Upload Trivy results to GitHub Security tab
+        if: ${{ github.repository_owner == env.ORG }}
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy-results.sarif'
@@ -212,12 +228,14 @@ jobs:
     needs: [setup, build, unit-test, sonarqube-internal, codeql-scan, container-scanning]
     steps:
       - name: Log in to registry
+        if: ${{ github.repository_owner == env.ORG }}
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build latest image
+        if: ${{ github.repository_owner == env.ORG }}
         run: |
           docker pull ${{ needs.setup.outputs.image_base }}:${{ needs.setup.outputs.commit_sha_short }}
           docker tag  ${{ needs.setup.outputs.image_base }}:${{ needs.setup.outputs.commit_sha_short }} ${{ needs.setup.outputs.image_base }}:latest
@@ -230,23 +248,27 @@ jobs:
     needs: setup
     steps:
       - name: Log in to registry
+        if: ${{ github.repository_owner == env.ORG }}
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Check out the release tag
+        if: ${{ github.repository_owner == env.ORG }}
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.release.tag_name }}
           fetch-depth: 0
       - name: Resolve commit sha for the tag
+        if: ${{ github.repository_owner == env.ORG }}
         id: rev
         shell: bash
         run: |
           SHORT_SHA="$(git rev-parse --short=12 HEAD)"
           echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
       - name: Tag image with release tag
+        if: ${{ github.repository_owner == env.ORG }}
         run: |
           docker pull ${{ needs.setup.outputs.image_base }}:${{ steps.rev.outputs.short_sha }}
           docker tag  ${{ needs.setup.outputs.image_base }}:${{ steps.rev.outputs.short_sha }} ${{ needs.setup.outputs.image_base }}:${{ github.event.release.tag_name }}

--- a/.github/workflows/test_and_validate.yml
+++ b/.github/workflows/test_and_validate.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
     - name: Checkout the commit
       uses: actions/checkout@v4
-    
+
     - name: Build Unit Tests
       uses: ./.github/actions/ngen-build
       with:
@@ -50,7 +50,7 @@ jobs:
         export ASAN_OPTIONS=${ASAN_OPTIONS}:detect_container_overflow=0
         ./cmake_build/test/test_geopackage
       timeout-minutes: 15
-    
+
     - name: Clean Up
       uses: ./.github/actions/clean-build
 
@@ -127,7 +127,7 @@ jobs:
 
       #make sure cxx bmi is initialized/ready
       - uses: ./.github/actions/ngen-submod-build
-        with: 
+        with:
           mod-dir: "extern/bmi-cxx/"
 
       - name: Build Unit Tests


### PR DESCRIPTION
Specified the GitHub Organization in our Actions files so that NGWPC pipelines do not run in NOAA-OWP pipelines, and vice versa


## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
