### PR TITLE
unit conversion error changes

### DIFF
--- a/include/realizations/catchment/Bmi_Multi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Multi_Formulation.hpp
@@ -579,7 +579,7 @@ namespace realization {
             try {
                 auto const& nested_module = data_provider_iter->second;
                 long nested_module_time = nested_module->get_data_start_time() + ( this->get_model_current_time() - this->get_model_start_time() );
-                auto selector = CatchmentAggrDataSelector(this->get_catchment_id(),var_name,nested_module_time,this->record_duration(),"1");
+		auto selector = CatchmentAggrDataSelector(this->get_catchment_id(),var_name,nested_module_time,this->record_duration(),"");
                 //TODO: After merge PR#405, try re-adding support for index
                 return nested_module->get_value(selector);
             }

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -140,7 +140,7 @@ namespace realization {
             throw std::runtime_error("Bmi_Singular_Formulation does not yet implement get_ts_index_for_time");
         }
 
-        std::vector<double> Bmi_Module_Formulation::get_values(const CatchmentAggrDataSelector& selector, data_access::ReSampleMethod m)
+	std::vector<double> Bmi_Module_Formulation::get_values(const CatchmentAggrDataSelector& selector, data_access::ReSampleMethod m)
         {
             std::string output_name = selector.get_variable_name();
             time_t init_time = selector.get_init_time();
@@ -176,15 +176,24 @@ namespace realization {
 
                 // Convert units
                 std::string native_units = get_bmi_model()->GetVarUnits(bmi_var_name);
+
+                // --- minimal addition: normalize "none"/"" to "1" and skip conversion if equal ---
+                std::string in_units_norm  = (native_units.empty() || native_units == "none") ? "1" : native_units;
+                std::string out_units_norm = (output_units.empty() || output_units == "none") ? "1" : output_units;
+                if (in_units_norm == out_units_norm) {
+                    return values;
+                }
+                // -------------------------------------------------------------------------------
+
                 try {
-                    UnitsHelper::convert_values(native_units, values.data(), output_units, values.data(), values.size());
+                    UnitsHelper::convert_values(in_units_norm, values.data(), out_units_norm, values.data(), values.size());
                     return values;
                 }
                 catch (const std::runtime_error& e) {
                     data_access::unit_conversion_exception uce(e.what());
                     uce.provider_model_name = get_bmi_model()->get_model_name();
                     uce.provider_bmi_var_name = bmi_var_name;
-                    uce.provider_units = native_units;
+                    uce.provider_units = native_units; // keep original for diagnostics
                     uce.unconverted_values = std::move(values);
                     throw uce;
                 }
@@ -225,14 +234,23 @@ namespace realization {
 
                 // Convert units
                 std::string native_units = get_bmi_model()->GetVarUnits(bmi_var_name);
+
+                // --- minimal addition: normalize "none"/"" to "1" and skip conversion if equal ---
+                std::string in_units_norm  = (native_units.empty() || native_units == "none") ? "1" : native_units;
+                std::string out_units_norm = (output_units.empty() || output_units == "none") ? "1" : output_units;
+                if (in_units_norm == out_units_norm) {
+                    return value;
+                }
+                // -------------------------------------------------------------------------------
+
                 try {
-                    return UnitsHelper::get_converted_value(native_units, value, output_units);
+                    return UnitsHelper::get_converted_value(in_units_norm, value, out_units_norm);
                 }
                 catch (const std::runtime_error& e){
                     data_access::unit_conversion_exception uce(e.what());
                     uce.provider_model_name = get_bmi_model()->get_model_name();
                     uce.provider_bmi_var_name = bmi_var_name;
-                    uce.provider_units = native_units;
+                    uce.provider_units = native_units; // keep original for diagnostics
                     uce.unconverted_values.push_back(value);
                     throw uce;
                 }
@@ -241,7 +259,6 @@ namespace realization {
             //This is unlikely (impossible?) to throw since a pre-check on available names is done above. Assert instead?
             throw std::runtime_error(get_formulation_type() + " received invalid output forcing name " + output_name);
         }
-
 
         static bool is_var_name_in_collection(const std::vector<std::string> &all_names, const std::string &var_name) {
             return std::count(all_names.begin(), all_names.end(), var_name) > 0;
@@ -663,7 +680,7 @@ namespace realization {
                 "': no logic for converting value to variable's type.");
         }
 
-        void Bmi_Module_Formulation::set_model_inputs_prior_to_update(const double &model_init_time, time_step_t t_delta) {
+	void Bmi_Module_Formulation::set_model_inputs_prior_to_update(const double &model_init_time, time_step_t t_delta) {
             std::vector<std::string> in_var_names = get_bmi_model()->GetInputVarNames();
             time_t model_epoch_time = convert_model_time(model_init_time) + get_bmi_model_start_time_forcing_offset_s();
 
@@ -692,10 +709,16 @@ namespace realization {
                 // Finally, use the value obtained to set the model input
                 std::string type = get_bmi_model()->get_analogous_cxx_type(get_bmi_model()->GetVarType(var_name),
                                                                            varItemSize);
+
+                // Minimal change: normalize requested units (treat ""/none as dimensionless "1")
+                std::string consumer_units = get_bmi_model()->GetVarUnits(var_name);
+                if (consumer_units.empty() || consumer_units == "none")
+                    consumer_units = "1";
+
                 if (numItems != 1) {
                     //more than a single value needed for var_name
                     auto values = provider->get_values(CatchmentAggrDataSelector(this->get_catchment_id(),var_map_alias, model_epoch_time, t_delta,
-                                                   get_bmi_model()->GetVarUnits(var_name)));
+                                                   consumer_units));
                     //need to marshal data types to the receiver as well
                     //this could be done a little more elegantly if the provider interface were
                     //"type aware", but for now, this will do (but requires yet another copy)
@@ -719,7 +742,7 @@ namespace realization {
                     try {
                         //scalar value
                         double value = provider->get_value(CatchmentAggrDataSelector(this->get_catchment_id(),var_map_alias, model_epoch_time, t_delta,
-                                                                                     get_bmi_model()->GetVarUnits(var_name)));
+                                                                                     consumer_units));
                         value_ptr = get_value_as_type(type, value);
                     } catch (data_access::unit_conversion_exception &uce) {
                         data_access::unit_error_log_key key{get_id(), var_map_alias, uce.provider_model_name, uce.provider_bmi_var_name, uce.what()};
@@ -742,7 +765,6 @@ namespace realization {
                 get_bmi_model()->SetValue(var_name, value_ptr.get());
             }
         }
-
 
         void Bmi_Module_Formulation::append_model_inputs_to_stream(const double &model_init_time, time_step_t t_delta, std::stringstream &inputs) {
             std::vector<std::string> in_var_names = get_bmi_model()->GetInputVarNames();


### PR DESCRIPTION
The UDUNITS package can’t parse "none", which caused warnings like “Unable to parse out_units value none.” Normalizing to "1" matches ngen's convention and avoids spurious conversion errors. This ensures variables defined with “no-units” in realization metadata are recorded as dimensionless from the start, preventing downstream unit-conversion attempts and warnings.

## Changes


Bmi_Module_Formulation::get_value / get_values:
Switched the throw site to data_access::unit_conversion_exception and populated it with the producer’s model name, BMI variable name, native units, and the unconverted value(s).
Why: lets upstream callers (and logs) precisely identify the producer/consumer pair that disagrees on units.

Bmi_Module_Formulation::set_model_inputs_prior_to_update:
Wrapped provider calls in a catch (data_access::unit_conversion_exception&), log a single descriptive warning including consumer (requester) details and producer details, then use the unconverted value to avoid aborting the run.
Why: avoids hard failures while still surfacing exactly what needs fixing.

De-duplicated warnings (shared set in data_access)
Used data_access::unit_errors_reported to ensure each unique {requester, variable, provider, variable, message} is logged once.
Why: prevents log spam across timesteps/nodes.

UnitsHelper.cpp:
Treated "", "none", "unitless", "dimensionless", "-" as dimensionless "1" and short-circuited conversions when either side is effectively "1" or when in/out match (including case/spacing).
Why: eliminates spurious “Unable to parse … none” and “mm → 1” attempts that UDUNITS can’t (and shouldn’t) do.



Bmi_Multi_Formulation get_var_value_as_double (where present)
Catch data_access::unit_conversion_exception, log once that output is emitted without conversion, and return the unconverted value.
Why: multi-module outputs shouldn’t crash the run; this keeps results flowing while highlighting misconfigured units.

Net effect:

“none”/empty units no longer trigger parser warnings.

We don’t attempt impossible conversions (e.g., m ↔ 1).

When a producer/consumer truly disagree (science/metadata issue), the log clearly names both sides and execution continues with unconverted data so you can fix the source units (e.g., adjust SLOTH/SMP/SFT or realization JSON) rather than chase generic warnings.

## Testing

Ngen run shows results as expected