### PR TITLE
Improve unit conversion error logging (NGWPC-7604)

### DIFF
--- a/extern/test_bmi_c/src/bmi_test_bmi_c.c
+++ b/extern/test_bmi_c/src/bmi_test_bmi_c.c
@@ -21,7 +21,7 @@ static const char *output_var_locations[OUTPUT_VAR_NAME_COUNT] = { "node", "node
 // Don't forget to update Get_value/Get_value_at_indices (and setter) implementation if these are adjusted
 static const char *input_var_names[INPUT_VAR_NAME_COUNT] = { "INPUT_VAR_1", "INPUT_VAR_2" };
 static const char *input_var_types[INPUT_VAR_NAME_COUNT] = { "double", "double" };
-static const char *input_var_units[INPUT_VAR_NAME_COUNT] = {  "m", "m/s" };
+static const char *input_var_units[INPUT_VAR_NAME_COUNT] = {  "m", "Pa" };
 static const int input_var_item_count[INPUT_VAR_NAME_COUNT] = { 1, 1 };
 static const char *input_var_grids[INPUT_VAR_NAME_COUNT] = { 0, 0 };
 static const char *input_var_locations[INPUT_VAR_NAME_COUNT] = { "node", "node" };

--- a/extern/test_bmi_cpp/include/test_bmi_cpp.hpp
+++ b/extern/test_bmi_cpp/include/test_bmi_cpp.hpp
@@ -172,8 +172,8 @@ class TestBmiCpp : public bmi::Bmi {
         std::vector<std::string> input_var_types = { "double", "double" };
         std::vector<std::string> output_var_types = { "double", "double" };
         std::vector<std::string> model_var_types = {};
-        std::vector<std::string> input_var_units = { "m", "m" };
-        std::vector<std::string> output_var_units = { "m", "m/s", "m", "m" };
+        std::vector<std::string> input_var_units = { "mm/s", "Pa" };
+        std::vector<std::string> output_var_units = { "mm/s", "m/s", "m", "m" };
         std::vector<std::string> model_var_units = {};
         std::vector<std::string> input_var_locations = { "node", "node" };
         std::vector<std::string> output_var_locations = { "node", "node" };

--- a/extern/test_bmi_fortran/src/bmi_test_bmi_fortran.f90
+++ b/extern/test_bmi_fortran/src/bmi_test_bmi_fortran.f90
@@ -123,10 +123,10 @@ module bmitestbmi
   integer :: input_grid(4) = [0, 0, 0, 1]
 
   character (len=BMI_MAX_UNITS_NAME) :: &
-    output_units(6) = [character(BMI_MAX_UNITS_NAME):: 'm', 'm', 's', 'm', 'm', 'm']
+    output_units(6) = [character(BMI_MAX_UNITS_NAME):: 'mm s^-1', 'm', 's', 'm', 'm', 'm']
 
   character (len=BMI_MAX_UNITS_NAME) :: &
-    input_units(4) = [character(BMI_MAX_UNITS_NAME):: 'm', 'm', 's', 'm']
+    input_units(4) = [character(BMI_MAX_UNITS_NAME):: 'mm s^-1', 'Pa', 'K', 'mm s^-1']
 
   character (len=BMI_MAX_LOCATION_NAME) :: &
     output_location(6) = [character(BMI_MAX_LOCATION_NAME):: 'node', 'node', 'node', 'node', 'node', 'node']

--- a/extern/test_bmi_py/bmi_model.py
+++ b/extern/test_bmi_py/bmi_model.py
@@ -73,12 +73,12 @@ class bmi_model(Bmi):
     #     since the input variable names could come from any forcing...
     #------------------------------------------------------
     #_var_name_map_long_first = {
-    _var_name_units_map = {'INPUT_VAR_1':['INPUT_VAR_1','-'],
-                           'INPUT_VAR_2':['INPUT_VAR_2','-'],
-                           'OUTPUT_VAR_1':['OUTPUT_VAR_1','-'],
-                           'OUTPUT_VAR_2':['OUTPUT_VAR_2','-'],
+    _var_name_units_map = {'INPUT_VAR_1':['INPUT_VAR_1','mm/s'],
+                           'INPUT_VAR_2':['INPUT_VAR_2','Pa'],
+                           'OUTPUT_VAR_1':['OUTPUT_VAR_1','m'],
+                           'OUTPUT_VAR_2':['OUTPUT_VAR_2','mm/s'],
                            'OUTPUT_VAR_3':['OUTPUT_VAR_3','-'],
-                           'GRID_VAR_1':['OUTPUT_VAR_1','-'],
+                           'GRID_VAR_1':['OUTPUT_VAR_1','mm/s'],
                            'GRID_VAR_2':['GRID_VAR_2','-'],
                             }
 

--- a/include/forcing/CsvPerFeatureForcingProvider.hpp
+++ b/include/forcing/CsvPerFeatureForcingProvider.hpp
@@ -341,12 +341,16 @@ class CsvPerFeatureForcingProvider : public data_access::GenericDataProvider
                     }
                 }
 
+                LOG("CsvProvider has variable '" + var_name + "' with units '" + units + "'", LogLevel::DEBUG);
+
                 auto wkf = data_access::WellKnownFields.find(var_name);
                 if(wkf != data_access::WellKnownFields.end()){
                     units = units.empty() ? std::get<1>(wkf->second) : units;
+                    auto wkf_name = std::get<0>(wkf->second);
+                    LOG("CsvProvider has well-known name '" + wkf_name + "' for variable '" + var_name + "' with units '" + units + "'", LogLevel::DEBUG);
                     available_forcings.push_back(var_name); // Allow lookup by non-canonical name
                     available_forcings_units[var_name] = units; // Allow lookup of units by non-canonical name
-                    var_name = std::get<0>(wkf->second); // Use the CSDMS name from here on
+                    var_name = wkf_name; // Use the CSDMS name from here on
                 }
 
                 forcing_vectors[var_name] = {};

--- a/include/forcing/CsvPerFeatureForcingProvider.hpp
+++ b/include/forcing/CsvPerFeatureForcingProvider.hpp
@@ -170,13 +170,12 @@ class CsvPerFeatureForcingProvider : public data_access::GenericDataProvider
         try {
             return UnitsHelper::get_converted_value(available_forcings_units[output_name], value, output_units);
         }
-        catch (const std::runtime_error& e){
-            #ifndef UDUNITS_QUIET
-            std::stringstream ss;
-            ss <<"WARN: Unit conversion unsuccessful - Returning unconverted value! (\""<<e.what()<<"\")"<<std::endl;
-            LOG(ss.str(), LogLevel::SEVERE); ss.str("");
-            #endif
-            return value;
+        catch (const std::runtime_error& e) {
+            data_access::unit_conversion_exception uce(e.what());
+            uce.provider_model_name = "CsvPerFeatureProvider" + catchment_id;
+            uce.provider_bmi_var_name = output_name;
+            uce.unconverted_values.push_back(value);
+            throw uce;
         }
     }
 

--- a/include/forcing/CsvPerFeatureForcingProvider.hpp
+++ b/include/forcing/CsvPerFeatureForcingProvider.hpp
@@ -172,7 +172,7 @@ class CsvPerFeatureForcingProvider : public data_access::GenericDataProvider
         }
         catch (const std::runtime_error& e) {
             data_access::unit_conversion_exception uce(e.what());
-            uce.provider_model_name = "CsvPerFeatureProvider" + catchment_id;
+            uce.provider_model_name = "CsvPerFeatureProvider " + catchment_id;
             uce.provider_bmi_var_name = output_name;
             uce.provider_units = available_forcings_units[output_name];
             uce.unconverted_values.push_back(value);

--- a/include/forcing/CsvPerFeatureForcingProvider.hpp
+++ b/include/forcing/CsvPerFeatureForcingProvider.hpp
@@ -172,7 +172,7 @@ class CsvPerFeatureForcingProvider : public data_access::GenericDataProvider
         }
         catch (const std::runtime_error& e) {
             data_access::unit_conversion_exception uce(e.what());
-            uce.provider_model_name = "CsvPerFeatureProvider " + catchment_id;
+            uce.provider_model_name = "CsvPerFeatureProvider " + std::to_string(catchment_id);
             uce.provider_bmi_var_name = output_name;
             uce.provider_units = available_forcings_units[output_name];
             uce.unconverted_values.push_back(value);

--- a/include/forcing/CsvPerFeatureForcingProvider.hpp
+++ b/include/forcing/CsvPerFeatureForcingProvider.hpp
@@ -174,6 +174,7 @@ class CsvPerFeatureForcingProvider : public data_access::GenericDataProvider
             data_access::unit_conversion_exception uce(e.what());
             uce.provider_model_name = "CsvPerFeatureProvider" + catchment_id;
             uce.provider_bmi_var_name = output_name;
+            uce.provider_units = available_forcings_units[output_name];
             uce.unconverted_values.push_back(value);
             throw uce;
         }

--- a/include/forcing/DataProvider.hpp
+++ b/include/forcing/DataProvider.hpp
@@ -3,6 +3,8 @@
 
 #include <string>
 #include <vector>
+#include <set>
+#include <tuple>
 #include <boost/core/span.hpp>
 
 namespace data_access
@@ -101,6 +103,32 @@ namespace data_access
         private:
     };
 
+    struct unit_error_log_key {
+        std::string requester_name;
+        std::string requester_variable;
+        std::string provider_name;
+        std::string provider_variable;
+        std::string failure_message;
+
+        bool operator<(unit_error_log_key const& rhs) const {
+            return std::tie(requester_name, requester_variable, provider_name, provider_variable, failure_message)
+                 < std::tie(rhs.requester_name, rhs.requester_variable, rhs.provider_name, rhs.provider_variable, rhs.failure_message);
+        }
+
+        bool operator==(unit_error_log_key const& rhs) const {
+            return std::tie(requester_name, requester_variable, provider_name, provider_variable, failure_message)
+                == std::tie(rhs.requester_name, rhs.requester_variable, rhs.provider_name, rhs.provider_variable, rhs.failure_message);
+        }
+    };
+
+    extern std::set<unit_error_log_key> unit_errors_reported;
+
+    struct unit_conversion_exception : public std::runtime_error {
+        unit_conversion_exception(std::string message) : std::runtime_error(message) {}
+        std::string provider_model_name;
+        std::string provider_bmi_var_name;
+        std::vector<double> unconverted_values;
+    };
 }
 
 

--- a/include/forcing/DataProvider.hpp
+++ b/include/forcing/DataProvider.hpp
@@ -127,6 +127,7 @@ namespace data_access
         unit_conversion_exception(std::string message) : std::runtime_error(message) {}
         std::string provider_model_name;
         std::string provider_bmi_var_name;
+        std::string provider_units;
         std::vector<double> unconverted_values;
     };
 }

--- a/include/realizations/catchment/Bmi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Formulation.hpp
@@ -264,6 +264,33 @@ namespace realization {
             output_variable_names = out_var_names;
         }
 
+        struct unit_error_log_key {
+            std::string requester_name;
+            std::string requester_variable;
+            std::string provider_name;
+            std::string provider_variable;
+            std::string failure_message;
+
+            bool operator<(unit_error_log_key const& rhs) const {
+                return std::tie(requester_name, requester_variable, provider_name, provider_variable, failure_message)
+                    < std::tie(rhs.requester_name, rhs.requester_variable, rhs.provider_name, rhs.provider_variable, rhs.failure_message);
+            }
+
+            bool operator==(unit_error_log_key const& rhs) const {
+                return std::tie(requester_name, requester_variable, provider_name, provider_variable, failure_message)
+                    == std::tie(rhs.requester_name, rhs.requester_variable, rhs.provider_name, rhs.provider_variable, rhs.failure_message);
+            }
+        };
+
+        static std::set<unit_error_log_key> unit_errors_reported;
+
+        struct unit_conversion_exception : public std::runtime_error {
+            unit_conversion_exception(std::string message) : std::runtime_error(message) {}
+            std::string provider_model_name;
+            std::string provider_bmi_var_name;
+            std::vector<double> unconverted_values;
+        };
+
     private:
 
         std::string bmi_main_output_var;

--- a/include/realizations/catchment/Bmi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Formulation.hpp
@@ -264,33 +264,6 @@ namespace realization {
             output_variable_names = out_var_names;
         }
 
-        struct unit_error_log_key {
-            std::string requester_name;
-            std::string requester_variable;
-            std::string provider_name;
-            std::string provider_variable;
-            std::string failure_message;
-
-            bool operator<(unit_error_log_key const& rhs) const {
-                return std::tie(requester_name, requester_variable, provider_name, provider_variable, failure_message)
-                    < std::tie(rhs.requester_name, rhs.requester_variable, rhs.provider_name, rhs.provider_variable, rhs.failure_message);
-            }
-
-            bool operator==(unit_error_log_key const& rhs) const {
-                return std::tie(requester_name, requester_variable, provider_name, provider_variable, failure_message)
-                    == std::tie(rhs.requester_name, rhs.requester_variable, rhs.provider_name, rhs.provider_variable, rhs.failure_message);
-            }
-        };
-
-        static std::set<unit_error_log_key> unit_errors_reported;
-
-        struct unit_conversion_exception : public std::runtime_error {
-            unit_conversion_exception(std::string message) : std::runtime_error(message) {}
-            std::string provider_model_name;
-            std::string provider_bmi_var_name;
-            std::vector<double> unconverted_values;
-        };
-
     private:
 
         std::string bmi_main_output_var;

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -486,8 +486,26 @@ namespace realization {
         /** A configured mapping of BMI model variable names to standard names for use inside the framework. */
         std::map<std::string, std::string> bmi_var_names_map;
         bool model_initialized = false;
-        bool unitGetValueErrLogged = false;
-        bool unitGetValuesErrLogged = false;
+
+        struct unit_error_log_key {
+            std::string requester_name;
+            std::string requester_variable;
+            std::string provider_name;
+            std::string provider_variable;
+            std::string failure_message;
+
+            bool operator<(unit_error_log_key const& rhs) const {
+                return std::tie(requester_name, requester_variable, provider_name, provider_variable, failure_message)
+                    < std::tie(rhs.requester_name, rhs.requester_variable, rhs.provider_name, rhs.provider_variable, rhs.failure_message);
+            }
+
+            bool operator==(unit_error_log_key const& rhs) const {
+                return std::tie(requester_name, requester_variable, provider_name, provider_variable, failure_message)
+                    == std::tie(rhs.requester_name, rhs.requester_variable, rhs.provider_name, rhs.provider_variable, rhs.failure_message);
+            }
+        };
+
+        static std::set<unit_error_log_key> unit_errors_reported;
 
         std::vector<std::string> OPTIONAL_PARAMETERS = {
                 BMI_REALIZATION_CFG_PARAM_OPT__USES_FORCINGS

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -487,26 +487,6 @@ namespace realization {
         std::map<std::string, std::string> bmi_var_names_map;
         bool model_initialized = false;
 
-        struct unit_error_log_key {
-            std::string requester_name;
-            std::string requester_variable;
-            std::string provider_name;
-            std::string provider_variable;
-            std::string failure_message;
-
-            bool operator<(unit_error_log_key const& rhs) const {
-                return std::tie(requester_name, requester_variable, provider_name, provider_variable, failure_message)
-                    < std::tie(rhs.requester_name, rhs.requester_variable, rhs.provider_name, rhs.provider_variable, rhs.failure_message);
-            }
-
-            bool operator==(unit_error_log_key const& rhs) const {
-                return std::tie(requester_name, requester_variable, provider_name, provider_variable, failure_message)
-                    == std::tie(rhs.requester_name, rhs.requester_variable, rhs.provider_name, rhs.provider_variable, rhs.failure_message);
-            }
-        };
-
-        static std::set<unit_error_log_key> unit_errors_reported;
-
         std::vector<std::string> OPTIONAL_PARAMETERS = {
                 BMI_REALIZATION_CFG_PARAM_OPT__USES_FORCINGS
                 BMI_REALIZATION_CFG_PARAM_OPT__FORCING_FILE,

--- a/include/realizations/catchment/Bmi_Multi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Multi_Formulation.hpp
@@ -583,6 +583,10 @@ namespace realization {
                 //TODO: After merge PR#405, try re-adding support for index
                 return nested_module->get_value(selector);
             }
+            catch (unit_conversion_exception &uce) {
+                // We asked for it as a dimensionless quantity, "1", just above
+                return uce.unconverted_values[0];
+            }
             // If there was any problem with the cast and extraction of the value, throw runtime error
             catch (std::exception &e) {
                 std::string throw_msg; throw_msg.assign("Multi BMI formulation can't use associated data provider as a nested module"

--- a/include/realizations/catchment/Bmi_Multi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Multi_Formulation.hpp
@@ -583,7 +583,7 @@ namespace realization {
                 //TODO: After merge PR#405, try re-adding support for index
                 return nested_module->get_value(selector);
             }
-            catch (unit_conversion_exception &uce) {
+            catch (data_access::unit_conversion_exception &uce) {
                 // We asked for it as a dimensionless quantity, "1", just above
                 return uce.unconverted_values[0];
             }

--- a/include/realizations/catchment/Bmi_Multi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Multi_Formulation.hpp
@@ -585,6 +585,11 @@ namespace realization {
             }
             catch (data_access::unit_conversion_exception &uce) {
                 // We asked for it as a dimensionless quantity, "1", just above
+                static bool no_conversion_message_logged = false;
+                if (!no_conversion_message_logged) {
+                    no_conversion_message_logged = true;
+                    LOG("Emitting output variables from Bmi_Multi_Formulation without unit conversion - see NGWPC-7604", LogLevel::WARNING);
+                }
                 return uce.unconverted_values[0];
             }
             // If there was any problem with the cast and extraction of the value, throw runtime error

--- a/src/forcing/NetCDFPerFeatureDataProvider.cpp
+++ b/src/forcing/NetCDFPerFeatureDataProvider.cpp
@@ -419,14 +419,12 @@ double NetCDFPerFeatureDataProvider::get_value(const CatchmentAggrDataSelector& 
     }
     catch (const std::runtime_error& e)
     {
-        //minor change to aid debugging (log_stream is an output log stream for messages from the underlying library, therefore logging to both EWTS and library logger) 
-        netcdf_ss << "NetCDFPerFeatureDataProvider: get_converted_value Unit conversion unsuccessful - Returning unconverted value! (" << e.what() << ")" << std::endl;
-        log_stream << netcdf_ss.str();
-        LOG(netcdf_ss.str(), LogLevel::WARNING); netcdf_ss.str("");
-        netcdf_ss << "=== Exiting get_value function ===" << std::endl;
-        log_stream << netcdf_ss.str();
-        LOG(netcdf_ss.str(), LogLevel::WARNING); netcdf_ss.str("");
-        return rvalue;
+        data_access::unit_conversion_exception uce(e.what());
+        uce.provider_model_name = "NetCDFPerFeatureDataProvider " + catchment_id;
+        uce.provider_bmi_var_name = selector.get_variable_name();
+        uce.provider_units = native_units;
+        uce.unconverted_values.push_back(rvalue);
+        throw uce;
     }
 
     return rvalue;

--- a/src/realizations/catchment/Bmi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Formulation.cpp
@@ -18,3 +18,7 @@ namespace realization
                 BMI_REALIZATION_CFG_PARAM_REQ__MODEL_TYPE,
         };
 }
+
+namespace data_access {
+    std::set<unit_error_log_key> unit_errors_reported;
+}

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -134,13 +134,6 @@ namespace realization {
             throw std::runtime_error("Bmi_Singular_Formulation does not yet implement get_ts_index_for_time");
         }
 
-        struct unit_conversion_exception : public std::runtime_error {
-            unit_conversion_exception(std::string message) : std::runtime_error(message) {}
-            std::string provider_model_name;
-            std::string provider_bmi_var_name;
-            std::vector<double> unconverted_values;
-        };
-
         std::vector<double> Bmi_Module_Formulation::get_values(const CatchmentAggrDataSelector& selector, data_access::ReSampleMethod m)
         {
             std::string output_name = selector.get_variable_name();
@@ -739,8 +732,6 @@ namespace realization {
                 get_bmi_model()->SetValue(var_name, value_ptr.get());
             }
         }
-
-        std::set<Bmi_Module_Formulation::unit_error_log_key> Bmi_Module_Formulation::unit_errors_reported = {};
 
         void Bmi_Module_Formulation::append_model_inputs_to_stream(const double &model_init_time, time_step_t t_delta, std::stringstream &inputs) {
             std::vector<std::string> in_var_names = get_bmi_model()->GetInputVarNames();

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -178,6 +178,7 @@ namespace realization {
                     data_access::unit_conversion_exception uce(e.what());
                     uce.provider_model_name = get_bmi_model()->get_model_name();
                     uce.provider_bmi_var_name = bmi_var_name;
+                    uce.provider_units = native_units;
                     uce.unconverted_values = std::move(values);
                     throw uce;
                 }
@@ -225,6 +226,7 @@ namespace realization {
                     data_access::unit_conversion_exception uce(e.what());
                     uce.provider_model_name = get_bmi_model()->get_model_name();
                     uce.provider_bmi_var_name = bmi_var_name;
+                    uce.provider_units = native_units;
                     uce.unconverted_values.push_back(value);
                     throw uce;
                 }
@@ -720,9 +722,11 @@ namespace realization {
                         if (new_error) {
                             std::stringstream ss;
                             ss << "Unit conversion failure:"
-                               << " requester '" << get_bmi_model()->get_model_name() << "' catchment '" << get_catchment_id() << "' variable '" << var_map_alias << "'"
-                               << " provider '" << uce.provider_model_name << "' source variable '" << uce.provider_bmi_var_name << "'"
-                               << " raw value " << uce.unconverted_values[0]
+                               << " requester {'" << get_bmi_model()->get_model_name() << "' catchment '" << get_catchment_id()
+                               << "' variable '" << var_name << "'" << " (alias '" << var_map_alias << "')"
+                               << " units '" << get_bmi_model()->GetVarUnits(var_name) << "'}"
+                               << " provider {'" << uce.provider_model_name << "' source variable '" << uce.provider_bmi_var_name << "'"
+                               << " raw value " << uce.unconverted_values[0] << "}"
                                << " message \"" << uce.what() << "\"";
                             LOG(ss.str(), LogLevel::WARNING); ss.str("");
                         }

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -223,7 +223,7 @@ namespace realization {
                 }
                 catch (const std::runtime_error& e){
                     data_access::unit_conversion_exception uce(e.what());
-                    uce.provider_model_name = get_id();
+                    uce.provider_model_name = get_bmi_model()->get_model_name();
                     uce.provider_bmi_var_name = bmi_var_name;
                     uce.unconverted_values.push_back(value);
                     throw uce;

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -737,6 +737,7 @@ namespace realization {
             }
         }
 
+
         void Bmi_Module_Formulation::append_model_inputs_to_stream(const double &model_init_time, time_step_t t_delta, std::stringstream &inputs) {
             std::vector<std::string> in_var_names = get_bmi_model()->GetInputVarNames();
             time_t model_epoch_time = convert_model_time(model_init_time) + get_bmi_model_start_time_forcing_offset_s();

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -183,7 +183,7 @@ namespace realization {
                 }
                 catch (const std::runtime_error& e) {
                     unit_conversion_exception uce(e.what());
-                    uce.provider_model_name = get_id();
+                    uce.provider_model_name = get_bmi_model()->get_model_name();
                     uce.provider_bmi_var_name = bmi_var_name;
                     uce.unconverted_values = std::move(values);
                     throw uce;
@@ -727,7 +727,7 @@ namespace realization {
                         if (new_error) {
                             std::stringstream ss;
                             ss << "Unit conversion failure:"
-                               << " requester '" << get_id() << "' catchment '" << get_catchment_id() << "' variable '" << var_map_alias << "'"
+                               << " requester '" << get_bmi_model()->get_model_name() << "' catchment '" << get_catchment_id() << "' variable '" << var_map_alias << "'"
                                << " provider '" << uce.provider_model_name << "' source variable '" << uce.provider_bmi_var_name << "'"
                                << " raw value " << uce.unconverted_values[0]
                                << " message \"" << uce.what() << "\"";

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -175,7 +175,7 @@ namespace realization {
                     return values;
                 }
                 catch (const std::runtime_error& e) {
-                    unit_conversion_exception uce(e.what());
+                    data_access::unit_conversion_exception uce(e.what());
                     uce.provider_model_name = get_bmi_model()->get_model_name();
                     uce.provider_bmi_var_name = bmi_var_name;
                     uce.unconverted_values = std::move(values);
@@ -222,7 +222,7 @@ namespace realization {
                     return UnitsHelper::get_converted_value(native_units, value, output_units);
                 }
                 catch (const std::runtime_error& e){
-                    unit_conversion_exception uce(e.what());
+                    data_access::unit_conversion_exception uce(e.what());
                     uce.provider_model_name = get_id();
                     uce.provider_bmi_var_name = bmi_var_name;
                     uce.unconverted_values.push_back(value);
@@ -713,9 +713,9 @@ namespace realization {
                         double value = provider->get_value(CatchmentAggrDataSelector(this->get_catchment_id(),var_map_alias, model_epoch_time, t_delta,
                                                                                      get_bmi_model()->GetVarUnits(var_name)));
                         value_ptr = get_value_as_type(type, value);
-                    } catch (unit_conversion_exception &uce) {
-                        unit_error_log_key key{get_id(), var_map_alias, uce.provider_model_name, uce.provider_bmi_var_name, uce.what()};
-                        auto ret = unit_errors_reported.insert(key);
+                    } catch (data_access::unit_conversion_exception &uce) {
+                        data_access::unit_error_log_key key{get_id(), var_map_alias, uce.provider_model_name, uce.provider_bmi_var_name, uce.what()};
+                        auto ret = data_access::unit_errors_reported.insert(key);
                         bool new_error = ret.second;
                         if (new_error) {
                             std::stringstream ss;

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -25,8 +25,14 @@ namespace realization {
             if (timestep != (next_time_step_index - 1)) {
                 throw std::invalid_argument("Only current time step valid when getting output for BMI C++ formulation");
             }
-            std::string output_str;
 
+            static bool no_conversion_message_logged = false;
+            if (!no_conversion_message_logged) {
+                no_conversion_message_logged = true;
+                LOG("Emitting output variables from Bmi_Module_Formulation without unit conversion - see NGWPC-7604", LogLevel::WARNING);
+            }
+
+            std::string output_str;
             for (const std::string& name : get_output_variable_names()) {
                 output_str += (output_str.empty() ? "" : ",") + std::to_string(get_var_value_as_double(0, name));
             }

--- a/test/bmi/Bmi_Cpp_Adapter_Test.cpp
+++ b/test/bmi/Bmi_Cpp_Adapter_Test.cpp
@@ -51,7 +51,7 @@ protected:
     std::vector<std::string> expected_output_var_names = { "OUTPUT_VAR_1", "OUTPUT_VAR_2" };
     std::vector<std::string> expected_output_var_locations = { "node", "node" };
     std::vector<int> expected_output_var_grids = { 0, 0 };
-    std::vector<std::string> expected_output_var_units = { "m", "m" };
+    std::vector<std::string> expected_output_var_units = { "mm/s", "m" };
     std::vector<std::string> expected_output_var_types = { "double", "double" };
     int expected_grid_rank = 1;
     int expected_grid_size = 1;

--- a/test/bmi/Bmi_Fortran_Adapter_Test.cpp
+++ b/test/bmi/Bmi_Fortran_Adapter_Test.cpp
@@ -52,7 +52,7 @@ protected:
     std::vector<std::string> expected_output_var_locations = { "node", "node", "node", "node", "node"};
     std::vector<int> expected_output_var_grids = { 0, 0, 0, 1, 2, 2 };
     std::vector<int> expected_input_var_grids = { 0, 0, 0, 1 };
-    std::vector<std::string> expected_output_var_units = { "m", "m", "s", "m", "m", "m" };
+    std::vector<std::string> expected_output_var_units = { "mm s^-1", "m", "s", "m", "m", "m" };
     std::vector<std::string> expected_output_var_types = { "double precision", "real", "integer", "double precision", "double precision", "double precision" };
     std::vector<int> expected_output_var_item_sizes = { 8, 4, 4, 8, 8, 8};
     std::vector<std::string> expected_input_var_types = { "double precision", "real", "integer", "double precision" };

--- a/test/forcing/CsvPerFeatureForcingProvider_Test.cpp
+++ b/test/forcing/CsvPerFeatureForcingProvider_Test.cpp
@@ -94,24 +94,24 @@ TEST_F(CsvPerFeatureForcingProviderTest, TestForcingDataRead)
     time_t t = begin+(i*3600);
     std::cerr << std::ctime(&t) << std::endl;
 
-    current_precipitation = Forcing_Object->get_value(CatchmentAggrDataSelector("", CSDMS_STD_NAME_LIQUID_EQ_PRECIP_RATE, begin+(i*3600), 3600, ""), data_access::SUM);
+    current_precipitation = Forcing_Object->get_value(CatchmentAggrDataSelector("", CSDMS_STD_NAME_LIQUID_EQ_PRECIP_RATE, begin+(i*3600), 3600, "mm/s"), data_access::SUM);
 
     EXPECT_NEAR(current_precipitation, 7.9999999999999996e-07, 0.00000005);
 
-    double temp_k = Forcing_Object->get_value(CatchmentAggrDataSelector("", CSDMS_STD_NAME_SURFACE_TEMP, begin+(i*3600), 3600, ""), data_access::MEAN);
+    double temp_k = Forcing_Object->get_value(CatchmentAggrDataSelector("", CSDMS_STD_NAME_SURFACE_TEMP, begin+(i*3600), 3600, "K"), data_access::MEAN);
 
     EXPECT_NEAR(temp_k, 286.9, 0.00001);
 
     int current_epoch;
 
     i = 387;
-    current_precipitation = Forcing_Object->get_value(CatchmentAggrDataSelector("", CSDMS_STD_NAME_LIQUID_EQ_PRECIP_RATE, begin+(i*3600), 3600, ""), data_access::SUM);
+    current_precipitation = Forcing_Object->get_value(CatchmentAggrDataSelector("", CSDMS_STD_NAME_LIQUID_EQ_PRECIP_RATE, begin+(i*3600), 3600, "mm/s"), data_access::SUM);
 
     EXPECT_NEAR(current_precipitation, 6.9999999999999996e-07, 0.00000005);
 
     //Check exceeding the forcing range to retrieve the last forcing precipation rate
     i = 388;
-    current_precipitation = Forcing_Object->get_value(CatchmentAggrDataSelector("", CSDMS_STD_NAME_LIQUID_EQ_PRECIP_RATE, begin+(i*3600), 3600, ""), data_access::SUM);
+    current_precipitation = Forcing_Object->get_value(CatchmentAggrDataSelector("", CSDMS_STD_NAME_LIQUID_EQ_PRECIP_RATE, begin+(i*3600), 3600, "mm/s"), data_access::SUM);
 
     EXPECT_NEAR(current_precipitation, 6.9999999999999996e-07, 0.00000005);
 }
@@ -127,18 +127,18 @@ TEST_F(CsvPerFeatureForcingProviderTest, TestForcingDataReadAltFormat)
     time_t t = begin+(i*3600);
     std::cerr << std::ctime(&t) << std::endl;
 
-    current_precipitation = Forcing_Object_2->get_value(CatchmentAggrDataSelector("", CSDMS_STD_NAME_LIQUID_EQ_PRECIP_RATE, begin+(i*3600), 3600, ""), data_access::SUM);
+    current_precipitation = Forcing_Object_2->get_value(CatchmentAggrDataSelector("", CSDMS_STD_NAME_LIQUID_EQ_PRECIP_RATE, begin+(i*3600), 3600, "mm/s"), data_access::SUM);
 
     EXPECT_NEAR(current_precipitation, 0.00032685, 0.00000001);
 
-    double temp_k = Forcing_Object_2->get_value(CatchmentAggrDataSelector("", CSDMS_STD_NAME_SURFACE_TEMP, begin+(i*3600), 3600, ""), data_access::MEAN);
+    double temp_k = Forcing_Object_2->get_value(CatchmentAggrDataSelector("", CSDMS_STD_NAME_SURFACE_TEMP, begin+(i*3600), 3600, "K"), data_access::MEAN);
 
     EXPECT_NEAR(temp_k, 265.77, 0.00001);
 
     int current_epoch;
 
     i = 34;
-    current_precipitation = Forcing_Object_2->get_value(CatchmentAggrDataSelector("", CSDMS_STD_NAME_LIQUID_EQ_PRECIP_RATE, begin+(i*3600), 3600, ""), data_access::SUM);
+    current_precipitation = Forcing_Object_2->get_value(CatchmentAggrDataSelector("", CSDMS_STD_NAME_LIQUID_EQ_PRECIP_RATE, begin+(i*3600), 3600, "mm/s"), data_access::SUM);
 
     EXPECT_NEAR(current_precipitation, 0.00013539, 0.00000001);
 
@@ -156,7 +156,7 @@ TEST_F(CsvPerFeatureForcingProviderTest, TestForcingDataUnitConversion)
     time_t t = begin+(i*3600);
     std::cerr << std::ctime(&t) << std::endl;
 
-    current_precipitation = Forcing_Object->get_value(CatchmentAggrDataSelector("", CSDMS_STD_NAME_LIQUID_EQ_PRECIP_RATE, begin+(i*3600), 3600, ""), data_access::SUM);
+    current_precipitation = Forcing_Object->get_value(CatchmentAggrDataSelector("", CSDMS_STD_NAME_LIQUID_EQ_PRECIP_RATE, begin+(i*3600), 3600, "mm/s"), data_access::SUM);
 
     EXPECT_NEAR(current_precipitation, 7.9999999999999996e-07, 0.00000005);
 
@@ -188,9 +188,14 @@ TEST_F(CsvPerFeatureForcingProviderTest, TestForcingUnitHeaderParsing)
         {"U2D", "m s-1", "cm s-1"},
         {"V2D", "m/s", "cm s-1"},
         {"TEST", "kg", "g"},
+        // Disable the cases where units won't be parsed and
+        // conversion was previously not expected. The non-conversion
+        // is now being treated as an error, per NGWPC-7604
+#if 0
         {"PSFC[Pa)", "Pa", "bar"},
         {"SWDOWN(W m-2]", "W m-2", "langley"},
         {"LWDOWN [alt]", "W m-2", "langley"}
+#endif
     };
 
     for (auto ite = expected.begin(); ite != expected.end(); ite++) {


### PR DESCRIPTION
When there are failures to convert units between data providers and BMI model consumers, we want to be able to track down the issue quickly and efficiently. We also don't want to be flooded with repetitive warnings about the same failed conversion.

## Additions

- Exception type representing the provider's failure to perform a requested conversion
- Set of conversion failures seen previously, specific to the pair of formulations, variables, and units involved

## Changes

- Catch conversion failures in `Bmi_Module_Formulation::get_value[s]()` et al., add information, and rethrow rather than logging here
- Catch the enriched exception in `Bmi_Module_Formulation::set_model_inputs_prior_to_update()`, check whether that variety of failure has already been reported, and log if it has not.

## Removals

- Logging in `get_value` which is now redundant with logging in the caller
- Non-specific conversion failure logging flags

## Todos

- Currently unused `get_values()` call path isn't modified

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
