### PR TITLE
partitioning subset hydrofabrics (NGWPC-6553)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -403,6 +403,7 @@ message(STATUS "----------------------------------------------------------------
 ngen_multiline_message(
 "NGen version: ${ngen_VERSION}"
 "Build configuration summary:"
+"  Source directory: ${CMAKE_SOURCE_DIR}"
 "  Generator: ${CMAKE_GENERATOR}"
 "  Build type: ${CMAKE_BUILD_TYPE}"
 "  System: ${CMAKE_SYSTEM_NAME}"

--- a/include/geojson/FeatureVisitor.hpp
+++ b/include/geojson/FeatureVisitor.hpp
@@ -9,6 +9,7 @@ namespace geojson {
     class MultiLineStringFeature;
     class MultiPolygonFeature;
     class CollectionFeature;
+    class SentinelFeature;
 
     /**
      * An abstract class used to operate on the children of FeatureBase
@@ -27,6 +28,7 @@ namespace geojson {
             virtual void visit(MultiLineStringFeature *feature) = 0;
             virtual void visit(MultiPolygonFeature *feature) = 0;
             virtual void visit(CollectionFeature* feature) = 0;
+            virtual void visit(SentinelFeature *feature) = 0;
 
             virtual ~FeatureVisitor() = default;
     };

--- a/include/geojson/features/FeatureBase.hpp
+++ b/include/geojson/features/FeatureBase.hpp
@@ -41,16 +41,21 @@ namespace geojson {
 
     /**
      *  Describes a type of features
+     *
+     *  These are numbered in accordance with the GeoPackage
+     *  'well-known binary' (WKB) feature types, other than the
+     *  additional 'Sentinel' value defined here
      */
     enum class FeatureType {
-        None,                   /*!< Represents an empty feature with no sort of geometry */
-        Point,                  /*!< Represents a feature that contains a single Point geometry */
-        LineString,             /*!< Represents a feature that is represented by a series of interconnected points */
-        Polygon,                /*!< Represents a feature that is represented by a defined area */
-        MultiPoint,             /*!< Represents a feature that is represented by many points */
-        MultiLineString,        /*!< Represents a feature that is represented by multiple series of interconnected points */
-        MultiPolygon,           /*!< Represents a feature that is represented by multiple areas */
-        GeometryCollection      /*!< Represents a feature that contains a collection of different types of geometry */
+        None                 = 0,  /*!< Represents an empty feature with no sort of geometry */
+        Point                = 1,  /*!< Represents a feature that contains a single Point geometry */
+        LineString           = 2,  /*!< Represents a feature that is represented by a series of interconnected points */
+        Polygon              = 3,  /*!< Represents a feature that is represented by a defined area */
+        MultiPoint           = 4,  /*!< Represents a feature that is represented by many points */
+        MultiLineString      = 5,  /*!< Represents a feature that is represented by multiple series of interconnected points */
+        MultiPolygon         = 6,  /*!< Represents a feature that is represented by multiple areas */
+        GeometryCollection   = 7,  /*!< Represents a feature that contains a collection of different types of geometry */
+        Sentinel             = 100 /*!< Represents a 'dummy' feature included for computational consistency */
     };
 
     /**

--- a/include/geojson/features/Features.hpp
+++ b/include/geojson/features/Features.hpp
@@ -9,5 +9,6 @@
 #include "MultiLineStringFeature.hpp"
 #include "MultiPolygonFeature.hpp"
 #include "CollectionFeature.hpp"
+#include "SentinelFeature.hpp"
 
 #endif // GEOJSON_FEATURE_H

--- a/include/geojson/features/SentinelFeature.hpp
+++ b/include/geojson/features/SentinelFeature.hpp
@@ -1,0 +1,29 @@
+#ifndef GEOJSON_SENTINEL_FEATURE_H
+#define GEOJSON_SENTINEL_FEATURE_H
+
+#include "FeatureBase.hpp"
+#include <FeatureVisitor.hpp>
+#include <JSONGeometry.hpp>
+
+#include <string>
+#include <vector>
+#include <map>
+#include <exception>
+
+namespace geojson {
+
+    class SentinelFeature : public FeatureBase {
+        public:
+            SentinelFeature(
+                std::string new_id
+            ) : FeatureBase(std::move(new_id)) {
+                this->type = geojson::FeatureType::Sentinel;
+            }
+
+            void visit(FeatureVisitor& visitor) override {
+                visitor.visit(this);
+            }
+    };
+}
+
+#endif // GEOJSON_SENTINEL_FEATURE_H

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -444,6 +444,13 @@ int main(int argc, char* argv[]) {
     // TODO: Instead of iterating through a collection of FeatureBase objects mapping to catchments,
     // we instead want to iterate through HY_Catchment objects
     geojson::GeoJSON catchment_collection;
+    // As part of the fix for NOAA-OWP/ngen#284 / NGWPC-6553,
+    // partitioning may insert sentinel flowpaths downstream of
+    // terminal nexuses. Those sentinels will not exist in the
+    // catchmentDataFile. Their listing in catchment_subset_ids works
+    // because the respective geoFOO::read() functions return the
+    // intersection of features in the file and the specified subset,
+    // rather than erroring on missing features.
     if (boost::algorithm::ends_with(catchmentDataFile, "gpkg")) {
 #if NGEN_WITH_SQLITE3
         try {

--- a/src/partitionGenerator.cpp
+++ b/src/partitionGenerator.cpp
@@ -134,8 +134,6 @@ void generate_partitions(network::Network& network, const int& num_partitions, c
     nexus_set.reserve(partition_size);
     std::string part_id, partition_str;
 
-    std::string up_nexus;
-    std::string down_nexus;
     for(const auto& catchment : network.filter("cat", network::SortOrder::TransposedDepthFirstPreorder)){
             if (partition < remainder)
                 partition_size = partition_size_plus1;
@@ -164,15 +162,7 @@ void generate_partitions(network::Network& network, const int& num_partitions, c
             counter++;
             if(counter == partition_size)
             {
-                //partgen_ss<<"nexus "<<nexus<<" is remote DOWN on partition "<<partition<<std::endl;
                 //FIXME partitioning shouldn't have to assume dendritic network
-                std::vector<std::string> destinations = network.get_destination_ids(catchment);
-                if(destinations.size() == 0){
-                    partgen_ss <<"Error: Catchment "<<catchment<<" has no destination nexus.\n";
-                    LOG(partgen_ss.str(), LogLevel::FATAL); partgen_ss.str("");
-                    exit(1);
-                }
-                down_nexus = destinations[0];
 
                 part_id = std::to_string(partition);  // Is id used?
                 partition_str = std::to_string(partition);
@@ -187,12 +177,6 @@ void generate_partitions(network::Network& network, const int& num_partitions, c
 
                 partition++;
                 counter = 0;
-                //partgen_ss<<"\nnexus "<<nexus<<" is remote UP on partition "<<partition<<std::endl;
-
-                //this nexus overlaps partitions
-                //Handled above by ensure all up/down stream nexuses are recorded
-                up_nexus = down_nexus;
-                //partgen_ss<<"\nin partition "<<partition<<":"<<std::endl;
             }
     }
 

--- a/src/partitionGenerator.cpp
+++ b/src/partitionGenerator.cpp
@@ -149,9 +149,7 @@ void generate_partitions(network::Network& network, const int& num_partitions, P
             }
             if(nexus_set.size() == 0){
                 partgen_ss <<"Error: Catchment "<<catchment<<" has no destination nexus.\n";
-                LOG(partgen_ss.str(), LogLevel::FATAL); partgen_ss.str("");
-
-                exit(1);
+                LOG(partgen_ss.str(), LogLevel::WARNING); partgen_ss.str("");
             }
             for( auto upstream : network.get_origination_ids(catchment) ){
                 nexus_set.emplace(upstream);
@@ -160,6 +158,8 @@ void generate_partitions(network::Network& network, const int& num_partitions, P
 
             //keep track of all the features in this partition
             catchment_set.emplace(catchment);
+            LOG(catchment + " placed in partition " + std::to_string(partition), LogLevel::DEBUG);
+
             counter++;
             if(counter == partition_size)
             {
@@ -533,6 +533,16 @@ int main(int argc, char* argv[])
 
     //The container holding all remote_connections
     std::vector<RemoteConnectionVec> remote_connections_vec;
+
+    for (int i = 0; i < num_partitions; ++i) {
+        partgen_ss << "Partition " << i << " catchments: " << catchment_part[i].size() << "\n";
+        for (auto& c : catchment_part[i])
+            partgen_ss << c << std::endl;
+        partgen_ss << "nexuses " << nexus_part[i].size() << "\n";
+        for (auto& n : nexus_part[i])
+            partgen_ss << n << std::endl;
+        LOG(partgen_ss.str(), LogLevel::DEBUG); partgen_ss.str("");
+    }
 
     int total_remotes = 0;
     // loop over all partitions by partition id

--- a/src/partitionGenerator.cpp
+++ b/src/partitionGenerator.cpp
@@ -107,15 +107,16 @@ void write_remote_connections(const PartitionVSet& catchment_part, const Partiti
  * 
  * @param network 
  * @param num_partitions 
- * @param num_catchments
- * @param catchment_part 
+ * @param catchment_part  - which catchments will be simulation on each partition
+ * @param nexus_part - which nexuses have contributing catchments on each partition
  */
-void generate_partitions(network::Network& network, const int& num_partitions, const int& num_catchments, PartitionVSet& catchment_part,
-     PartitionVSet& nexus_part)
+void generate_partitions(network::Network& network, const int& num_partitions, PartitionVSet& catchment_part, PartitionVSet& nexus_part)
 {
+    auto catchments = network.filter("cat", network::SortOrder::TransposedDepthFirstPreorder);
+
     int partition = 0;
     int counter = 0;
-    int total = num_catchments;
+    int total = size(catchments);
     int partition_size = total/num_partitions;
     int partition_size_norm = partition_size;
     int remainder;
@@ -134,7 +135,7 @@ void generate_partitions(network::Network& network, const int& num_partitions, c
     nexus_set.reserve(partition_size);
     std::string part_id, partition_str;
 
-    for(const auto& catchment : network.filter("cat", network::SortOrder::TransposedDepthFirstPreorder)){
+    for(const auto& catchment : catchments){
             if (partition < remainder)
                 partition_size = partition_size_plus1;
             else
@@ -526,7 +527,7 @@ int main(int argc, char* argv[])
     Network global_network(global_nexus_collection);
 
     //Generate the partitioning
-    generate_partitions(global_network, num_partitions, num_catchments, catchment_part, nexus_part);
+    generate_partitions(global_network, num_partitions, catchment_part, nexus_part);
 
     //global_network.print_network();
 

--- a/src/partitionGenerator.cpp
+++ b/src/partitionGenerator.cpp
@@ -474,11 +474,8 @@ int main(int argc, char* argv[])
 
     std::string link_key = "toid";
   
-    Network catchment_network(catchment_collection, &link_key);
     //Assumes dendritic, can add check in network if needed.
     PartitionVSet catchment_part, nexus_part;
-    
-    //catchment_network.print_network();
 
     //build the remote connections from network
     // read the nexus hydrofabric, reuse the catchments

--- a/test/geojson/FeatureCollection_Test.cpp
+++ b/test/geojson/FeatureCollection_Test.cpp
@@ -55,6 +55,10 @@ class Visitor : public geojson::FeatureVisitor {
             this->types.push_back("CollectionFeature");
         }
 
+        void visit(geojson::SentinelFeature *feature) override {
+            this->types.push_back("SentinelFeature");
+        }
+
         std::string get(int index) {
             if( index >= 0 && index < types.size() )
               return this->types[index];


### PR DESCRIPTION
Prior to this PR, partitioning a hydrofabric in which there was a nexus that had multiple contributing catchments and no downstream catchment could lead to corrupted run results if those catchments were spread across multiple processes.

Fixes: #284

## Additions

- `SentinelFeature` type for the placeholder GeoJSON features that have no geography or geometry associated with them

## Changes

- Detect potential victim nexuses in the `partitionGenerator` input, and add sentinel flowpaths downstream of them
- Elaborate the CMake summary print just a bit

## Removals

- Bits of dead code

## Testing

1. Output from `partitionGenerator` on test subset hydrofabric from bug report looks as intended

## Screenshots

```
{
    "partitions":[
        {"id":0,
        "cat-ids":["cat-2395", "cat-2404", "cat-1118", "cat-758", "cat-757", "cat-1257", "cat-1344", "cat-1057", "cat-1480", "cat-1962", "cat-1368", "wb-TERMINAL_SENTINEL-nex-759"],
        "nex-ids":["nex-758", "nex-757", "nex-759"],
        "remote-connections":[
            {"mpi-rank": 1, "nex-id": "nex-759", "cat-id": "cat-1002", "cat-direction": "orig_cat-to-nex"},
            {"mpi-rank": 1, "nex-id": "nex-759", "cat-id": "cat-1143", "cat-direction": "orig_cat-to-nex"},
            {"mpi-rank": 1, "nex-id": "nex-759", "cat-id": "cat-1221", "cat-direction": "orig_cat-to-nex"},
            {"mpi-rank": 1, "nex-id": "nex-759", "cat-id": "cat-1418", "cat-direction": "orig_cat-to-nex"}]}, 
        {"id":1,
        "cat-ids":["cat-1354", "cat-1454", "cat-1591", "cat-1002", "cat-1670", "cat-1001", "cat-1143", "cat-1221", "cat-2018", "cat-1858", "cat-1418"],
        "nex-ids":["nex-1001", "nex-1002", "nex-1143", "nex-1221", "nex-1418", "nex-759"],
        "remote-connections":[
            {"mpi-rank": 0, "nex-id": "nex-759", "cat-id": "wb-TERMINAL_SENTINEL-nex-759", "cat-direction": "nex-to-dest_cat"}]}    ]
}
```

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: