### PR TITLE
Fix inadvertent removal of catchment group option (NGWPC-8363)

### DIFF
--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -184,7 +184,7 @@ namespace realization {
                             #endif
                             continue;
                         }
-                        realization::config::Config catchment_formulation(catchment_config.second);
+                        realization::config::Config catchment_formulation(catchment_config.second, formulation_groups, forcing_groups);
 
                         if (!catchment_formulation.has_formulation()) {
                             std::string throw_msg;


### PR DESCRIPTION
The constructor for catchments that was replaced with the version that does not account for groups. It appears this was done accidentally, so this change adds back in use of the groups constructor.

## Changes

- Construct catchments with the option to use groups.

## Testing

1. As reported by Jeff @jswade-rtx 

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
