### PR TITLE
Reword output var unit conversion warning in Bmi_Multi_Formulation.hpp

### DIFF
--- a/include/realizations/catchment/Bmi_Multi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Multi_Formulation.hpp
@@ -588,7 +588,7 @@ namespace realization {
                 static bool no_conversion_message_logged = false;
                 if (!no_conversion_message_logged) {
                     no_conversion_message_logged = true;
-                    LOG("Emitting output variables from Bmi_Multi_Formulation without unit conversion - see NGWPC-7604", LogLevel::WARNING);
+                    LOG("Output variables do not have unit conversion. Capability not yet implemented in ngen.", LogLevel::WARNING);
                 }
                 return uce.unconverted_values[0];
             }


### PR DESCRIPTION
The warning message recently added for output variable unit conversion was not clear but referred the reader to a specific NGWPC Jira which addressed the issue. The message was attempting to indicate that output variables are written without unit conversions. This capability was not originally designed or implemented in ngen. Jira [NGWPC-8601](https://jira.nextgenwaterprediction.com/browse/NGWPC-8301) has been created in the backlog for future implementation. 

This PR addresses the fix to BMI_Multi_Formulation.hpp (PR # 47 addressed the fix to Bmi_Module_formulation.cpp)

## Changes

- Reworded warning message to be more clear and removed reference to the Jira.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: