### PR TITLE
NetCDF Provider: Report file path in unit conversion exception (NGWPC-7604)

### DIFF
--- a/include/forcing/NetCDFPerFeatureDataProvider.hpp
+++ b/include/forcing/NetCDFPerFeatureDataProvider.hpp
@@ -128,7 +128,7 @@ namespace data_access
         TimeUnit time_unit;                             // the unit that time was stored as in the file
         double time_stride;                             // the amount of time between stored time values
         utils::StreamHandler log_stream;
-
+        std::string file_path;
 
         std::shared_ptr<netCDF::NcFile> nc_file;
 

--- a/src/forcing/NetCDFPerFeatureDataProvider.cpp
+++ b/src/forcing/NetCDFPerFeatureDataProvider.cpp
@@ -38,9 +38,11 @@ void NetCDFPerFeatureDataProvider::cleanup_shared_providers()
     shared_providers.clear();
 }
 
-NetCDFPerFeatureDataProvider::NetCDFPerFeatureDataProvider(std::string input_path, time_t sim_start, time_t sim_end,  utils::StreamHandler log_s) : log_stream(log_s), value_cache(20),
-    sim_start_date_time_epoch(sim_start),
-    sim_end_date_time_epoch(sim_end)
+NetCDFPerFeatureDataProvider::NetCDFPerFeatureDataProvider(std::string input_path, time_t sim_start, time_t sim_end,  utils::StreamHandler log_s)
+    : log_stream(log_s)
+    , value_cache(20)
+    , sim_start_date_time_epoch(sim_start)
+    , sim_end_date_time_epoch(sim_end)
 {
     //size_t sizep = 1073741824, nelemsp = 202481;
     //float preemptionp = 0.75;

--- a/src/forcing/NetCDFPerFeatureDataProvider.cpp
+++ b/src/forcing/NetCDFPerFeatureDataProvider.cpp
@@ -423,7 +423,7 @@ double NetCDFPerFeatureDataProvider::get_value(const CatchmentAggrDataSelector& 
     catch (const std::runtime_error& e)
     {
         data_access::unit_conversion_exception uce(e.what());
-        uce.provider_model_name = "NetCDFPerFeatureDataProvider";
+        uce.provider_model_name = "NetCDFPerFeatureDataProvider(" + file_path + ")";
         uce.provider_bmi_var_name = selector.get_variable_name();
         uce.provider_units = native_units;
         uce.unconverted_values.push_back(rvalue);

--- a/src/forcing/NetCDFPerFeatureDataProvider.cpp
+++ b/src/forcing/NetCDFPerFeatureDataProvider.cpp
@@ -420,7 +420,7 @@ double NetCDFPerFeatureDataProvider::get_value(const CatchmentAggrDataSelector& 
     catch (const std::runtime_error& e)
     {
         data_access::unit_conversion_exception uce(e.what());
-        uce.provider_model_name = "NetCDFPerFeatureDataProvider " + catchment_id;
+        uce.provider_model_name = "NetCDFPerFeatureDataProvider";
         uce.provider_bmi_var_name = selector.get_variable_name();
         uce.provider_units = native_units;
         uce.unconverted_values.push_back(rvalue);

--- a/src/forcing/NetCDFPerFeatureDataProvider.cpp
+++ b/src/forcing/NetCDFPerFeatureDataProvider.cpp
@@ -40,6 +40,7 @@ void NetCDFPerFeatureDataProvider::cleanup_shared_providers()
 
 NetCDFPerFeatureDataProvider::NetCDFPerFeatureDataProvider(std::string input_path, time_t sim_start, time_t sim_end,  utils::StreamHandler log_s)
     : log_stream(log_s)
+    , file_path(input_path)
     , value_cache(20)
     , sim_start_date_time_epoch(sim_start)
     , sim_end_date_time_epoch(sim_end)


### PR DESCRIPTION
Report on unit conversion errors from the NetCDF provider in full, so users can see where the source units came from

## Additions

- NetCDF Provider: store the provided file path for later use

## Changes

- NetCDF Provider: replace mistaken copy-paste `catchment_id` with `file_path`
- Reformat the constructor arguments for clarity

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

