### PR TITLE
Remove catchment_id from string construction

### DIFF
--- a/src/forcing/NetCDFPerFeatureDataProvider.cpp
+++ b/src/forcing/NetCDFPerFeatureDataProvider.cpp
@@ -420,7 +420,7 @@ double NetCDFPerFeatureDataProvider::get_value(const CatchmentAggrDataSelector& 
     catch (const std::runtime_error& e)
     {
         data_access::unit_conversion_exception uce(e.what());
-        uce.provider_model_name = "NetCDFPerFeatureDataProvider " + catchment_id;
+        uce.provider_model_name = "NetCDFPerFeatureDataProvider";
         uce.provider_bmi_var_name = selector.get_variable_name();
         uce.provider_units = native_units;
         uce.unconverted_values.push_back(rvalue);


### PR DESCRIPTION
When creating the runtime error message for unit conversion updates in the `NetCDFPerFeatureDataProvider`, the format from the CSV error message was replicated, but the `catchment_id` was not available in the scope of this method. There’s not going to be a whole lot of different files, unlike potential different CSV files for different catchments so it is not necessary in this context. Stating `NetCDFPerFeatureDataProvider` is sufficient for the error message.

## Removals

- Removed `catchment_id` from the `model_name` string construction.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:


