### PR TITLE
Add EWTS Environment Vars for BMI Forcing (NGWPC-7198) and rename TopoFlow to Topoflow-Glacier

### DIFF
--- a/include/utilities/Logger.hpp
+++ b/include/utilities/Logger.hpp
@@ -55,7 +55,7 @@ class Logger {
     bool        FindAndOpenLogConfigFile(std::string path, std::ifstream& configFileStream);
     std::string GetLogFilePath(void);
     std::string GetParentDirName(const std::string& path);
-    bool        JsonFileValid(std::ifstream& jsonFile);
+    bool        IsValidEnvVarName(const std::string& name);
     bool        LogFileReady(void);
     bool        ParseLoggerConfigFile(std::ifstream& jsonFile);
     void        ReadConfigFile(std::string searchPath);

--- a/src/utilities/logging/CMakeLists.txt
+++ b/src/utilities/logging/CMakeLists.txt
@@ -1,3 +1,7 @@
 add_library(logging logging_utils.cpp Logger.cpp)
 add_library(NGen::logging ALIAS logging)
 target_include_directories(logging PUBLIC ${PROJECT_SOURCE_DIR}/include/utilities)
+
+target_link_libraries(logging PUBLIC
+Boost::boost
+)

--- a/src/utilities/logging/Logger.cpp
+++ b/src/utilities/logging/Logger.cpp
@@ -63,7 +63,7 @@ const std::vector<std::string> allModules = {
     "SMP",
     "SNOW-17",
     "TOPMODEL",
-    "TOPOFLOW",
+    "TOPOFLOW-GLACIER",
     "T-ROUTE",
     "UEB",
     "LSTM",
@@ -324,9 +324,6 @@ void Logger::ReadConfigFile(std::string searchPath) {
     // Set logger defaults
     loggingEnabled = true;
     moduleLogLevels.clear();
-//    for (const auto& hydroModule : allModules) {
-//        moduleLogLevels[hydroModule] = LogLevel::INFO;
-//    }
 
     // Open and Parse config file
     std::ifstream jsonFile;
@@ -410,9 +407,9 @@ void Logger::ManageLoggingEnvVars(bool set) {
                 // This is important when running calibrations since iterative runs of ngen
                 // can number in the 1000's and it is only necessary to retain the last ngen run
                 envVar = hydroModule + "_LOGFILEPATH";
-                unsetenv(moduleNameInLog.c_str());
+                unsetenv(envVar.c_str());
                 envVar = hydroModule + "_LOGLEVEL";
-                unsetenv(moduleNameInLog.c_str());
+                unsetenv(envVar.c_str());
             }
         }
     }


### PR DESCRIPTION
Several modifications are being addressed in this PR related to the Error and Warning Trapping System (EWTS)
- The ngenCERF tool will only include module log level information in the logging config file if the module is in the formulation.
- The Topoflow module has been changed to Topoflow-Glacier to reflect the work done by EDFS to pull the glacier part of the module into its own standalone module.
- EWTS has been added to the ngen-forcing BMI code and requires ngen to set its log level environment variable.

## Additions

- Added `Forcing` as a module for the EWTS log level environment variable

## Removals

- Removed setting default levels for all known modules

## Changes

- Set the log level environment variables only for modules in the formulation
- Renamed the `TOPOFLOW` module for the EWTS code to `TOPOFLOW-GLACIER`
- Refactored set/unset of the ETWS environment variables to a single method with a set/unset argument
- Replace open-coded JSON pseudo-parsing with Boost JSON

## Testing

1. Built locally and ran forecast

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

