### PR TITLE
NGWPC-8301 Update formulation functions to work with a new units-specified json structure for output_variables

### DIFF
--- a/doc/BMI_MODELS.md
+++ b/doc/BMI_MODELS.md
@@ -156,7 +156,7 @@ There are some special BMI formulation config parameters which are required in c
     ```
 * `output_variables`
   * can specify the particular set and order of output variables to include in the realization's `get_output_line_for_timestep()` (and similar) function
-  * The new json structure contains an array of key-value pairs of output name, header in output file and units for conversion (if needed). The units has not been implemented yet. 
+  * The new JSON structure contains an array of key-value pairs of output name, header in output file and units for conversion (if needed). The units has not been implemented yet. 
   * The old JSON structure to mention the output variables as a list of strings is deprecated.
   * if not present, defaults to whatever it returned by the model's BMI `get_output_var_names()` function *the first time* it is invoked
   * if specified, must be at the **root** level of a formulation object.
@@ -165,21 +165,21 @@ There are some special BMI formulation config parameters which are required in c
     ```jsonc
     // Example for multi models formulation
     "output_variables": [
-		            {
+		        {
 			       "name": "SNEQV",
 			       "header": "WE_mm",
 			       "units": "mm"
-			    },
-			    {
-            "name": "soil_moisture_fraction",
-            "header": "sm_frac_0.4m",
-            "units":"1"
-	     		},
-	     		{
-            "name": "soil_moisture_fraction",
-            "header": "sm_profile_0.1m",
-            "units": "1"
-	     		    }
+            },
+            {
+              "name": "soil_moisture_fraction",
+              "header": "sm_frac_0.4m",
+              "units":"1"
+            },
+            {
+              "name": "soil_moisture_profile",
+              "header": "sm_profile_0.1m",
+              "units": "1"
+	     		  }
       ]
     ```
 * `output_header_fields`

--- a/doc/BMI_MODELS.md
+++ b/doc/BMI_MODELS.md
@@ -156,14 +156,31 @@ There are some special BMI formulation config parameters which are required in c
     ```
 * `output_variables`
   * can specify the particular set and order of output variables to include in the realization's `get_output_line_for_timestep()` (and similar) function
-  * JSON structure should be a list of strings
+  * The new json structure contains an array of key-value pairs of output name, header in output file and units for conversion (if needed). The units has not been implemented yet. 
+  * The old JSON structure to mention the output variables as a list of strings is deprecated.
   * if not present, defaults to whatever it returned by the model's BMI `get_output_var_names()` function *the first time* it is invoked
   * if specified, must be at the **root** level of a formulation object.
   * if specified for multi-BMI, it should be within the **formulation-root** config level, i.e. in the **root** config level for a given **formulation**.
   * e.g.,
     ```jsonc
-    // Example for CFE, which has 13 output variables
-    "output_variables": ["RAIN_RATE", "Q_OUT"]
+    // Example for multi models formulation
+    "output_variables": [
+		            {
+			       "name": "SNEQV",
+			       "header": "WE_mm",
+			       "units": "mm"
+			    },
+			    {
+            "name": "soil_moisture_fraction",
+            "header": "sm_frac_0.4m",
+            "units":"1"
+	     		},
+	     		{
+            "name": "soil_moisture_fraction",
+            "header": "sm_profile_0.1m",
+            "units": "1"
+	     		    }
+      ]
     ```
 * `output_header_fields`
   * can specify the header strings to use for the realization's printed output (i.e., the value returned by `get_output_header_line()`)

--- a/doc/REALIZATION_CONFIGURATION.md
+++ b/doc/REALIZATION_CONFIGURATION.md
@@ -52,6 +52,69 @@ The `global` key-value object must contain the following two object keys:
   }
 },  
 ```
+  * One of the `params` must be the `output_variables`. The legacy format contains the variables listed as a comma-separated list.
+  * Another `params` item must be the `output_header_fields`. The legacy format contains the headers listed as a comma-separated list.
+
+```
+"global": {
+        "formulations": [
+            {
+                "name": "bmi_multi", 
+                "params": {
+                    "name": "bmi_multi", 
+                    "model_type_name": "noah_smp_sft_cfex", 
+                    "main_output_variable": "Q_OUT", 
+                    "init_config": "", 
+                    "allow_exceed_end_time": false, 
+                    "fixed_time_step": false, 
+                    "uses_forcing_file": false, 
+                    "output_variables": [
+                        "SNEQV", 
+                        "soil_moisture_fraction", 
+                        "soil_moisture_profile"
+                    ], 
+                    "output_header_fields": [
+                        "SWE_mm", 
+                        "sm_frac_0.4m", 
+                        "sm_profile_0.1m"
+                    ],
+                  ---continued---  
+```
+  * The json format for `output_variables` has been updated to included information about the variables, headers and their units  as key-value pairs.
+  * The `output_header_fields` item is deprecated and a warning log message is added when the `output variables` are provided in the new format and the `output_header_fields` specified. 
+
+```
+"global": {
+        "formulations": [
+            {
+                "name": "bmi_multi", 
+                "params": {
+                    "name": "bmi_multi", 
+                    "model_type_name": "noah_smp_sft_cfex", 
+                    "main_output_variable": "Q_OUT", 
+                    "init_config": "", 
+                    "allow_exceed_end_time": false, 
+                    "fixed_time_step": false, 
+                    "uses_forcing_file": false,
+                    "output_variables": [
+		                {
+                        "name": "SNEQV",
+                        "header": "WE_mm",
+                        "units": "mm"
+                    },
+                    {
+                      "name": "soil_moisture_fraction",
+                      "header": "sm_frac_0.4m",
+                      "units":"1"
+                    },
+                    {
+                      "name": "soil_moisture_fraction",
+                      "header": "sm_profile_0.1m",
+                      "units": "1"
+                    }
+             	    ],
+              ---continued---
+```
 
 The `time` key-value object must contain the following three keys:
 * `start_time`

--- a/doc/REALIZATION_CONFIGURATION.md
+++ b/doc/REALIZATION_CONFIGURATION.md
@@ -81,7 +81,7 @@ The `global` key-value object must contain the following two object keys:
                   ---continued---  
 ```
   * The json format for `output_variables` has been updated to included information about the variables, headers and their units  as key-value pairs.
-  * The `output_header_fields` item is deprecated and a warning log message is added when the `output variables` are provided in the new format and the `output_header_fields` specified. 
+  * The `output_header_fields` item is deprecated and a warning log message is added when the `output_variables` are provided in the new format and the `output_header_fields` specified. 
 
 ```
 "global": {
@@ -108,7 +108,7 @@ The `global` key-value object must contain the following two object keys:
                       "units":"1"
                     },
                     {
-                      "name": "soil_moisture_fraction",
+                      "name": "soil_moisture_profile",
                       "header": "sm_profile_0.1m",
                       "units": "1"
                     }

--- a/include/core/mediator/UnitsHelper.hpp
+++ b/include/core/mediator/UnitsHelper.hpp
@@ -32,7 +32,7 @@ class UnitsHelper {
 
     static double* convert_values(const std::string &in_units, double* values, const std::string &out_units, double* out_values, const size_t & count);
 
-    static bool cannot_parse(const std::string &in_units);
+    static bool can_parse(const std::string &in_units);
 
     private:
      

--- a/include/core/mediator/UnitsHelper.hpp
+++ b/include/core/mediator/UnitsHelper.hpp
@@ -32,6 +32,8 @@ class UnitsHelper {
 
     static double* convert_values(const std::string &in_units, double* values, const std::string &out_units, double* out_values, const size_t & count);
 
+    static bool cannot_parse(const std::string &in_units);
+
     private:
      
     // Theoretically thread-safe. //TODO: Test?

--- a/include/realizations/catchment/Bmi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Formulation.hpp
@@ -264,6 +264,10 @@ namespace realization {
             output_variable_names = out_var_names;
         }
 
+        void set_output_variable_units(const std::vector<std::string> &output_units) {
+            output_variable_units = output_units;
+        }
+
     private:
 
         std::string bmi_main_output_var;
@@ -273,6 +277,11 @@ namespace realization {
          * `output_variable_names`.
          */
         std::vector<std::string> output_header_fields;
+        /**
+         * Output units for the variables output by the realization, as defined in
+         * `output_variables`.
+         */
+        std::vector<std::string> output_variable_units;
         /**
          * Names of the variables to include in the output from this formulation, which will be some ordered subset of
          * the BMI module output variables accessible to the instance.

--- a/include/realizations/catchment/Bmi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Formulation.hpp
@@ -21,7 +21,6 @@
 #define BMI_REALIZATION_CFG_PARAM_OPT__VAR_STD_NAMES "variables_names_map"
 // TODO: change this (and output_header_fields) to something like output_file_variables to distinguish from BMI output variables
 #define BMI_REALIZATION_CFG_PARAM_OPT__OUT_VARS "output_variables"
-#define BMI_REALIZATION_CFG_PARAM_OPT__OUT_NEW_VARS "output_variables_new"
 #define BMI_REALIZATION_CFG_PARAM_OPT__OUT_HEADER_FIELDS "output_header_fields"
 #define BMI_REALIZATION_CFG_PARAM_OPT__OUTPUT_PRECISION "output_precision"
 #define BMI_REALIZATION_CFG_PARAM_OPT__ALLOW_EXCEED_END "allow_exceed_end_time"

--- a/include/realizations/catchment/Bmi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Formulation.hpp
@@ -21,6 +21,7 @@
 #define BMI_REALIZATION_CFG_PARAM_OPT__VAR_STD_NAMES "variables_names_map"
 // TODO: change this (and output_header_fields) to something like output_file_variables to distinguish from BMI output variables
 #define BMI_REALIZATION_CFG_PARAM_OPT__OUT_VARS "output_variables"
+#define BMI_REALIZATION_CFG_PARAM_OPT__OUT_NEW_VARS "output_variables_new"
 #define BMI_REALIZATION_CFG_PARAM_OPT__OUT_HEADER_FIELDS "output_header_fields"
 #define BMI_REALIZATION_CFG_PARAM_OPT__OUTPUT_PRECISION "output_precision"
 #define BMI_REALIZATION_CFG_PARAM_OPT__ALLOW_EXCEED_END "allow_exceed_end_time"

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -255,6 +255,7 @@ namespace realization {
         const boost::span<char> get_serialization_state() const;
         void load_serialization_state(const boost::span<char> state) const;
         void free_serialization_state() const;
+        void set_realization_file_format(bool is_legacy_format);
 
     protected:
 
@@ -356,8 +357,6 @@ namespace realization {
          */
         bool is_model_initialized() const override;
 
-        bool is_realization_legacy_format() const;
-
         void set_allow_model_exceed_end_time(bool allow_exceed_end);
 
         void set_bmi_init_config(const std::string &init_config);
@@ -372,8 +371,6 @@ namespace realization {
         void set_bmi_model_start_time_forcing_offset_s(const time_t &offset_s);
 
         void set_bmi_model_time_step_fixed(bool is_fix_time_step);
-
-        void set_realization_file_format(bool is_legacy_format);
 
         /**
          * Set whether the backing model object has been initialize using the BMI standard ``Initialize`` function.
@@ -470,6 +467,8 @@ namespace realization {
          */
         int next_time_step_index = 0;
 
+        bool is_realization_legacy_format() const;
+
     private:
         /**
          * Whether model ``Update`` calls are allowed and handled in some way by the backing model for time steps after
@@ -491,6 +490,9 @@ namespace realization {
         std::map<std::string, std::string> bmi_var_names_map;
         bool model_initialized = false;
 
+        /** Whether the realization file follows legacy format or the new format. */
+        bool legacy_json_format = false;
+
         std::vector<std::string> OPTIONAL_PARAMETERS = {
                 BMI_REALIZATION_CFG_PARAM_OPT__USES_FORCINGS
                 BMI_REALIZATION_CFG_PARAM_OPT__FORCING_FILE,
@@ -507,9 +509,6 @@ namespace realization {
                 BMI_REALIZATION_CFG_PARAM_REQ__MAIN_OUT_VAR,
                 BMI_REALIZATION_CFG_PARAM_REQ__MODEL_TYPE,
         };
-
-        /** Whether the realization file follows legacy format or the new format. */
-        bool legacy_json_format = false;
 
     };
 /*

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -356,6 +356,8 @@ namespace realization {
          */
         bool is_model_initialized() const override;
 
+        bool is_realization_legacy_format() const;
+
         void set_allow_model_exceed_end_time(bool allow_exceed_end);
 
         void set_bmi_init_config(const std::string &init_config);
@@ -370,6 +372,8 @@ namespace realization {
         void set_bmi_model_start_time_forcing_offset_s(const time_t &offset_s);
 
         void set_bmi_model_time_step_fixed(bool is_fix_time_step);
+
+        void set_realization_file_format(bool is_legacy_format);
 
         /**
          * Set whether the backing model object has been initialize using the BMI standard ``Initialize`` function.
@@ -503,6 +507,9 @@ namespace realization {
                 BMI_REALIZATION_CFG_PARAM_REQ__MAIN_OUT_VAR,
                 BMI_REALIZATION_CFG_PARAM_REQ__MODEL_TYPE,
         };
+
+        /** Whether the realization file follows legacy format or the new format. */
+        bool legacy_json_format = false;
 
     };
 /*

--- a/include/realizations/catchment/Bmi_Multi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Multi_Formulation.hpp
@@ -444,6 +444,8 @@ namespace realization {
          */
         bool is_model_initialized() const override;
 
+        void set_realization_file_format(bool is_legacy_format);
+
         /**
          * Get whether a property's per-time-step values are each an aggregate sum over the entire time step.
          *
@@ -479,6 +481,8 @@ namespace realization {
          * @return Whether this time step goes beyond this formulations (i.e., any of it's modules') end time.
          */
         bool is_time_step_beyond_end_time(time_step_t t_index);
+
+
 
         /**
          * Get the index of the primary module.
@@ -718,6 +722,8 @@ namespace realization {
          */
         std::map<std::string, std::shared_ptr<data_access::GenericDataProvider>> availableData;
 
+        bool is_realization_legacy_format() const;
+
     private:
 
         /**
@@ -804,6 +810,9 @@ namespace realization {
         int next_time_step_index = 0;
         /** The index of the "primary" nested module, used when functionality is deferred to a particular module's behavior. */
         int primary_module_index = -1;
+
+        /** Whether the realization file follows legacy format or the new format. */
+        bool legacy_json_format = false;
 
         friend Bmi_Multi_Formulation_Test;
         friend class ::Bmi_Cpp_Multi_Array_Test;

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -482,9 +482,7 @@ int main(int argc, char* argv[]) {
     std::shared_ptr<realization::Formulation_Manager> manager =
         std::make_shared<realization::Formulation_Manager>(REALIZATION_CONFIG_PATH);
     manager->read(catchment_collection, utils::getStdOut());
-    ss << "Ending formulations" << std::endl;
-    LOG(ss.str(), LogLevel::INFO);
-    return 0;
+
 // TODO refactor manager->read so certain configs can be queried before the entire
 // realization collection is created
 #if NGEN_WITH_ROUTING

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -482,7 +482,9 @@ int main(int argc, char* argv[]) {
     std::shared_ptr<realization::Formulation_Manager> manager =
         std::make_shared<realization::Formulation_Manager>(REALIZATION_CONFIG_PATH);
     manager->read(catchment_collection, utils::getStdOut());
-
+    ss << "Ending formulations" << std::endl;
+    LOG(ss.str(), LogLevel::INFO);
+    return 0;
 // TODO refactor manager->read so certain configs can be queried before the entire
 // realization collection is created
 #if NGEN_WITH_ROUTING

--- a/src/core/mediator/UnitsHelper.cpp
+++ b/src/core/mediator/UnitsHelper.cpp
@@ -107,3 +107,10 @@ double* UnitsHelper::convert_values(const std::string &in_units, double* in_valu
 
     return out_values;
 }
+
+bool UnitsHelper::cannot_parse(const std::string &in_units)
+{
+    std::call_once(unit_system_inited, init_unit_system);
+    ut_unit* from = ut_parse(unit_system, in_units.c_str(), UT_UTF8);
+    return (from == NULL) ? true : false;
+}

--- a/src/core/mediator/UnitsHelper.cpp
+++ b/src/core/mediator/UnitsHelper.cpp
@@ -112,5 +112,5 @@ bool UnitsHelper::can_parse(const std::string &in_units)
 {
     std::call_once(unit_system_inited, init_unit_system);
     ut_unit* from = ut_parse(unit_system, in_units.c_str(), UT_UTF8);
-    return (from == NULL) ? false : true;
+    return from != NULL;
 }

--- a/src/core/mediator/UnitsHelper.cpp
+++ b/src/core/mediator/UnitsHelper.cpp
@@ -108,9 +108,9 @@ double* UnitsHelper::convert_values(const std::string &in_units, double* in_valu
     return out_values;
 }
 
-bool UnitsHelper::cannot_parse(const std::string &in_units)
+bool UnitsHelper::can_parse(const std::string &in_units)
 {
     std::call_once(unit_system_inited, init_unit_system);
     ut_unit* from = ut_parse(unit_system, in_units.c_str(), UT_UTF8);
-    return (from == NULL) ? true : false;
+    return (from == NULL) ? false : true;
 }

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -384,32 +384,63 @@ namespace realization {
             determine_model_time_offset();
 
             // Output variable subset and order, if present
+            bool old_json_format = false;
+            std::vector<std::string> out_headers;//define empty vector for headers
+            std::vector<std::string> out_units;//define empty vector for units for new json structure
             auto out_var_it = properties.find(BMI_REALIZATION_CFG_PARAM_OPT__OUT_VARS);
             if (out_var_it != properties.end()) {
                 std::vector<geojson::JSONProperty> out_vars_json_list = out_var_it->second.as_list();
+                //Check if the first item is an object type or string type.
+                //string type: old format; object type: new format
+                if (out_vars_json_list.size() > 0){
+                    std::string item_type = get_propertytype_name(out_vars_json_list[0].get_type());
+                    if (item_type == "String"){
+                        old_json_format = true;
+                    }
+                }
                 std::vector<std::string> out_vars(out_vars_json_list.size());
-                for (int i = 0; i < out_vars_json_list.size(); ++i) {
-                    out_vars[i] = out_vars_json_list[i].as_string();
+                if (old_json_format){
+                    for (int i = 0; i < out_vars_json_list.size(); ++i) {
+                        out_vars[i] = out_vars_json_list[i].as_string();
+                    }
+                }
+                else{
+                    out_headers.resize(out_vars_json_list.size()); //assumption: number of vars = number of headers
+                    out_units.resize(out_vars_json_list.size()); //assumption: number of vars = number of units
+                    for (int i = 0; i < out_vars_json_list.size(); ++i) {
+                        out_vars[i] = out_vars_json_list[i].at("name").as_string();
+                        out_headers[i] = out_vars_json_list[i].at("header").as_string();
+                        out_units[i] = out_vars_json_list[i].at("units").as_string();
+                    }
                 }
                 set_output_variable_names(out_vars);
+                set_output_header_fields(out_headers);
             }
-                // Otherwise, just take what literally is provided by the model
+            // Otherwise, just take what literally is provided by the model
             else {
                 set_output_variable_names(get_bmi_model()->GetOutputVarNames());
             }
 
             // Output header fields, if present
-            auto out_headers_it = properties.find(BMI_REALIZATION_CFG_PARAM_OPT__OUT_HEADER_FIELDS);
-            if (out_headers_it != properties.end()) {
-                std::vector<geojson::JSONProperty> out_headers_json_list = out_var_it->second.as_list();
-                std::vector<std::string> out_headers(out_headers_json_list.size());
-                for (int i = 0; i < out_headers_json_list.size(); ++i) {
-                    out_headers[i] = out_headers_json_list[i].as_string();
+            if(old_json_format){
+                auto out_headers_it = properties.find(BMI_REALIZATION_CFG_PARAM_OPT__OUT_HEADER_FIELDS);
+                if (out_headers_it != properties.end()) {
+                    std::vector<geojson::JSONProperty> out_headers_json_list = out_var_it->second.as_list();
+                    std::vector<std::string> out_headers(out_headers_json_list.size());
+                    for (int i = 0; i < out_headers_json_list.size(); ++i) {
+                        out_headers[i] = out_headers_json_list[i].as_string();
+                    }
+                    set_output_header_fields(out_headers);
                 }
-                set_output_header_fields(out_headers);
+                else {
+                    set_output_header_fields(get_output_variable_names());
+                }
             }
-            else {
+            else{
+                // if new format and no output/headers are mentioned.
                 set_output_header_fields(get_output_variable_names());
+            }
+
             }
 
             // Output precision, if present

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -441,8 +441,6 @@ namespace realization {
                 set_output_header_fields(get_output_variable_names());
             }
 
-            }
-
             // Output precision, if present
             auto out_precision_it = properties.find(BMI_REALIZATION_CFG_PARAM_OPT__OUTPUT_PRECISION);
             if (out_precision_it != properties.end()) {

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -419,8 +419,8 @@ namespace realization {
                             //in such cases, we assign variable name to the header.
                             out_headers[i] = out_vars[i];
                             std::stringstream ss;
-                            ss << "Header not provided for " << out_vars[i] << ". Using the variable name as header." << std::endl;
-                            LOG(ss.str(), LogLevel::WARNING); ss.str("");
+                            ss << "Header not provided for '" << out_vars[i] << "'. Using the variable name as header." << std::endl;
+                            LOG(ss.str(), LogLevel::INFO); ss.str("");
                         }
                         out_units[i] = out_vars_json_list[i].at("units").as_string();
                     }

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -427,7 +427,7 @@ namespace realization {
                     //check if the units can be parsed correctly and write a warning message
                     std::stringstream ss;
                     for (const std::string& out_unit : out_units) {
-                        if (UnitsHelper::cannot_parse(out_unit))
+                        if (!UnitsHelper::can_parse(out_unit))
                         {
                             ss << "Unable to parse '" << out_unit << "' in units value." << std::endl;
                             LOG(ss.str(), LogLevel::WARNING); ss.str("");

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -424,6 +424,16 @@ namespace realization {
                         }
                         out_units[i] = out_vars_json_list[i].at("units").as_string();
                     }
+                    //check if the units can be parsed correctly and write a warning message
+                    std::stringstream ss;
+                    for (const std::string& out_unit : out_units) {
+                        if (UnitsHelper::cannot_parse(out_unit))
+                        {
+                            ss << "Unable to parse '" << out_unit << "' in units value." << std::endl;
+                            LOG(ss.str(), LogLevel::WARNING); ss.str("");
+                        }
+                    }
+                    set_output_variable_units(out_units);
                 }
                 set_output_variable_names(out_vars);
                 set_output_header_fields(out_headers);

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -100,9 +100,9 @@ void Bmi_Multi_Formulation::create_multi_formulation(geojson::PropertyMap proper
     // TODO: get synced end_time values for all models
 
     // Setup formulation output variable subset and order, if present
-    bool old_format = false;
+    bool old_json_format = false;
     std::vector<std::string> out_headers;//define empty vector for headers
-    std::vector<std::string> out_units;//define empty vector for headers for new format
+    std::vector<std::string> out_units;//define empty vector for units for new json structure
     auto out_var_it = properties.find(BMI_REALIZATION_CFG_PARAM_OPT__OUT_VARS);
     if (out_var_it != properties.end()) {
         std::vector<geojson::JSONProperty> out_vars_json_list = out_var_it->second.as_list();
@@ -111,11 +111,11 @@ void Bmi_Multi_Formulation::create_multi_formulation(geojson::PropertyMap proper
         if (out_vars_json_list.size() > 0){
             std::string item_type = get_propertytype_name(out_vars_json_list[0].get_type());
             if (item_type == "String"){
-                old_format = true;
+                old_json_format = true;
             }
         }
         std::vector<std::string> out_vars(out_vars_json_list.size());
-        if (old_format){
+        if (old_json_format){
             for (int i = 0; i < out_vars_json_list.size(); ++i) {
                 out_vars[i] = out_vars_json_list[i].as_string();
             }
@@ -143,7 +143,7 @@ void Bmi_Multi_Formulation::create_multi_formulation(geojson::PropertyMap proper
     //  a certain case).
 
     // Output header fields, if present
-    if(old_format){
+    if(old_json_format){
         auto out_headers_it = properties.find(BMI_REALIZATION_CFG_PARAM_OPT__OUT_HEADER_FIELDS);
         if (out_headers_it != properties.end()) {
             std::vector<geojson::JSONProperty> out_headers_json_list = out_headers_it->second.as_list();
@@ -170,7 +170,9 @@ void Bmi_Multi_Formulation::create_multi_formulation(geojson::PropertyMap proper
     else{
         //in new format, if headers are not set. 
         //This happens when the the BMI output variables of the last nested module should be used.
-        set_output_header_fields(get_output_variable_names());
+        if(out_headers.size() == 0){
+            set_output_header_fields(get_output_variable_names());
+        }
     }
 
     // Output precision, if present

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -138,6 +138,16 @@ void Bmi_Multi_Formulation::create_multi_formulation(geojson::PropertyMap proper
                 }
                 out_units[i] = out_vars_json_list[i].at("units").as_string();
             }
+            //check if the units can be parsed correctly and write a warning message
+            std::stringstream ss;
+            for (const std::string& out_unit : out_units) {
+                if (UnitsHelper::cannot_parse(out_unit))
+                {
+                    ss << "Unable to parse '" << out_unit << "' in units value." << std::endl;
+                    LOG(ss.str(), LogLevel::WARNING); ss.str("");
+                }
+            }
+            set_output_variable_units(out_units);
         }
         set_output_variable_names(out_vars);
         set_output_header_fields(out_headers);
@@ -189,7 +199,7 @@ void Bmi_Multi_Formulation::create_multi_formulation(geojson::PropertyMap proper
             LOG("Deprecated output_header_fields item found in realization file ignored.", LogLevel::WARNING);
         }
     }
-
+    
     // Output precision, if present
     auto out_precision_it = properties.find(BMI_REALIZATION_CFG_PARAM_OPT__OUTPUT_PRECISION);
     if (out_precision_it != properties.end()) {

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -141,7 +141,7 @@ void Bmi_Multi_Formulation::create_multi_formulation(geojson::PropertyMap proper
             //check if the units can be parsed correctly and write a warning message
             std::stringstream ss;
             for (const std::string& out_unit : out_units) {
-                if (UnitsHelper::cannot_parse(out_unit))
+                if (!UnitsHelper::can_parse(out_unit))
                 {
                     ss << "Unable to parse '" << out_unit << "' in units value." << std::endl;
                     LOG(ss.str(), LogLevel::WARNING); ss.str("");

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -114,6 +114,9 @@ void Bmi_Multi_Formulation::create_multi_formulation(geojson::PropertyMap proper
         is_out_vars_from_last_mod = true;
         set_output_variable_names(modules.back()->get_output_variable_names());
     }
+    std::stringstream ss_test;
+    ss_test << "Number of output variable names " << get_output_variable_names().size() << std::endl;
+    LOG(ss_test.str(), LogLevel::INFO); ss_test.str("");
     // TODO: consider warning if nested module formulations have formulation output variables, as that level of the
     //  config is (at present) going to be ignored (though strictly speaking, this doesn't apply to the last module in
     //  a certain case).

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -114,9 +114,25 @@ void Bmi_Multi_Formulation::create_multi_formulation(geojson::PropertyMap proper
         is_out_vars_from_last_mod = true;
         set_output_variable_names(modules.back()->get_output_variable_names());
     }
+
+    auto out_var_it = properties.find(BMI_REALIZATION_CFG_PARAM_OPT__OUT_NEW_VARS);
     std::stringstream ss_test;
-    ss_test << "Number of output variable names " << get_output_variable_names().size() << std::endl;
-    LOG(ss_test.str(), LogLevel::INFO); ss_test.str("");
+    if (out_var_it != properties.end()) {
+        std::vector<geojson::JSONProperty> out_vars_json_list = out_var_it->second.as_list();
+        std::vector<std::string> out_vars(out_vars_json_list.size());
+        for (int i = 0; i < out_vars_json_list.size(); ++i) {
+            out_vars[i] = out_vars_json_list[i].as_string();
+            ss_test << "Output variable name: " << out_vars[i] << std::endl;
+            LOG(ss_test.str(), LogLevel::INFO); ss_test.str("");
+        }
+        set_output_variable_names(out_vars);
+    }
+    // Otherwise, for multi BMI, the BMI output variables of the last nested module should be used.
+    else {
+        //is_out_vars_from_last_mod = true;
+        //set_output_variable_names(modules.back()->get_output_variable_names());
+    }
+    
     // TODO: consider warning if nested module formulations have formulation output variables, as that level of the
     //  config is (at present) going to be ignored (though strictly speaking, this doesn't apply to the last module in
     //  a certain case).

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -167,7 +167,7 @@ void Bmi_Multi_Formulation::create_multi_formulation(geojson::PropertyMap proper
             }
             else {
                 std::stringstream ss;
-                ss << "configured output headers have " << out_headers.size() << " fields, but there are "
+                ss << "Configured output headers have " << out_headers.size() << " fields, but there are "
                         << get_output_variable_names().size() << " variables in the output" << std::endl;
                 LOG(ss.str(), LogLevel::WARNING); ss.str("");
                 set_output_header_fields(get_output_variable_names());


### PR DESCRIPTION
Implemented functionality to be able to read a new json structure in realization file to specify output variables with their expected units. It is also expected to be backward compatible with the existing format.

## Changes
- BMI_Multi_Formulation.cpp, BMI_Module_Forumulation.cpp: Read the new or old format
- Check the units specified for ability to parse

## Testing

1.Tested with both the formats using the CNF data and the ngen ran successfully and produced output as expected.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
