### PR TITLE
Remove attempt to import deprecated ngen_routing module (NGWPC-8286)

### DIFF
--- a/src/routing/Routing_Py_Adapter.cpp
+++ b/src/routing/Routing_Py_Adapter.cpp
@@ -16,25 +16,15 @@ Routing_Py_Adapter::Routing_Py_Adapter(std::string t_route_config_file_with_path
   t_route_config_path(t_route_config_file_with_path){
   //hold a reference to the interpreter, ensures an interpreter exists as long as the reference is held
   interpreter = utils::ngenPy::InterpreterUtil::getInstance();
-  //Import ngen_main.  Will throw error if module isn't available
-  //in the embedded interpreters PYTHON_PATH
+  // Import the routing module.  An error will be thrown if module isn't available
+  // in the embedded interpreters PYTHON_PATH
   try {
-    LOG("Trying t-route module ngen_routing.ngen_main.", LogLevel::INFO);
-    this->t_route_module = utils::ngenPy::InterpreterUtil::getPyModule("ngen_routing.ngen_main");
-    LOG("Routing module ngen_routing.ngen_main detected and used. Use of this version is deprecated!", LogLevel::WARNING);
+    this->t_route_module = utils::ngenPy::InterpreterUtil::getPyModule("nwm_routing.__main__");
+    LOG("Routing module nwm_routing.__main__ detected and used.", LogLevel::INFO);
   }
-  catch (const pybind11::error_already_set& e){
-    try {
-      LOG("Module ngen_routing.ngen_main not found; Trying different t-route module", LogLevel::WARNING);
-      LOG("Trying t-route module nwm_routing.__main__.", LogLevel::INFO);
-      // The legacy module has a `nwm_routing.__main__`, so we have to try this one second!
-      this->t_route_module = utils::ngenPy::InterpreterUtil::getPyModule("nwm_routing.__main__");
-      LOG("Routing module nwm_routing.__main__ detected and used.", LogLevel::INFO);
-    }
-    catch (const pybind11::error_already_set& e){
-      LOG("Unable to import a supported routing module.", LogLevel::SEVERE);
-      throw e;
-    }
+  catch (const pybind11::error_already_set& e) {
+    LOG("Unable to import a supported routing module.", LogLevel::FATAL);
+    throw e;
   }
 }
 

--- a/src/routing/Routing_Py_Adapter.cpp
+++ b/src/routing/Routing_Py_Adapter.cpp
@@ -19,17 +19,20 @@ Routing_Py_Adapter::Routing_Py_Adapter(std::string t_route_config_file_with_path
   //Import ngen_main.  Will throw error if module isn't available
   //in the embedded interpreters PYTHON_PATH
   try {
+    LOG("Trying t-route module ngen_routing.ngen_main.", LogLevel::INFO);
     this->t_route_module = utils::ngenPy::InterpreterUtil::getPyModule("ngen_routing.ngen_main");
-    LOG("Legacy t-route module detected; use of this version is deprecated!", LogLevel::WARNING);
+    LOG("Routing module ngen_routing.ngen_main detected and used. Use of this version is deprecated!", LogLevel::WARNING);
   }
   catch (const pybind11::error_already_set& e){
     try {
+      LOG("Module ngen_routing.ngen_main not found; Trying different t-route module", LogLevel::WARNING);
+      LOG("Trying t-route module nwm_routing.__main__.", LogLevel::INFO);
       // The legacy module has a `nwm_routing.__main__`, so we have to try this one second!
       this->t_route_module = utils::ngenPy::InterpreterUtil::getPyModule("nwm_routing.__main__");
-      LOG("Legacy t-route module nwm_routing.__main__ detected and used.", LogLevel::DEBUG);
+      LOG("Routing module nwm_routing.__main__ detected and used.", LogLevel::INFO);
     }
     catch (const pybind11::error_already_set& e){
-      LOG("Unable to import a supported routing module.", LogLevel::FATAL);
+      LOG("Unable to import a supported routing module.", LogLevel::SEVERE);
       throw e;
     }
   }


### PR DESCRIPTION
The newly added code to provide better detail when importing a python module exposed a sequence in the routing code that first tries to import the `ngen_routing` module, which has been deprecated, then the `nwm_routing`, which is successful. Per direction of Nels and Bobby at OWP, removed the initial attempt to use `ngen_routing` and default to importing `nwm_routing`.

## Changes

- Update LOG message wording.

## Removals

- Removed attempt to import a deprecated module and associated log messages

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

