### PR TITLE
NGWPC-8862: Clean up object instances holding Python interpreter references during finalize() process

### DIFF
--- a/include/forcing/ForcingsEngineDataProvider.hpp
+++ b/include/forcing/ForcingsEngineDataProvider.hpp
@@ -105,6 +105,13 @@ struct ForcingsEngineDataProvider : public DataProvider<DataType, SelectionType>
     using clock_type = std::chrono::system_clock;
 
     ~ForcingsEngineDataProvider() override = default;
+    void finalize() override
+    {
+        if (bmi_ != nullptr) {
+            bmi_->Finalize();
+            bmi_ = nullptr;
+        }
+    }
 
     boost::span<const std::string> get_available_variable_names() const override
     {

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -857,8 +857,7 @@ int main(int argc, char* argv[]) {
                                    nexus_downstream_flows.data() + (i * nexus_count));
                 py_troute.Update();
             }
-            // Finalize will write the output file
-            py_troute.Finalize();
+            // py_troute will call Finalize() and write files on destruction
         }
     }
 #endif
@@ -879,6 +878,7 @@ int main(int argc, char* argv[]) {
     }
 
     manager->finalize();
+    _interp.reset();
 
 #if NGEN_WITH_MPI
     MPI_Finalize();

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -749,6 +749,8 @@ int main(int argc, char* argv[]) {
     MPI_Barrier(MPI_COMM_WORLD);
 #endif
 
+    manager->finalize();
+
 #if NGEN_WITH_ROUTING
 #if NGEN_WITH_MPI
     if (mpi_num_procs > 1) {
@@ -878,7 +880,6 @@ int main(int argc, char* argv[]) {
         ss.str("");
     }
 
-    manager->finalize();
     _interp.reset();
 
 #if NGEN_WITH_MPI

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -857,7 +857,8 @@ int main(int argc, char* argv[]) {
                                    nexus_downstream_flows.data() + (i * nexus_count));
                 py_troute.Update();
             }
-            // py_troute will call Finalize() and write files on destruction
+            // Finalize will write the output file
+            py_troute.Finalize();
         }
     }
 #endif


### PR DESCRIPTION
Jobs were failing with heap corruption and calls to `MPI_Comm_size` after `MPI_Finalize` during ESMF cleanup happening when the Python interpreter instance was being destroyed. Make the cleanup happen explicitly before `MPI_Finalize`

Addresses NGWPC-8862, NGWPC-8882, and probably others as well.

## Changes

- Add missing calls to `ForcingsEngineDataProvider::finalize()`
- Explicitly release the `InterpreterUtil` pointer before `MPI_Finalize`, rather than waiting for it to go out of scope afterward at the end of `main()`

## Testing

1.

## Notes

- The release of the `InterpreterUtil` pointer is a big, imprecise hammer. It covers a lot of cleanup steps that should probably be identified and made explicit, so that the code is more malleable and reusable in the future.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
