### PR TITLE
Optional Catchment CSV Outputs (NGWPC-8769)

### DIFF
--- a/include/core/DomainLayer.hpp
+++ b/include/core/DomainLayer.hpp
@@ -43,7 +43,8 @@ namespace ngen
                 std::shared_ptr<realization::Catchment_Formulation> formulation):
                     Layer(desc, s_t, features, idx), formulation(formulation)
         {
-            formulation->write_output("Time Step,""Time,"+formulation->get_output_header_line(",")+"\n");
+            if (formulation->get_output_header_count() > 0)
+                formulation->write_output("Time Step,""Time,"+formulation->get_output_header_line(",")+"\n");
         }
 
         /***

--- a/include/core/DomainLayer.hpp
+++ b/include/core/DomainLayer.hpp
@@ -73,10 +73,12 @@ namespace ngen
                             +" at domain layer "+description.name
                             +" (layer id: "+std::to_string(description.id)+")";
                 throw models::external::State_Exception(msg);
-            } 
-            std::string output = std::to_string(output_time_index)+","+current_timestamp+","+
-            formulation->get_output_line_for_timestep(output_time_index)+"\n";
-            formulation->write_output(output);
+            }
+            if (formulation->get_output_header_count() > 0) {
+                std::string output = std::to_string(output_time_index)+","+current_timestamp+","
+                    + formulation->get_output_line_for_timestep(output_time_index)+"\n";
+                formulation->write_output(output);
+            }
             ++output_time_index;
             if ( output_time_index < simulation_time.get_total_output_times() )
             {

--- a/include/core/Layer.hpp
+++ b/include/core/Layer.hpp
@@ -137,9 +137,12 @@ namespace ngen
                 int results_index = catchment_indexes[id];
                 catchment_outflows[results_index] += response;
 #endif // NGEN_WITH_ROUTING
-                std::string output = std::to_string(output_time_index)+","+current_timestamp+","+
-                                    r_c->get_output_line_for_timestep(output_time_index)+"\n";
-                r_c->write_output(output);
+                if (r_c->get_output_header_count() > 0) {
+                    // only write output if config specifies output values
+                    std::string output = std::to_string(output_time_index)+","+current_timestamp+","+
+                                        r_c->get_output_line_for_timestep(output_time_index)+"\n";
+                    r_c->write_output(output);
+                }
                 //TODO put this somewhere else.  For now, just trying to ensure we get m^3/s into nexus output
                 double area;
                 try{

--- a/include/core/SurfaceLayer.hpp
+++ b/include/core/SurfaceLayer.hpp
@@ -16,11 +16,9 @@ namespace ngen
                 feature_type& f, 
                 geojson::GeoJSON cd, 
                 long idx,
-                const std::vector<std::string>& n_u,
-                std::unordered_map<std::string, std::ofstream>& output_files) : 
+                const std::vector<std::string>& n_u) : 
                     Layer(desc,p_u,s_t,f,cd,idx), 
-                    nexus_ids(n_u), 
-                    nexus_outfiles(output_files)
+                    nexus_ids(n_u)
         {
 
         }
@@ -37,7 +35,6 @@ namespace ngen
         private:
 
         std::vector<std::string> nexus_ids;
-        std::unordered_map<std::string, std::ofstream>& nexus_outfiles;
     };
 }
 

--- a/include/realizations/catchment/Bmi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Formulation.hpp
@@ -159,6 +159,10 @@ namespace realization {
             return boost::algorithm::join(get_output_header_fields(), delimiter);
         }
 
+        size_t get_output_header_count() const override {
+            return get_output_header_fields().size();
+        }
+
         /**
          * Get the names of variables in formulation output.
          *

--- a/include/realizations/catchment/Catchment_Formulation.hpp
+++ b/include/realizations/catchment/Catchment_Formulation.hpp
@@ -92,6 +92,19 @@ namespace realization {
             }
 
             /**
+             * Get get a count of fields that will be included by ``get_output_header_line``.
+             *
+             * Note that like the output generating function, this line does not include anything for time step.
+             *
+             * A default implementation is provided for inheritors of this type, which includes only "Total Discharge."
+             *
+             * @return The number of fields included in the header output.
+             */
+            virtual size_t get_output_header_count() const {
+                return 1;
+            }
+
+            /**
              * Get a formatted line of output values for the given time step as a delimited string.
              *
              * This method is useful for preparing calculated data in a representation useful for output files, such as

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -63,8 +63,6 @@ int mpi_num_procs;
 #include <SurfaceLayer.hpp>
 std::stringstream ss("");
 
-std::unordered_map<std::string, std::ofstream> nexus_outfiles;
-
 void ngen::exec_info::runtime_summary(std::ostream& stream) noexcept {
     stream << "Runtime configuration summary:\n";
 
@@ -547,27 +545,6 @@ int main(int argc, char* argv[]) {
 
     nexus_collection.reset();
 
-    // Still hacking nexus output for the moment
-    for (const auto& id : features.nexuses()) {
-#if NGEN_WITH_MPI
-        if (mpi_num_procs > 1) {
-            if (!features.is_remote_sender_nexus(id)) {
-                nexus_outfiles[id].open(
-                    manager->get_output_root() + id + "_output.csv",
-                    std::ios::trunc
-                );
-            }
-        } else {
-            nexus_outfiles[id].open(
-                manager->get_output_root() + id + "_output.csv",
-                std::ios::trunc
-            );
-        }
-#else
-        nexus_outfiles[id].open(manager->get_output_root() + id + "_output.csv", std::ios::trunc);
-#endif
-    }
-
     ss << "Running Models" << std::endl;
     LOG(ss.str(), LogLevel::INFO);
     ss.str("");
@@ -639,8 +616,7 @@ int main(int argc, char* argv[]) {
                     features,
                     catchment_collection,
                     0,
-                    nexus_subset_ids,
-                    nexus_outfiles
+                    nexus_subset_ids
                 );
             }
         }

--- a/src/core/HY_Features.cpp
+++ b/src/core/HY_Features.cpp
@@ -33,10 +33,13 @@ HY_Features::HY_Features(network::Network network, std::shared_ptr<Formulation_M
         {
           //Find and prepare formulation
           auto formulation = formulations->get_formulation(feat_id);
-          formulation->set_output_stream(formulations->get_output_root() + feat_id + ".csv");
-          // TODO: add command line or config option to have this be omitted
-          //FIXME why isn't default param working here??? get_output_header_line() fails.
-          formulation->write_output("Time Step,""Time,"+formulation->get_output_header_line(",")+"\n");
+          if (formulation->get_output_header_count() > 0) {
+            // only create an output stream if there are output variables to be recorded
+            formulation->set_output_stream(formulations->get_output_root() + feat_id + ".csv");
+            // TODO: add command line or config option to have this be omitted
+            //FIXME why isn't default param working here??? get_output_header_line() fails.
+            formulation->write_output("Time Step,""Time,"+formulation->get_output_header_line(",")+"\n");
+          }
           //Find upstream nexus ids
           origins = network.get_origination_ids(feat_id);
 

--- a/src/core/SurfaceLayer.cpp
+++ b/src/core/SurfaceLayer.cpp
@@ -3,18 +3,16 @@
 /***
  * @brief Run one simulation timestep for each model in this layer, then gather catchment output
 */
-
 void ngen::SurfaceLayer::update_models(boost::span<double> catchment_outflows, 
                                        std::unordered_map<std::string, int> &catchment_indexes,
                                        boost::span<double> nexus_downstream_flows,
                                        std::unordered_map<std::string, int> &nexus_indexes,
                                        int current_step)
 {
-    
+    long current_time_index = output_time_index;
+
     Layer::update_models(catchment_outflows, catchment_indexes, nexus_downstream_flows, nexus_indexes, current_step);
 
-#if NGEN_WITH_ROUTING
-    long current_time_index = output_time_index;
     //At this point, could make an internal routing pass, extracting flows from nexuses and routing
     //across the flowpath to the next nexus.
     //Once everything is updated for this timestep, dump the nexus output
@@ -38,8 +36,12 @@ void ngen::SurfaceLayer::update_models(boost::span<double> catchment_outflows,
         }
 
         //std::cerr << "Requesting water from nexus, id = " << id << " at time = " <<current_time_index << ",  percent = 100, destination = " << cat_id << std::endl;
+#if NGEN_WITH_ROUTING
         int nexus_index = nexus_indexes[id];
         nexus_downstream_flows[nexus_index] += nexus->get_downstream_flow(cat_id, current_time_index, 100.0);
+#else // NGEN_WITH_ROUTING
+
+#endif
 
         #if NGEN_WITH_MPI
         }
@@ -50,5 +52,4 @@ void ngen::SurfaceLayer::update_models(boost::span<double> catchment_outflows,
         //If using below, then another single time vector would be needed to hold the timestamp
         //nexus_flows[id].push_back(contribution_at_t); 
     } //done nexuses
-#endif // NGEN_WITH_ROUTING
 }

--- a/src/core/SurfaceLayer.cpp
+++ b/src/core/SurfaceLayer.cpp
@@ -9,10 +9,13 @@ void ngen::SurfaceLayer::update_models(boost::span<double> catchment_outflows,
                                        std::unordered_map<std::string, int> &nexus_indexes,
                                        int current_step)
 {
+#if NGEN_WITH_ROUTING
     long current_time_index = output_time_index;
+#endif // NGEN_WITH_ROUTING
 
     Layer::update_models(catchment_outflows, catchment_indexes, nexus_downstream_flows, nexus_indexes, current_step);
 
+#if NGEN_WITH_ROUTING
     //At this point, could make an internal routing pass, extracting flows from nexuses and routing
     //across the flowpath to the next nexus.
     //Once everything is updated for this timestep, dump the nexus output
@@ -36,12 +39,8 @@ void ngen::SurfaceLayer::update_models(boost::span<double> catchment_outflows,
         }
 
         //std::cerr << "Requesting water from nexus, id = " << id << " at time = " <<current_time_index << ",  percent = 100, destination = " << cat_id << std::endl;
-#if NGEN_WITH_ROUTING
         int nexus_index = nexus_indexes[id];
         nexus_downstream_flows[nexus_index] += nexus->get_downstream_flow(cat_id, current_time_index, 100.0);
-#else // NGEN_WITH_ROUTING
-
-#endif
 
         #if NGEN_WITH_MPI
         }
@@ -52,4 +51,5 @@ void ngen::SurfaceLayer::update_models(boost::span<double> catchment_outflows,
         //If using below, then another single time vector would be needed to hold the timestamp
         //nexus_flows[id].push_back(contribution_at_t); 
     } //done nexuses
+#endif // NGEN_WITH_ROUTING
 }

--- a/src/core/SurfaceLayer.cpp
+++ b/src/core/SurfaceLayer.cpp
@@ -10,17 +10,16 @@ void ngen::SurfaceLayer::update_models(boost::span<double> catchment_outflows,
                                        std::unordered_map<std::string, int> &nexus_indexes,
                                        int current_step)
 {
-    long current_time_index = output_time_index;
     
     Layer::update_models(catchment_outflows, catchment_indexes, nexus_downstream_flows, nexus_indexes, current_step);
 
+#if NGEN_WITH_ROUTING
+    long current_time_index = output_time_index;
     //At this point, could make an internal routing pass, extracting flows from nexuses and routing
     //across the flowpath to the next nexus.
     //Once everything is updated for this timestep, dump the nexus output
     for(const auto& id : features.nexuses()) 
     {
-        std::string current_timestamp = simulation_time.get_timestamp(current_time_index);
-        
         #if NGEN_WITH_MPI
         if (!features.is_remote_sender_nexus(id)) { //Ensures only one side of the dual sided remote nexus actually doing this...
         #endif
@@ -39,14 +38,8 @@ void ngen::SurfaceLayer::update_models(boost::span<double> catchment_outflows,
         }
 
         //std::cerr << "Requesting water from nexus, id = " << id << " at time = " <<current_time_index << ",  percent = 100, destination = " << cat_id << std::endl;
-        double contribution_at_t = features.nexus_at(id)->get_downstream_flow(cat_id, current_time_index, 100.0);
-#if NGEN_WITH_ROUTING
         int nexus_index = nexus_indexes[id];
-        nexus_downstream_flows[nexus_index] += contribution_at_t;
-#endif // NGEN_WITH_ROUTING
-        if(nexus_outfiles[id].is_open()) {
-        nexus_outfiles[id] << current_time_index << ", " << current_timestamp << ", " << contribution_at_t << std::endl;
-        }
+        nexus_downstream_flows[nexus_index] += nexus->get_downstream_flow(cat_id, current_time_index, 100.0);
 
         #if NGEN_WITH_MPI
         }
@@ -57,4 +50,5 @@ void ngen::SurfaceLayer::update_models(boost::span<double> catchment_outflows,
         //If using below, then another single time vector would be needed to hold the timestamp
         //nexus_flows[id].push_back(contribution_at_t); 
     } //done nexuses
+#endif // NGEN_WITH_ROUTING
 }

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -391,6 +391,10 @@ namespace realization {
                 for (int i = 0; i < out_vars_json_list.size(); ++i) {
                     out_vars[i] = out_vars_json_list[i].as_string();
                 }
+                if (out_vars.size() == 1 && out_vars[0].empty()) {
+                    // empty array may be read as [""], so make it empty
+                    out_vars.pop_back();
+                }
                 set_output_variable_names(out_vars);
             }
                 // Otherwise, just take what literally is provided by the model
@@ -400,7 +404,7 @@ namespace realization {
 
             // Output header fields, if present
             auto out_headers_it = properties.find(BMI_REALIZATION_CFG_PARAM_OPT__OUT_HEADER_FIELDS);
-            if (out_headers_it != properties.end()) {
+            if (out_headers_it != properties.end() && get_output_variable_names().size() != 0) {
                 std::vector<geojson::JSONProperty> out_headers_json_list = out_var_it->second.as_list();
                 std::vector<std::string> out_headers(out_headers_json_list.size());
                 for (int i = 0; i < out_headers_json_list.size(); ++i) {

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -107,6 +107,10 @@ void Bmi_Multi_Formulation::create_multi_formulation(geojson::PropertyMap proper
         for (int i = 0; i < out_vars_json_list.size(); ++i) {
             out_vars[i] = out_vars_json_list[i].as_string();
         }
+        if (out_vars.size() == 1 && out_vars[0].empty()) {
+            // empty array may be read as [""], so make it empty
+            out_vars.pop_back();
+        }
         set_output_variable_names(out_vars);
     }
     // Otherwise, for multi BMI, the BMI output variables of the last nested module should be used.
@@ -120,7 +124,7 @@ void Bmi_Multi_Formulation::create_multi_formulation(geojson::PropertyMap proper
 
     // Output header fields, if present
     auto out_headers_it = properties.find(BMI_REALIZATION_CFG_PARAM_OPT__OUT_HEADER_FIELDS);
-    if (out_headers_it != properties.end()) {
+    if (out_headers_it != properties.end() && get_output_variable_names().size() != 0) {
         std::vector<geojson::JSONProperty> out_headers_json_list = out_headers_it->second.as_list();
         std::vector<std::string> out_headers(out_headers_json_list.size());
         for (int i = 0; i < out_headers_json_list.size(); ++i) {


### PR DESCRIPTION
NGEN was identified to run significantly faster when not writing any catchment output data. This update allows the catchment CSVs to not be made if the realization config files formulations's output_variables is an empty list. To keep compatibility, omitting the output_variables parameter will have NGEN use the BMI's default output variables.

## Additions

- Virtual class function on Catchment_Formulation for getting the number of output header fields: get_output_header_count
- Override for get_output_header_count. This is used to check whether catchment files should be created and written to.

## Changes

- Bmi_Module_Formulation and Bmi_Multi_Formulation can read empty lists for the output_variables.
- HY_Features and DomainLayer will not create a catchment output CSV if the catchment's formulation has no output fields.
- Layer will not attempt to write outputs if its formulation has no output fields. 

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [ ] Linux
