### PR TITLE
Convert cout and asserts to EWTS log messages

### DIFF
--- a/include/realizations/catchment/Catchment_Formulation.hpp
+++ b/include/realizations/catchment/Catchment_Formulation.hpp
@@ -7,6 +7,8 @@
 #include <HY_CatchmentArea.hpp>
 #include "GenericDataProvider.hpp"
 
+#include "Logger.hpp"
+
 #define DEFAULT_FORMULATION_OUTPUT_DELIMITER ","
 
 namespace realization {
@@ -42,16 +44,23 @@ namespace realization {
          */
         static void config_pattern_substitution(geojson::PropertyMap &properties, const std::string &key,
                                                 const std::string &pattern, const std::string &replacement) {
+            std::stringstream ss;
             auto it = properties.find(key);
             // Do nothing and return if either the key isn't found or the associated property isn't a string
             if (it == properties.end() || it->second.get_type() != geojson::PropertyType::String) {
-                std::cout << "[DEBUG] Skipping pattern substitution for key: " << key << " (not found or not a string)" << std::endl;
+                ss.str("");
+                ss << "Skipping pattern substitution for key: " << key << " (not found or not a string)" << std::endl;
+                LOG(ss.str(), LogLevel::DEBUG);
                 return;
             }
 
             std::string value = it->second.as_string();
-            std::cout << "[DEBUG] config_pattern_substitution Performing pattern substitution for key: " << key << ", pattern: " << pattern << ", replacement: " << replacement << std::endl;
-//            std::cout << "[DEBUG] Original value: " << value << std::endl;
+            ss.str("");
+            ss << "config_pattern_substitution Performing pattern substitution for key: " << key << ", pattern: " << pattern << ", replacement: " << replacement << std::endl;
+            LOG(ss.str(), LogLevel::DEBUG);
+//            ss.str("");
+//            ss << "Original value: " << value << std::endl;
+//            LOG(ss.str(), LogLevel::DEBUG);
 
             size_t id_index = value.find(pattern);
             while (id_index != std::string::npos) {
@@ -63,7 +72,9 @@ namespace realization {
             properties.erase(key);
             properties.emplace(key, geojson::JSONProperty(key, value));
 
-//            std::cout << "[DEBUG] Substitution result for key: " << key << " -> " << value << std::endl;
+//            ss.str("");
+//            ss << "Substitution result for key: " << key << " -> " << value << std::endl;
+//            LOG(ss.str(), LogLevel::DEBUG);
         }
 
             /**

--- a/include/realizations/catchment/Formulation_Constructors.hpp
+++ b/include/realizations/catchment/Formulation_Constructors.hpp
@@ -44,6 +44,8 @@ namespace realization {
     ) {
         constructor formulation_constructor = formulations.at(formulation_type);
         std::shared_ptr<data_access::GenericDataProvider> fp;
+        std::stringstream ss; 
+
         if (forcing_config.provider == "CsvPerFeature" || forcing_config.provider == ""){
             fp = std::make_shared<CsvPerFeatureForcingProvider>(forcing_config);
         }
@@ -57,8 +59,11 @@ namespace realization {
         }
 #if NGEN_WITH_PYTHON
         else if (forcing_config.provider == "ForcingsEngineLumpedDataProvider") {
-            std::cout << "[ngen debug] Using ForcingsEngineLumpedDataProvider for '" << identifier
-                      << "' with init_config = " << forcing_config.init_config << std::endl;
+
+            ss.str(""); 
+            ss << "Using ForcingsEngineLumpedDataProvider for '" << identifier
+               << "' with init_config = " << forcing_config.init_config << std::endl;
+            LOG(ss.str(), LogLevel::DEBUG);
 
 
             // Confirm requirements like Python module + WGRIB2 are present
@@ -68,14 +73,18 @@ namespace realization {
             auto start = forcing_config.simulation_start_t;
             auto end   = forcing_config.simulation_end_t;
 
-            std::cout << "[ngen debug] About to call ForcingsEngineLumpedDataProvider constructor" << std::endl;
+            ss.str(""); 
+            ss << "About to call ForcingsEngineLumpedDataProvider constructor" << std::endl;
+            LOG(ss.str(), LogLevel::DEBUG);
 
             // Construct the ForcingsEngineLumpedDataProvider
             fp = std::make_shared<data_access::ForcingsEngineLumpedDataProvider>(
                 forcing_config.init_config, start, end, identifier
             );
 
-            std::cout << "[ngen debug] Finished calling ForcingsEngineLumpedDataProvider constructor" << std::endl;
+            ss.str(""); 
+            ss << "Finished calling ForcingsEngineLumpedDataProvider constructor" << std::endl;
+            LOG(ss.str(), LogLevel::DEBUG);
         }
 #endif
         else { // Some unknown string in the provider field?

--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -838,7 +838,7 @@ namespace realization {
                         }
                     } else {
                         ss.str("");
-                        ss << " ailed to parse external parameter: catchment `"
+                        ss << " Failed to parse external parameter: catchment `"
                            << catchment_feature->get_id()
                            << "` does not contain the property `"
                            << param_name << "`\n";

--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -32,7 +32,6 @@ namespace realization {
 
     class Formulation_Manager {
         public:
-
             std::shared_ptr<Simulation_Time> Simulation_Time_Object;
 
             Formulation_Manager(std::stringstream &data) {
@@ -55,7 +54,8 @@ namespace realization {
 
             void read(geojson::GeoJSON fabric, utils::StreamHandler output_stream) {
                 std::stringstream ss;
-                std::cout << "[DEBUG] Entering Formulation_Manager::read()" << std::endl;
+                ss.str(""); ss << "Entering Formulation_Manager::read()" << std::endl;
+                LOG(ss.str(), LogLevel::DEBUG);
 
                 //TODO seperate the parsing of configuration options like time
                 //and routing and other non feature specific tasks from this main function
@@ -101,7 +101,8 @@ namespace realization {
 
                         // add the layer to storage
                         layer_storage.put_layer(layer_desc, layer_desc.id);
-                        std::cout << "[DEBUG] Layer added: ID = " << layer_desc.id << ", Name = " << layer_desc.name << std::endl;
+                        ss.str(""); ss << "Layer added: ID = " << layer_desc.id << ", Name = " << layer_desc.name << std::endl;
+                        LOG(ss.str(), LogLevel::DEBUG);
 
                         if (layer.has_formulation() && layer.get_domain() == "catchments") {
                             double c_value = UnitsHelper::get_converted_value(layer_desc.time_step_units, layer_desc.time_step, "s");
@@ -136,9 +137,10 @@ namespace realization {
                     using_routing = true;
                 #else
                     using_routing = false;
-                    ss <<"WARNING: Formulation Manager found routing configuration"
-                             << ", but routing support isn't enabled. No routing will occur." << std::endl;
-                    LOG(ss.str(), LogLevel::SEVERE); ss.str("");
+                    ss.str("");
+                    ss <<"Formulation Manager found routing configuration"
+                       << ", but routing support isn't enabled. No routing will occur." << std::endl;
+                    LOG(ss.str(), LogLevel::WARNING);
                 #endif // NGEN_WITH_ROUTING
                  }
 
@@ -168,15 +170,17 @@ namespace realization {
 
                 if (possible_catchment_configs) {
                     for (std::pair<std::string, boost::property_tree::ptree> catchment_config : *possible_catchment_configs) {
-                        std::cout << "[DEBUG] Processing catchment: " << catchment_config.first << std::endl;
+                        ss.str(""); ss << "Processing catchment: " << catchment_config.first << std::endl;
+                        LOG(ss.str(), LogLevel::DEBUG);
 
                         int catchment_index = fabric->find(catchment_config.first);
                         if (catchment_index == -1) {
                             #ifndef NGEN_QUIET
-                            ss <<"WARNING: Formulation_Manager::read: Cannot create formulation for catchment "
-                               << catchment_config.first
-                               << " that isn't identified in the hydrofabric or requested subset" << std::endl;
-                            LOG(ss.str(), LogLevel::SEVERE); ss.str("");
+                             ss.str("");
+                             ss <<"Formulation_Manager::read: Cannot create formulation for catchment "
+                                << catchment_config.first
+                                << " that isn't identified in the hydrofabric or requested subset" << std::endl;
+                            LOG(ss.str(), LogLevel::WARNING);
                             #endif
                             continue;
                         }
@@ -191,7 +195,8 @@ namespace realization {
 
                         // Parse catchment-specific model_params
                         auto catchment_feature = fabric->get_feature(catchment_index);
-                        std::cout << "[DEBUG] Linking external properties for catchment: " << catchment_config.first << std::endl;
+                        ss.str(""); ss << "Linking external properties for catchment: " << catchment_config.first << std::endl;
+                        LOG(ss.str(), LogLevel::DEBUG);
                         catchment_formulation.formulation.link_external(catchment_feature);
 
                         this->add_formulation(
@@ -202,18 +207,21 @@ namespace realization {
                                 output_stream
                             )
                         );
-                        std::cout << "[DEBUG] Formulation constructed for catchment: " << catchment_config.first << std::endl;
+                        ss.str(""); ss << "Formulation constructed for catchment: " << catchment_config.first << std::endl;
+                        LOG(ss.str(), LogLevel::DEBUG);
                     }
                 }
 
                 // Process any catchments not explicitly defined in the realization file
                 for (geojson::Feature location : *fabric) {
                     if (not this->contains(location->get_id())) {
-                        std::cout << "[DEBUG] Creating missing formulation for location: " << location->get_id() << std::endl;
+                        ss.str(""); ss << "Creating missing formulation for location: " << location->get_id() << std::endl;
+                        LOG(ss.str(), LogLevel::DEBUG);
                         std::shared_ptr<Catchment_Formulation> missing_formulation = this->construct_missing_formulation(
                             location, output_stream, simulation_time_config);
                         this->add_formulation(missing_formulation);
-//                        std::cout << "[DEBUG] Missing formulation created for location: " << location->get_id() << std::endl;
+//                        ss.str(""); ss << "Missing formulation created for location: " << location->get_id() << std::endl;
+//                        LOG(ss.str(), LogLevel::DEBUG);
                     }
                 }
             }
@@ -271,7 +279,9 @@ namespace realization {
              * @return routing t_route_config_file_with_path
              */
             std::string get_t_route_config_file_with_path() {
-                std::cout << "[DEBUG] Retrieving t_route config file path" << std::endl;
+                std::stringstream ss;
+                ss.str(""); ss << "Retrieving t_route config file path" << std::endl;
+                LOG(ss.str(), LogLevel::DEBUG);
                 if(this->routing_config != nullptr)
                     return this->routing_config->t_route_config_file_with_path;
                 else
@@ -296,7 +306,9 @@ namespace realization {
                 // constituent formulations points to any forcing
                 // object other than the enclosing
                 // Bmi_Multi_Formulation instance itself.
-                std::cout << "[DEBUG] Finalizing Formulation_Manager" << std::endl;
+                std::stringstream ss;
+                ss.str(""); ss << "Finalizing Formulation_Manager" << std::endl;
+                LOG(ss.str(), LogLevel::DEBUG);
                 for (auto const& fmap: formulations) {
                     fmap.second->finalize();
                 }
@@ -310,7 +322,8 @@ namespace realization {
 #if NGEN_WITH_PYTHON
                 data_access::detail::ForcingsEngineStorage::instances.clear();
 #endif
-                std::cout << "[DEBUG] Formulation_Manager finalized" << std::endl;
+                ss.str(""); ss << "Formulation_Manager finalized" << std::endl;
+                LOG(ss.str(), LogLevel::DEBUG);
             }
 
             /**
@@ -364,7 +377,9 @@ namespace realization {
              * @return a reference to the LayerStorageObject
              */
             ngen::LayerDataStorage& get_layer_metadata() {
-                std::cout << "[DEBUG] Retrieving layer metadata" << std::endl;
+                std::stringstream ss;
+                ss.str(""); ss << "Retrieving layer metadata" << std::endl;
+                LOG(ss.str(), LogLevel::DEBUG);
                 return layer_storage;
             }
 
@@ -376,7 +391,9 @@ namespace realization {
                 const realization::config::Config& catchment_formulation,
                 utils::StreamHandler output_stream
             ) {
-                std::cout << "[DEBUG] Entering construct_formulation_from_config for identifier: " << identifier << std::endl;
+                std::stringstream ss;
+                ss.str(""); ss << "Entering construct_formulation_from_config for identifier: " << identifier << std::endl;
+                LOG(ss.str(), LogLevel::DEBUG);
 
                 // Check if the formulation exists
                 if (!formulation_exists(catchment_formulation.formulation.type)) {
@@ -389,18 +406,20 @@ namespace realization {
                 }
 
                 // Check for missing forcing parameters
-                std::cout << "[DEBUG] Checking forcing parameters for identifier: " << identifier << std::endl;
+                ss.str(""); ss << "Checking forcing parameters for identifier: " << identifier << std::endl;
+                LOG(ss.str(), LogLevel::DEBUG);
                 if (catchment_formulation.forcing.parameters.empty()) {
                     std::string throw_msg;
                     throw_msg.assign("No forcing definition was found for " + identifier);
-                    LOG(throw_msg, LogLevel::WARNING);
+                    LOG(throw_msg, LogLevel::FATAL);
                     throw std::runtime_error(throw_msg);
                 }
 
                 // Check for missing path
                 std::vector<std::string> missing_parameters;
                 if (!catchment_formulation.forcing.has_key("path")) {
-                    std::cout << "[DEBUG] Missing path parameter for identifier: " << identifier << std::endl;
+                    ss.str(""); ss << "Missing path parameter for identifier: " << identifier << std::endl;
+                    LOG(ss.str(), LogLevel::DEBUG);
                     missing_parameters.push_back("path");
                 }
 
@@ -422,30 +441,38 @@ namespace realization {
 
                 // Extract forcing parameters
                 forcing_params forcing_config = this->get_forcing_params(catchment_formulation.forcing.parameters, identifier, simulation_time_config);
-                std::cout << "[ngen debug] Forcing parameters extracted for identifier: " << identifier << std::endl;
-                std::cout << "  [ngen debug] Forcing path:        " << forcing_config.path << std::endl;
-                std::cout << "  [ngen debug] Forcing provider:    " << forcing_config.provider << std::endl;
-                std::cout << "  [ngen debug] Forcing init_config: " << forcing_config.init_config << std::endl;
+                ss.str("");
+                ss << "Forcing parameters extracted for identifier: " << identifier << std::endl;
+                ss << "  Forcing path:        " << forcing_config.path << std::endl;
+                ss << "  Forcing provider:    " << forcing_config.provider << std::endl;
+                ss << "  Forcing init_config: " << forcing_config.init_config << std::endl;
+                LOG(ss.str(), LogLevel::DEBUG);
 
                 std::time_t start_t = static_cast<std::time_t>(forcing_config.simulation_start_t);
                 std::time_t end_t   = static_cast<std::time_t>(forcing_config.simulation_end_t);
 
-                std::cout << "  [ngen debug] Simulation start time: " << std::put_time(std::gmtime(&start_t), "%Y-%m-%d %H:%M:%S UTC")
+                ss.str("");
+                ss << "  Simulation start time: " << std::put_time(std::gmtime(&start_t), "%Y-%m-%d %H:%M:%S UTC")
                           << " (" << forcing_config.simulation_start_t << ")" << std::endl;
-                std::cout << "  [ngen debug] Simulation end time:   " << std::put_time(std::gmtime(&end_t), "%Y-%m-%d %H:%M:%S UTC")
+                ss << "  Simulation end time:   " << std::put_time(std::gmtime(&end_t), "%Y-%m-%d %H:%M:%S UTC")
                           << " (" << forcing_config.simulation_end_t << ")" << std::endl;
+                LOG(ss.str(), LogLevel::DEBUG);
 
                 // Construct formulation
-                std::cout << "[DEBUG] Constructing formulation for type: " << catchment_formulation.formulation.type << std::endl;
+                ss.str(""); ss << "Constructing formulation for type: " << catchment_formulation.formulation.type << std::endl;
+                LOG(ss.str(), LogLevel::DEBUG);
                 std::shared_ptr<Catchment_Formulation> constructed_formulation = construct_formulation(
                     catchment_formulation.formulation.type, identifier, forcing_config, output_stream
                 );
-                std::cout << "[DEBUG] Formulation constructed successfully for identifier: " << identifier << std::endl;
+                ss.str(""); ss << "Formulation constructed successfully for identifier: " << identifier << std::endl;
+                LOG(ss.str(), LogLevel::DEBUG);
 
                 // Create formulation instance
-                std::cout << "[DEBUG] Calling create_formulation for identifier: " << identifier << std::endl;
+                ss.str(""); ss << "Calling create_formulation for identifier: " << identifier << std::endl;
+                LOG(ss.str(), LogLevel::DEBUG);
                 constructed_formulation->create_formulation(catchment_formulation.formulation.parameters);
-                std::cout << "[DEBUG] Formulation creation completed for identifier: " << identifier << std::endl;
+                ss.str(""); ss << "Formulation creation completed for identifier: " << identifier << std::endl;
+                LOG(ss.str(), LogLevel::DEBUG);
 
                 return constructed_formulation;
             }
@@ -455,39 +482,47 @@ namespace realization {
                 utils::StreamHandler output_stream,
                 simulation_time_params &simulation_time_config
             ) {
+                std::stringstream ss;
                 const std::string identifier = feature->get_id();
-                std::cout << "[DEBUG] Entering construct_missing_formulation for identifier: " << identifier << std::endl;
+                ss.str(""); ss << "Entering construct_missing_formulation for identifier: " << identifier << std::endl;
+                LOG(ss.str(), LogLevel::DEBUG);
 
                 // Extract forcing parameters from the global config
                 forcing_params forcing_config = this->get_forcing_params(global_config.forcing.parameters, identifier, simulation_time_config);
-                std::cout << "[ngen debug] Forcing parameters extracted for identifier: " << identifier << std::endl;
-                std::cout << "  [ngen debug] Forcing path:        " << forcing_config.path << std::endl;
-                std::cout << "  [ngen debug] Forcing provider:    " << forcing_config.provider << std::endl;
-                std::cout << "  [ngen debug] Forcing init_config: " << forcing_config.init_config << std::endl;
+                ss.str(""); 
+                ss << "Forcing parameters extracted for identifier: " << identifier << std::endl;
+                ss << "  Forcing path:        " << forcing_config.path << std::endl;
+                ss << "  Forcing provider:    " << forcing_config.provider << std::endl;
+                ss << "  Forcing init_config: " << forcing_config.init_config << std::endl;
+                LOG(ss.str(), LogLevel::DEBUG);
 
                 std::time_t start_t = static_cast<std::time_t>(forcing_config.simulation_start_t);
                 std::time_t end_t   = static_cast<std::time_t>(forcing_config.simulation_end_t);
 
-                std::cout << "  [ngen debug] Simulation start time: " << std::put_time(std::gmtime(&start_t), "%Y-%m-%d %H:%M:%S UTC")
+                ss.str(""); 
+                ss << "  Simulation start time: " << std::put_time(std::gmtime(&start_t), "%Y-%m-%d %H:%M:%S UTC")
                           << " (" << forcing_config.simulation_start_t << ")" << std::endl;
-                std::cout << "  [ngen debug] Simulation end time:   " << std::put_time(std::gmtime(&end_t), "%Y-%m-%d %H:%M:%S UTC")
+                ss << "  Simulation end time:   " << std::put_time(std::gmtime(&end_t), "%Y-%m-%d %H:%M:%S UTC")
                           << " (" << forcing_config.simulation_end_t << ")" << std::endl;
+                LOG(ss.str(), LogLevel::DEBUG);
 
                 // Construct the formulation object
-                std::cout << "[DEBUG] Entering construct_formulation for identifier: " << identifier << ", type: " << global_config.formulation.type << std::endl;
+                ss.str(""); ss << "Entering construct_formulation for identifier: " << identifier << ", type: " << global_config.formulation.type << std::endl;
+                LOG(ss.str(), LogLevel::DEBUG);
                 std::shared_ptr<Catchment_Formulation> missing_formulation = construct_formulation(
                     global_config.formulation.type,
                     identifier,
                     forcing_config,
                     output_stream
                 );
-                std::cout << "[DEBUG] Formulation object constructed for identifier: " << identifier << std::endl;
+                ss.str(""); ss << "Formulation object constructed for identifier: " << identifier << std::endl;
+                LOG(ss.str(), LogLevel::DEBUG);
 
                 // Make a copy of the global configuration so parameters don't clash when linking to external data
                 realization::config::Config global_copy = global_config;
 
 //                // Log parameters before substitution
-//                std::cout << "[DEBUG] Global config parameters (before substitution) for identifier: " << identifier << std::endl;
+//                ss.str(""); ss << "Global config parameters (before substitution) for identifier: " << identifier << std::endl;
 //                for (auto it = global_copy.formulation.parameters.begin(); it != global_copy.formulation.parameters.end(); ++it) {
 //                    const std::string& key = it->first;
 //                    const geojson::JSONProperty& value = it->second;
@@ -500,7 +535,8 @@ namespace realization {
 //                }
 
                 // Substitute {{id}} in the global formulation
-                std::cout << "[DEBUG] Checking for init_config before substitution for identifier: " << identifier << std::endl;
+                ss.str(""); ss << "Checking for init_config before substitution for identifier: " << identifier << std::endl;
+                LOG(ss.str(), LogLevel::DEBUG);
                 auto init_config_it = global_copy.formulation.parameters.find(BMI_REALIZATION_CFG_PARAM_REQ__INIT_CONFIG);
                 if (init_config_it != global_copy.formulation.parameters.end()) {
                     const geojson::JSONProperty& init_config_property = init_config_it->second;
@@ -508,9 +544,12 @@ namespace realization {
                     if (init_config_property.get_type() == geojson::PropertyType::String) {
                         std::string original_value = init_config_property.as_string();
                         if (!original_value.empty()) {
-                            std::cout << "[DEBUG] construct_missing_formulation Performing pattern substitution for key: " << BMI_REALIZATION_CFG_PARAM_REQ__INIT_CONFIG
-                                      << ", pattern: {{id}}, replacement: " << identifier << std::endl;
-//                            std::cout << "[DEBUG] Original value: " << original_value << std::endl;
+                            ss.str(""); ss << "construct_missing_formulation Performing pattern substitution for key: " << BMI_REALIZATION_CFG_PARAM_REQ__INIT_CONFIG
+                                           << ", pattern: {{id}}, replacement: " << identifier << std::endl;
+                            LOG(ss.str(), LogLevel::DEBUG);
+                            ss.str("");
+//                            ss.str(""); ss << "Original value: " << original_value << std::endl;
+//                            LOG(ss.str(), LogLevel::DEBUG);
 
                             Catchment_Formulation::config_pattern_substitution(
                                 global_copy.formulation.parameters,
@@ -519,17 +558,21 @@ namespace realization {
                                 identifier
                             );
                         } else {
-                            std::cout << "[WARNING] init_config is present but empty for identifier: " << identifier << std::endl;
+                            ss.str(""); ss << "init_config is present but empty for identifier: " << identifier << std::endl;
+                            LOG(ss.str(), LogLevel::WARNING);
                         }
                     } else {
-                        std::cout << "[WARNING] init_config is present but not a string for identifier: " << identifier << std::endl;
+                        ss.str(""); ss << "init_config is present but not a string for identifier: " << identifier << std::endl;
+                        LOG(ss.str(), LogLevel::WARNING);
                     }
                 } else {
-                    std::cout << "[WARNING] init_config not present in global configuration for identifier: " << identifier << std::endl;
+                    ss.str(""); ss << "[WARNING] init_config not present in global configuration for identifier: " << identifier << std::endl;
+                    LOG(ss.str(), LogLevel::WARNING);
                 }
 
 //                // Log parameters after substitution
-//                std::cout << "[DEBUG] Global config parameters (after substitution) for identifier: " << identifier << std::endl;
+//                ss.str(""); ss << "Global config parameters (after substitution) for identifier: " << identifier << std::endl;
+//                LOG(ss.str(), LogLevel::DEBUG);
 //                for (auto it = global_copy.formulation.parameters.begin(); it != global_copy.formulation.parameters.end(); ++it) {
 //                    const std::string& key = it->first;
 //                    const geojson::JSONProperty& value = it->second;
@@ -542,33 +585,40 @@ namespace realization {
 //                }
 
                 // Link external properties
-                std::cout << "[DEBUG] Linking external properties for identifier: " << identifier << std::endl;
+                ss.str(""); ss << "Linking external properties for identifier: " << identifier << std::endl;
+                LOG(ss.str(), LogLevel::DEBUG);
                 auto formulation = realization::config::Formulation(global_copy.formulation);
                 formulation.link_external(feature);
 
                 // Create the formulation
-                std::cout << "[DEBUG] Creating formulation for identifier: " << identifier << std::endl;
+                ss.str(""); ss << "Creating formulation for identifier: " << identifier << std::endl;
+                LOG(ss.str(), LogLevel::DEBUG);
                 missing_formulation->create_formulation(formulation.parameters);
-//                std::cout << "[DEBUG] Formulation creation completed for identifier: " << identifier << std::endl;
+//                ss.str(""); ss << "Formulation creation completed for identifier: " << identifier << std::endl;
+//                LOG(ss.str(), LogLevel::DEBUG);
 
                 return missing_formulation;
             }
 
             forcing_params get_forcing_params(const geojson::PropertyMap &forcing_prop_map, std::string identifier, simulation_time_params &simulation_time_config) {
-                std::cout << "[DEBUG] Entering get_forcing_params for identifier: " << identifier << std::endl;
+                std::stringstream ss;
+                ss.str(""); ss << "Entering get_forcing_params for identifier: " << identifier << std::endl;
+                LOG(ss.str(), LogLevel::DEBUG);
 
                 // Extract the required 'path' parameter
                 std::string path = "";
                 if (forcing_prop_map.count("path") != 0) {
                     path = forcing_prop_map.at("path").as_string();
-                    std::cout << "  [DEBUG] Forcing path: " << path << std::endl;
+                    ss.str(""); ss << "  Forcing path: " << path << std::endl;
+                    LOG(ss.str(), LogLevel::DEBUG);
                 }
 
                 // Extract the required 'provider' parameter
                 std::string provider;
                 if (forcing_prop_map.count("provider") != 0) {
                     provider = forcing_prop_map.at("provider").as_string();
-                    std::cout << "  [DEBUG] Forcing provider: " << provider << std::endl;
+                    ss.str(""); ss << "  Forcing provider: " << provider << std::endl;
+                    LOG(ss.str(), LogLevel::DEBUG);
                 }
 
                 // Extract the optional 'init_config' parameter from 'params'
@@ -579,7 +629,8 @@ namespace realization {
                         const geojson::PropertyMap& params_map = params_property.get_values();
                         if (params_map.count("init_config") != 0) {
                             init_config = params_map.at("init_config").as_string();
-                            std::cout << "  [DEBUG] Forcing init_config: " << init_config << std::endl;
+                            ss.str(""); ss << "  Forcing init_config: " << init_config << std::endl;
+                            LOG(ss.str(), LogLevel::DEBUG);
                         }
                     } else {
                         std::cout << "[WARNING] 'params' is not an object for identifier: " << identifier << std::endl;
@@ -779,17 +830,19 @@ namespace realization {
                             case geojson::PropertyType::List:
                             case geojson::PropertyType::Object:
                             default:
-                                ss  << "WARNING: property type " << static_cast<int>(catchment_attribute.get_type()) << " not allowed as model parameter. "
+                                ss.str("");
+                                ss  << "property type " << static_cast<int>(catchment_attribute.get_type()) << " not allowed as model parameter. "
                                           << "Must be one of: Natural (int), Real (double), Boolean, or String" << '\n';
-                                LOG(ss.str(), LogLevel::SEVERE); ss.str("");
+                                LOG(ss.str(), LogLevel::WARNING); ss.str("");
                                 break;
                         }
                     } else {
-                        ss  << "WARNING Failed to parse external parameter: catchment `"
-                                  << catchment_feature->get_id()
-                                  << "` does not contain the property `"
-                                  << param_name << "`\n";
-                        LOG(ss.str(), LogLevel::SEVERE); ss.str("");
+                        ss.str("");
+                        ss << " ailed to parse external parameter: catchment `"
+                           << catchment_feature->get_id()
+                           << "` does not contain the property `"
+                           << param_name << "`\n";
+                        LOG(ss.str(), LogLevel::WARNING); 
                     }
                 }
 
@@ -851,9 +904,9 @@ namespace realization {
                             default:
                                 // TODO: Should list/object values be passed to model parameters?
                                 //       Typically, feature properties *should* be scalars.
-                                ss  << "WARNING: property type " << static_cast<int>(catchment_attribute.get_type()) << " not allowed as model parameter. "
-                                          << "Must be one of: Natural (int), Real (double), Boolean, or String" << '\n';
-                                LOG(ss.str(), LogLevel::SEVERE); ss.str("");
+                                ss.str(""); ss << "property type " << static_cast<int>(catchment_attribute.get_type()) << " not allowed as model parameter. "
+                                               << "Must be one of: Natural (int), Real (double), Boolean, or String" << '\n';
+                                LOG(ss.str(), LogLevel::WARNING);
                                 break;
                         }
                     }

--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -176,11 +176,11 @@ namespace realization {
                         int catchment_index = fabric->find(catchment_config.first);
                         if (catchment_index == -1) {
                             #ifndef NGEN_QUIET
-                             ss.str("");
-                             ss <<"Formulation_Manager::read: Cannot create formulation for catchment "
-                                << catchment_config.first
-                                << " that isn't identified in the hydrofabric or requested subset" << std::endl;
-                            LOG(ss.str(), LogLevel::WARNING);
+                                ss.str("");
+                                ss << "Formulation_Manager::read: Cannot create formulation for catchment "
+                                   << catchment_config.first
+                                   << " that isn't identified in the hydrofabric or requested subset" << std::endl;
+                                LOG(ss.str(), LogLevel::WARNING);
                             #endif
                             continue;
                         }

--- a/include/utilities/Logger.hpp
+++ b/include/utilities/Logger.hpp
@@ -40,6 +40,8 @@ class Logger {
 		throw std::runtime_error(message);
 	};
 
+    static Logger* GetLogger();
+
   private:
     // Methods
     static std::string ConvertLogLevelToString(LogLevel level);
@@ -74,8 +76,6 @@ class Logger {
     bool         openedOnce = false;
     
     std::unordered_map<std::string, LogLevel> moduleLogLevels;
-
-    static Logger* GetLogger();
 };
 
 // Placed here to ensure the class is declared before setting this preprocessor symbol

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -690,7 +690,7 @@ int main(int argc, char* argv[]) {
                 // next time
                 if (layer_next_time <= next_time && layer_next_time <= prev_layer_time) {
                     if (count % 100 == 0) {
-                        ss << "Updating layer: " << layer->get_name() << "\n";
+                        ss << "Updating layer: " << layer->get_name() << " Count=" << count << "\n";
                         LOG(ss.str(), LogLevel::DEBUG);
                         ss.str("");
                     }

--- a/src/forcing/ForcingsEngineLumpedDataProvider.cpp
+++ b/src/forcing/ForcingsEngineLumpedDataProvider.cpp
@@ -153,14 +153,14 @@ Provider::data_type Provider::get_value(
             << " (" << tb_t << ")"
             << " | start: " << std::put_time(std::gmtime(&s_t), "%Y-%m-%d %H:%M:%S UTC")
             << " (" << s_t << ")" << std::endl;
-        LOG(LogLevel::INFO, ss.str());
+        LOG(LogLevel::DEBUG, ss.str());
 
         ss.str(""); 
         ss << "get_value() Time end:   " << std::put_time(std::gmtime(&te_t), "%Y-%m-%d %H:%M:%S UTC")
             << " (" << te_t << ")"
             << " | end:   " << std::put_time(std::gmtime(&e_t), "%Y-%m-%d %H:%M:%S UTC")
             << " (" << e_t << ")" << std::endl;
-        LOG(LogLevel::INFO, ss.str());
+        LOG(LogLevel::DEBUG, ss.str());
 
         using namespace std::literals::chrono_literals;
         if (!(start >= time_begin_)) {
@@ -234,14 +234,14 @@ std::vector<Provider::data_type> Provider::get_values(
               << " (" << tb_t << ")"
               << " | start: " << std::put_time(std::gmtime(&s_t), "%Y-%m-%d %H:%M:%S UTC")
               << " (" << s_t << ")" << std::endl;
-    LOG(LogLevel::INFO, ss.str());
+    LOG(LogLevel::DEBUG, ss.str());
 
     ss.str("");
     ss << "get_values() Time end:   " << std::put_time(std::gmtime(&te_t), "%Y-%m-%d %H:%M:%S UTC")
               << " (" << te_t << ")"
               << " | end:   " << std::put_time(std::gmtime(&e_t), "%Y-%m-%d %H:%M:%S UTC")
               << " (" << e_t << ")" << std::endl;
-    LOG(LogLevel::INFO, ss.str());
+    LOG(LogLevel::DEBUG, ss.str());
 
     using namespace std::literals::chrono_literals;
     if (!(start >= time_begin_)) {

--- a/src/forcing/ForcingsEngineLumpedDataProvider.cpp
+++ b/src/forcing/ForcingsEngineLumpedDataProvider.cpp
@@ -65,7 +65,8 @@ Provider::ForcingsEngineLumpedDataProvider(
     // running the correct configuration of the forcings engine for this class.
     const auto cat_id_pos = std::find(var_output_names_.begin(), var_output_names_.end(), "CAT-ID");
     if (cat_id_pos == var_output_names_.end()) {
-        std::cerr << "[ngen error] Failed to initialize ForcingsEngineLumpedDataProvider: "
+
+        ss << "Failed to initialize ForcingsEngineLumpedDataProvider: "
                   << "`CAT-ID` is not an output variable of the forcings engine."
                   << " Does " << init_config << " have `GRID_TYPE` set to 'hydrofabric'?" << std::endl;
         throw std::runtime_error{
@@ -128,9 +129,11 @@ Provider::data_type Provider::get_value(
     std::stringstream ss; 
     if (!(divide_id_ == convert_divide_id_stoi(selector.get_id()))) {
         ss.str("");
-        ss << "divide_id_ " << divide_id_ << " != selector id " << convert_divide_id_stoi(selector.get_id());
+        ss << "get_value() divide_id_ " << divide_id_ << " != selector id " << convert_divide_id_stoi(selector.get_id());
         LOG(LogLevel::FATAL, ss.str());
-        assert(divide_id_ == convert_divide_id_stoi(selector.get_id()));
+        throw std::runtime_error{
+            "Divide ID mismatch in the forcings engine."
+        };
     }
 
     auto variable = ensure_variable(selector.get_variable_name());
@@ -162,17 +165,21 @@ Provider::data_type Provider::get_value(
         using namespace std::literals::chrono_literals;
         if (!(start >= time_begin_)) {
             LOG(LogLevel::FATAL,
-                "Begin time less than start: start=%lld vs time_begin_=%lld",
+                "get_value() Begin time less than start: start=%lld vs time_begin_=%lld",
                 static_cast<long long>(start.time_since_epoch().count()),
                 static_cast<long long>(time_begin_.time_since_epoch().count()));
-            assert(start >= time_begin_);
+            throw std::runtime_error{
+                "Begin time range error."
+            };
         }
         if (!(end < time_end_ + time_step_ + 1s)) {
             LOG(LogLevel::FATAL,
-                "Next Timestep > end: end=%lld vs limit=%lld",
+                "get_value() Next Timestep > end: end=%lld vs limit=%lld",
                 static_cast<long long>(end.time_since_epoch().count()),
                 static_cast<long long>((time_end_ + time_step_ + 1s).time_since_epoch().count()));
-            assert(end < time_end_ + time_step_ + 1s);
+            throw std::runtime_error{
+                "End time range error."
+            };
         }
 
         auto current = start;
@@ -205,9 +212,11 @@ std::vector<Provider::data_type> Provider::get_values(
     std::stringstream ss; 
     if (!(divide_id_ == convert_divide_id_stoi(selector.get_id()))) {
         ss.str("");
-        ss << "divide id " << divide_id_ << "not equal to selector.get_id" << convert_divide_id_stoi(selector.get_id());
+        ss << "get_values() divide id " << divide_id_ << "not equal to selector.get_id" << convert_divide_id_stoi(selector.get_id());
         LOG(LogLevel::FATAL, ss.str());
-        assert(divide_id_ == convert_divide_id_stoi(selector.get_id()));
+        throw std::runtime_error{
+            "Divide ID mismatch in the forcings engine."
+        };
    }
  
     auto variable = ensure_variable(selector.get_variable_name());
@@ -237,17 +246,21 @@ std::vector<Provider::data_type> Provider::get_values(
     using namespace std::literals::chrono_literals;
     if (!(start >= time_begin_)) {
         LOG(LogLevel::FATAL,
-            "Begin time less than start: start=%lld vs time_begin_=%lld",
+            "get_values() Begin time less than start: start=%lld vs time_begin_=%lld",
             static_cast<long long>(start.time_since_epoch().count()),
             static_cast<long long>(time_begin_.time_since_epoch().count()));
-        assert(start >= time_begin_);
+        throw std::runtime_error{
+            "Start time range error."
+        };
     }
     if (!(end < time_end_ + time_step_ + 1s)) {
         LOG(LogLevel::FATAL,
-            "Next Timestep > end: end=%lld vs limit=%lld",
+            "get_values() Next Timestep > end: end=%lld vs limit=%lld",
             static_cast<long long>(end.time_since_epoch().count()),
             static_cast<long long>((time_end_ + time_step_ + 1s).time_since_epoch().count()));
-        assert(end < time_end_ + time_step_ + 1s);
+        throw std::runtime_error{
+            "End time range error."
+        };
     }   
 
     

--- a/src/forcing/ForcingsEngineLumpedDataProvider.cpp
+++ b/src/forcing/ForcingsEngineLumpedDataProvider.cpp
@@ -19,9 +19,11 @@ std::size_t convert_divide_id_stoi(const std::string& divide_id)
         : &divide_id[separator + 1]
     );
 
-    std::cout << "[ngen debug] Converting divide ID: " << divide_id
-              << " -> " << split << std::endl;
-
+    std::stringstream ss; 
+    ss.str(""); 
+    ss << "Converting divide ID: " << divide_id
+       << " -> " << split << std::endl;
+    LOG(ss.str(), LogLevel::DEBUG);
     return std::atol(split);
 }
 
@@ -34,19 +36,28 @@ Provider::ForcingsEngineLumpedDataProvider(
   : BaseProvider(init_config, time_begin_seconds, time_end_seconds)
 {
     // Add detailed logging of the constructor arguments
-    std::cout << "\n[ngen debug] Initializing ForcingsEngineLumpedDataProvider:" << std::endl;
-    std::cout << "  init_config:  " << init_config << std::endl;
-
+    std::stringstream ss; 
+    ss.str(""); 
+    ss << "Initializing ForcingsEngineLumpedDataProvider:" << std::endl;
+    ss << "  init_config:  " << init_config << std::endl;
+    LOG(ss.str(), LogLevel::DEBUG);
+    
     std::time_t tb_t = static_cast<std::time_t>(time_begin_seconds);
     std::time_t te_t = static_cast<std::time_t>(time_end_seconds);
 
-    std::cout << "  Time begin:   " << std::put_time(std::gmtime(&tb_t), "%Y-%m-%d %H:%M:%S UTC")
-              << " (" << time_begin_seconds << ")" << std::endl;
+    ss.str(""); 
+    ss << "  Time begin:   " << std::put_time(std::gmtime(&tb_t), "%Y-%m-%d %H:%M:%S UTC")
+       << " (" << time_begin_seconds << ")" << std::endl;
+    LOG(ss.str(), LogLevel::DEBUG);
 
-    std::cout << "  Time end:     " << std::put_time(std::gmtime(&te_t), "%Y-%m-%d %H:%M:%S UTC")
-              << " (" << time_end_seconds << ")" << std::endl;
+    ss.str(""); 
+    ss << "  Time end:     " << std::put_time(std::gmtime(&te_t), "%Y-%m-%d %H:%M:%S UTC")
+       << " (" << time_end_seconds << ")" << std::endl;
+    LOG(ss.str(), LogLevel::DEBUG);
 
-    std::cout << "  divide ID:    " << divide_id << std::endl;
+    ss.str(""); 
+    ss << "  divide ID:    " << divide_id << std::endl;
+    LOG(ss.str(), LogLevel::DEBUG);
 
     divide_id_ = convert_divide_id_stoi(divide_id);
 
@@ -61,14 +72,18 @@ Provider::ForcingsEngineLumpedDataProvider(
             "Failed to initialize ForcingsEngineLumpedDataProvider: `CAT-ID` is not an output variable of the forcings engine."
         };
     }
-    std::cout << "[ngen debug] Found CAT-ID in output names" << std::endl;
+    ss.str(""); 
+    ss << " Found CAT-ID in output names" << std::endl;
+    LOG(ss.str(), LogLevel::DEBUG);
 
     var_output_names_.erase(cat_id_pos);
 
     const auto size_id_dimension = static_cast<std::size_t>(
         bmi_->GetVarNbytes("CAT-ID") / bmi_->GetVarItemsize("CAT-ID")
     );
-    std::cout << "[ngen debug] CAT-ID size: " << size_id_dimension << std::endl;
+    ss.str(""); 
+    ss << " CAT-ID size: " << size_id_dimension << std::endl;
+    LOG(ss.str(), LogLevel::DEBUG);
 
     // Copy CAT-ID values into instance vector
     const auto cat_id_span = boost::span<const int>(
@@ -78,15 +93,21 @@ Provider::ForcingsEngineLumpedDataProvider(
 
     auto divide_id_pos = std::find(cat_id_span.begin(), cat_id_span.end(), divide_id_);
     if (divide_id_pos == cat_id_span.end()) {
-        std::cerr << "[ngen error] Unable to find divide ID `" << divide_id
-                  << "` in the given Forcings Engine domain" << std::endl;
+        ss.str(""); 
+        ss << "Unable to find divide ID `" << divide_id
+            << "` in the given Forcings Engine domain" << std::endl;
+        LOG(ss.str(), LogLevel::SEVERE);
         divide_idx_ = static_cast<std::size_t>(-1);
     } else {
         divide_idx_ = std::distance(cat_id_span.begin(), divide_id_pos);
-        std::cout << "[ngen debug] Divide ID found at index: " << divide_idx_ << std::endl;
+        ss.str(""); 
+        ss << " Divide ID found at index: " << divide_idx_ << std::endl;
+        LOG(ss.str(), LogLevel::INFO);
     }
 
-    std::cout << "[ngen debug] ForcingsEngineLumpedDataProvider initialization complete" << std::endl;
+    ss.str(""); 
+    ss << " ForcingsEngineLumpedDataProvider initialization complete" << std::endl;
+    LOG(LogLevel::DEBUG, ss.str());
 }
 
 std::size_t Provider::divide() const noexcept
@@ -104,7 +125,13 @@ Provider::data_type Provider::get_value(
     data_access::ReSampleMethod m
 )
 {
-    assert(divide_id_ == convert_divide_id_stoi(selector.get_id()));
+    std::stringstream ss; 
+    if (!(divide_id_ == convert_divide_id_stoi(selector.get_id()))) {
+        ss.str("");
+        ss << "divide_id_ " << divide_id_ << " != selector id " << convert_divide_id_stoi(selector.get_id());
+        LOG(LogLevel::FATAL, ss.str());
+        assert(divide_id_ == convert_divide_id_stoi(selector.get_id()));
+    }
 
     auto variable = ensure_variable(selector.get_variable_name());
 
@@ -118,19 +145,35 @@ Provider::data_type Provider::get_value(
         auto s_t  = std::chrono::system_clock::to_time_t(start);
         auto e_t  = std::chrono::system_clock::to_time_t(end);
 
-        std::cout << "get_value() Time begin: " << std::put_time(std::gmtime(&tb_t), "%Y-%m-%d %H:%M:%S UTC")
-                  << " (" << tb_t << ")"
-                  << " | start: " << std::put_time(std::gmtime(&s_t), "%Y-%m-%d %H:%M:%S UTC")
-                  << " (" << s_t << ")" << std::endl;
+        ss.str(""); 
+        ss << "get_value() Time begin: " << std::put_time(std::gmtime(&tb_t), "%Y-%m-%d %H:%M:%S UTC")
+            << " (" << tb_t << ")"
+            << " | start: " << std::put_time(std::gmtime(&s_t), "%Y-%m-%d %H:%M:%S UTC")
+            << " (" << s_t << ")" << std::endl;
+        LOG(LogLevel::INFO, ss.str());
 
-        std::cout << "get_value() Time end:   " << std::put_time(std::gmtime(&te_t), "%Y-%m-%d %H:%M:%S UTC")
-                  << " (" << te_t << ")"
-                  << " | end:   " << std::put_time(std::gmtime(&e_t), "%Y-%m-%d %H:%M:%S UTC")
-                  << " (" << e_t << ")" << std::endl;
+        ss.str(""); 
+        ss << "get_value() Time end:   " << std::put_time(std::gmtime(&te_t), "%Y-%m-%d %H:%M:%S UTC")
+            << " (" << te_t << ")"
+            << " | end:   " << std::put_time(std::gmtime(&e_t), "%Y-%m-%d %H:%M:%S UTC")
+            << " (" << e_t << ")" << std::endl;
+        LOG(LogLevel::INFO, ss.str());
 
         using namespace std::literals::chrono_literals;
-        assert(start >= time_begin_);
-        assert(end < time_end_ + time_step_ + 1s);
+        if (!(start >= time_begin_)) {
+            LOG(LogLevel::FATAL,
+                "Begin time less than start: start=%lld vs time_begin_=%lld",
+                static_cast<long long>(start.time_since_epoch().count()),
+                static_cast<long long>(time_begin_.time_since_epoch().count()));
+            assert(start >= time_begin_);
+        }
+        if (!(end < time_end_ + time_step_ + 1s)) {
+            LOG(LogLevel::FATAL,
+                "Next Timestep > end: end=%lld vs limit=%lld",
+                static_cast<long long>(end.time_since_epoch().count()),
+                static_cast<long long>((time_end_ + time_step_ + 1s).time_since_epoch().count()));
+            assert(end < time_end_ + time_step_ + 1s);
+        }
 
         auto current = start;
         while (current < end) {
@@ -148,7 +191,10 @@ Provider::data_type Provider::get_value(
         return acc;
     }
 
-    throw std::runtime_error{"Given ReSampleMethod " + std::to_string(m) + " not implemented."};
+    ss.str(""); 
+    ss << "Given ReSampleMethod " + std::to_string(m) + " not implemented.";
+    LOG(LogLevel::FATAL, ss.str());
+    throw std::runtime_error{ss.str()};
 }
 
 std::vector<Provider::data_type> Provider::get_values(
@@ -156,8 +202,14 @@ std::vector<Provider::data_type> Provider::get_values(
     data_access::ReSampleMethod /* unused */
 )
 {
-    assert(divide_id_ == convert_divide_id_stoi(selector.get_id()));
-
+    std::stringstream ss; 
+    if (!(divide_id_ == convert_divide_id_stoi(selector.get_id()))) {
+        ss.str("");
+        ss << "divide id " << divide_id_ << "not equal to selector.get_id" << convert_divide_id_stoi(selector.get_id());
+        LOG(LogLevel::FATAL, ss.str());
+        assert(divide_id_ == convert_divide_id_stoi(selector.get_id()));
+   }
+ 
     auto variable = ensure_variable(selector.get_variable_name());
 
     const auto start = clock_type::from_time_t(selector.get_init_time());
@@ -168,20 +220,37 @@ std::vector<Provider::data_type> Provider::get_values(
     auto s_t  = std::chrono::system_clock::to_time_t(start);
     auto e_t  = std::chrono::system_clock::to_time_t(end);
 
-    std::cout << "get_values() Time begin: " << std::put_time(std::gmtime(&tb_t), "%Y-%m-%d %H:%M:%S UTC")
+    ss.str("");
+    ss << "get_values() Time begin: " << std::put_time(std::gmtime(&tb_t), "%Y-%m-%d %H:%M:%S UTC")
               << " (" << tb_t << ")"
               << " | start: " << std::put_time(std::gmtime(&s_t), "%Y-%m-%d %H:%M:%S UTC")
               << " (" << s_t << ")" << std::endl;
+    LOG(LogLevel::INFO, ss.str());
 
-    std::cout << "get_values() Time end:   " << std::put_time(std::gmtime(&te_t), "%Y-%m-%d %H:%M:%S UTC")
+    ss.str("");
+    ss << "get_values() Time end:   " << std::put_time(std::gmtime(&te_t), "%Y-%m-%d %H:%M:%S UTC")
               << " (" << te_t << ")"
               << " | end:   " << std::put_time(std::gmtime(&e_t), "%Y-%m-%d %H:%M:%S UTC")
               << " (" << e_t << ")" << std::endl;
+    LOG(LogLevel::INFO, ss.str());
 
     using namespace std::literals::chrono_literals;
-    assert(start >= time_begin_);
-    assert(end < time_end_ + time_step_ + 1s);
+    if (!(start >= time_begin_)) {
+        LOG(LogLevel::FATAL,
+            "Begin time less than start: start=%lld vs time_begin_=%lld",
+            static_cast<long long>(start.time_since_epoch().count()),
+            static_cast<long long>(time_begin_.time_since_epoch().count()));
+        assert(start >= time_begin_);
+    }
+    if (!(end < time_end_ + time_step_ + 1s)) {
+        LOG(LogLevel::FATAL,
+            "Next Timestep > end: end=%lld vs limit=%lld",
+            static_cast<long long>(end.time_since_epoch().count()),
+            static_cast<long long>((time_end_ + time_step_ + 1s).time_since_epoch().count()));
+        assert(end < time_end_ + time_step_ + 1s);
+    }   
 
+    
     std::vector<double> values;
     auto current = start;
     while (current < end) {


### PR DESCRIPTION
While developing the forcing code the developer used cout and asserts instead of logging the errors or debug statements to the Error and Warning Trapping System (EWTS). This generated debug statements regardless of the log level. It was necessary to convert these to EWTS log messages so they are captured in the log.

## Additions

- Added local declaration of the stringstream ss variable so as not to rely on a declaration from another module. 
- Added clearing of the ss variable before each use.
- Added log messages before asserts.
- Converted asserts to throwing a runtime error exception.

## Changes

- Converted cout and cerr statements to their appropriate EWTS log messages. 

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [x] Linux
