### PR TITLE
Apply unit conversion to formulation output variables and catchment runoff response (NGWPC-8824)

### DIFF
--- a/extern/test_bmi_py/bmi_model.py
+++ b/extern/test_bmi_py/bmi_model.py
@@ -80,6 +80,12 @@ class bmi_model(Bmi):
                            'OUTPUT_VAR_3':['OUTPUT_VAR_3','-'],
                            'GRID_VAR_1':['OUTPUT_VAR_1','mm/s'],
                            'GRID_VAR_2':['GRID_VAR_2','-'],
+                           'GRID_VAR_3':['GRID_VAR_3','-'],
+                           'OUTPUT_VAR_1__1':['OUTPUT_VAR_1__1','-'],
+                           'OUTPUT_VAR_2__1':['OUTPUT_VAR_2__1','-'],
+                           'OUTPUT_VAR_1__0':['OUTPUT_VAR_1__0','-'],
+                           'OUTPUT_VAR_2__0':['OUTPUT_VAR_2__0','-'],
+                           'OUTPUT_VAR_3__0':['OUTPUT_VAR_3__0','-']
                             }
 
     #------------------------------------------------------

--- a/extern/test_bmi_py/bmi_model.py
+++ b/extern/test_bmi_py/bmi_model.py
@@ -79,7 +79,8 @@ class bmi_model(Bmi):
                            'OUTPUT_VAR_2':['OUTPUT_VAR_2','mm/s'],
                            'OUTPUT_VAR_3':['OUTPUT_VAR_3','-'],
                            'GRID_VAR_1':['OUTPUT_VAR_1','mm/s'],
-                           'GRID_VAR_2':['GRID_VAR_2','-']
+                           'GRID_VAR_2':['GRID_VAR_2','-'],
+                           'GRID_VAR_3':['GRID_VAR_3','-']
                            }
 
     #------------------------------------------------------

--- a/extern/test_bmi_py/bmi_model.py
+++ b/extern/test_bmi_py/bmi_model.py
@@ -79,14 +79,8 @@ class bmi_model(Bmi):
                            'OUTPUT_VAR_2':['OUTPUT_VAR_2','mm/s'],
                            'OUTPUT_VAR_3':['OUTPUT_VAR_3','-'],
                            'GRID_VAR_1':['OUTPUT_VAR_1','mm/s'],
-                           'GRID_VAR_2':['GRID_VAR_2','-'],
-                           'GRID_VAR_3':['GRID_VAR_3','-'],
-                           'OUTPUT_VAR_1__1':['OUTPUT_VAR_1__1','-'],
-                           'OUTPUT_VAR_2__1':['OUTPUT_VAR_2__1','-'],
-                           'OUTPUT_VAR_1__0':['OUTPUT_VAR_1__0','-'],
-                           'OUTPUT_VAR_2__0':['OUTPUT_VAR_2__0','-'],
-                           'OUTPUT_VAR_3__0':['OUTPUT_VAR_3__0','-']
-                            }
+                           'GRID_VAR_2':['GRID_VAR_2','-']
+                           }
 
     #------------------------------------------------------
     # A list of static attributes/parameters.

--- a/include/forcing/CsvPerFeatureForcingProvider.hpp
+++ b/include/forcing/CsvPerFeatureForcingProvider.hpp
@@ -235,6 +235,17 @@ class CsvPerFeatureForcingProvider : public data_access::GenericDataProvider
         return available_forcings;
     }
 
+    const std::string get_provider_units_for_variable(const std::string& name) const {
+        auto iter = available_forcings_units.find(name);
+        if(iter != available_forcings_units.end()){
+            return iter->second;
+        }
+        std::string throw_msg;
+        throw_msg.assign("Got request to retrieve units for variable '" + name + "', but it was not found in the data provider. This should not happen." + SOURCE_LOC);
+        LOG(throw_msg, LogLevel::WARNING);
+        throw std::runtime_error(throw_msg);
+    };
+
     private:
 
     /**

--- a/include/forcing/DataProvider.hpp
+++ b/include/forcing/DataProvider.hpp
@@ -43,9 +43,13 @@ namespace data_access
          */
         virtual void finalize() { }
 
-        /** Return the variables that are accessable by this data provider */
+        /** Return the variables that are accessible by this data provider */
 
         virtual boost::span<const std::string> get_available_variable_names() const = 0;
+
+        /** Return the unit for the requested variable that is accessible by this data provider */
+
+        virtual const std::string get_provider_units_for_variable(const std::string& name) const = 0;
 
         /** Return the first valid time for which data from the request variable  can be requested */
 

--- a/include/forcing/ForcingsEngineDataProvider.hpp
+++ b/include/forcing/ForcingsEngineDataProvider.hpp
@@ -117,7 +117,7 @@ struct ForcingsEngineDataProvider : public DataProvider<DataType, SelectionType>
         if(iter != var_output_units_map_.end()){
             return iter->second;
         }
-        std::string throw_msg; 
+        std::string throw_msg;
         throw_msg.assign("Got request to retrieve units for variable '" + name + "', but it was not found in the data provider. This should not happen." + SOURCE_LOC);
         LOG(throw_msg, LogLevel::WARNING);
         throw std::runtime_error(throw_msg);
@@ -244,7 +244,7 @@ struct ForcingsEngineDataProvider : public DataProvider<DataType, SelectionType>
             var_output_names_ = bmi_->GetOutputVarNames();
             for (const std::string &output_var_name : var_output_names_) {
                 var_output_units_map_[output_var_name] = bmi_->GetVarUnits(output_var_name);
-            } 
+            }
             if (Logger::GetLogger()->GetLogLevel() == LogLevel::DEBUG) {
                 ss.str(""); ss << "BMI instance initialized successfully" << std::endl;
                 LOG(LogLevel::DEBUG, ss.str());

--- a/include/forcing/ForcingsEngineDataProvider.hpp
+++ b/include/forcing/ForcingsEngineDataProvider.hpp
@@ -111,6 +111,18 @@ struct ForcingsEngineDataProvider : public DataProvider<DataType, SelectionType>
         return var_output_names_;
     }
 
+    const std::string get_provider_units_for_variable(const std::string& name) const override
+    {
+        auto iter = var_output_units_map_.find(name);
+        if(iter != var_output_units_map_.end()){
+            return iter->second;
+        }
+        std::string throw_msg; 
+        throw_msg.assign("Got request to retrieve units for variable '" + name + "', but it was not found in the data provider. This should not happen." + SOURCE_LOC);
+        LOG(throw_msg, LogLevel::WARNING);
+        throw std::runtime_error(throw_msg);
+    }
+
     long get_data_start_time() const override
     {
         return clock_type::to_time_t(time_begin_);
@@ -230,6 +242,9 @@ struct ForcingsEngineDataProvider : public DataProvider<DataType, SelectionType>
             // NOTE: using std::lround instead of static_cast will prevent potential UB
             time_step_ = std::chrono::seconds{std::lround(bmi_->GetTimeStep())};
             var_output_names_ = bmi_->GetOutputVarNames();
+            for (const std::string &output_var_name : var_output_names_) {
+                var_output_units_map_[output_var_name] = bmi_->GetVarUnits(output_var_name);
+            } 
             if (Logger::GetLogger()->GetLogLevel() == LogLevel::DEBUG) {
                 ss.str(""); ss << "BMI instance initialized successfully" << std::endl;
                 LOG(LogLevel::DEBUG, ss.str());
@@ -284,6 +299,9 @@ struct ForcingsEngineDataProvider : public DataProvider<DataType, SelectionType>
 
     //! Output variable names
     std::vector<std::string> var_output_names_{};
+
+    //! Units of Output variables
+    std::map<std::string, std::string> var_output_units_map_;
 
     //! Calendar time for simulation beginning
     clock_type::time_point time_begin_{};

--- a/include/forcing/NetCDFPerFeatureDataProvider.hpp
+++ b/include/forcing/NetCDFPerFeatureDataProvider.hpp
@@ -74,6 +74,8 @@ namespace data_access
         /** Return the variables that are accessable by this data provider */
         boost::span<const std::string> get_available_variable_names() const override;
 
+        const std::string get_provider_units_for_variable(const std::string& name) const override;
+
         /** return a list of ids in the current file */
         const std::vector<std::string>& get_ids() const;
 
@@ -140,7 +142,7 @@ namespace data_access
 
         const netCDF::NcVar& get_ncvar(const std::string& name);
 
-        const std::string& get_ncvar_units(const std::string& name);
+        const std::string& get_ncvar_units(const std::string& name) const;
 
     };
 }

--- a/include/forcing/NullForcingProvider.hpp
+++ b/include/forcing/NullForcingProvider.hpp
@@ -31,6 +31,8 @@ class NullForcingProvider : public data_access::GenericDataProvider
     inline bool is_property_sum_over_time_step(const std::string& name) const override;
 
     boost::span<const std::string> get_available_variable_names() const override;
+
+    const std::string get_provider_units_for_variable(const std::string& name) const override;
 };
 
 #endif // NGEN_NULLFORCING_H

--- a/include/forcing/WrappedDataProvider.hpp
+++ b/include/forcing/WrappedDataProvider.hpp
@@ -63,6 +63,10 @@ namespace data_access {
             return wrapped_provider->get_available_variable_names();
         }
 
+        const std::string get_provider_units_for_variable(const std::string& name) const override{
+            return wrapped_provider->get_provider_units_for_variable(name);
+        }
+
         /**
          * Get the inclusive beginning of the period of time over which this instance can provide data for this forcing.
          *

--- a/include/realizations/catchment/Bmi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Formulation.hpp
@@ -147,7 +147,7 @@ namespace realization {
             return output_header_fields;
         }
 
-         /**
+        /**
          * Get a header line appropriate for a file made up of entries from this type's implementation of
          * ``get_output_line_for_timestep``.
          *

--- a/include/realizations/catchment/Bmi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Formulation.hpp
@@ -228,7 +228,7 @@ namespace realization {
 
         virtual void update(time_step_t t_index, time_step_t t_delta) = 0;
 
-                /**
+        /**
          * Get the configured units for the variables in formulation output.
          *
          * Get the units of the variables to include in the output from this formulation as defined in the realization file

--- a/include/realizations/catchment/Bmi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Formulation.hpp
@@ -228,14 +228,6 @@ namespace realization {
 
         virtual void update(time_step_t t_index, time_step_t t_delta) = 0;
 
-        /**
-         * Get the configured units for the variables in formulation output.
-         *
-         * Get the units of the variables to include in the output from this formulation as defined in the realization file
-         *
-         * @return
-         */
-
     protected:
 
         /** Object to help with converting numeric output values to text. */

--- a/include/realizations/catchment/Bmi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Formulation.hpp
@@ -235,10 +235,6 @@ namespace realization {
          *
          * @return
          */
-        // TODO: rename this function to make it more clear it is FORMULATION output contents, not simply BMI variables
-        const std::vector<std::string> &get_output_variable_units() const {
-            return output_variable_units;
-        }
 
     protected:
 
@@ -278,10 +274,6 @@ namespace realization {
             output_variable_names = out_var_names;
         }
 
-        void set_output_variable_units(const std::vector<std::string> &output_units) {
-            output_variable_units = output_units;
-        }
-
     private:
 
         std::string bmi_main_output_var;
@@ -291,11 +283,7 @@ namespace realization {
          * `output_variable_names`.
          */
         std::vector<std::string> output_header_fields;
-        /**
-         * Output units for the variables output by the realization, as defined in
-         * `output_variables`.
-         */
-        std::vector<std::string> output_variable_units;
+
         /**
          * Names of the variables to include in the output from this formulation, which will be some ordered subset of
          * the BMI module output variables accessible to the instance.

--- a/include/realizations/catchment/Bmi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Formulation.hpp
@@ -240,6 +240,8 @@ namespace realization {
             return output_variable_units;
         }
 
+        virtual const std::string get_bmi_native_units(const std::string &name) const = 0;
+
     protected:
 
         /** Object to help with converting numeric output values to text. */

--- a/include/realizations/catchment/Bmi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Formulation.hpp
@@ -275,7 +275,6 @@ namespace realization {
          * `output_variable_names`.
          */
         std::vector<std::string> output_header_fields;
-
         /**
          * Names of the variables to include in the output from this formulation, which will be some ordered subset of
          * the BMI module output variables accessible to the instance.

--- a/include/realizations/catchment/Bmi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Formulation.hpp
@@ -240,8 +240,6 @@ namespace realization {
             return output_variable_units;
         }
 
-        virtual const std::string get_bmi_native_units(const std::string &name) const = 0;
-
     protected:
 
         /** Object to help with converting numeric output values to text. */

--- a/include/realizations/catchment/Bmi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Formulation.hpp
@@ -228,6 +228,18 @@ namespace realization {
 
         virtual void update(time_step_t t_index, time_step_t t_delta) = 0;
 
+                /**
+         * Get the configured units for the variables in formulation output.
+         *
+         * Get the units of the variables to include in the output from this formulation as defined in the realization file
+         *
+         * @return
+         */
+        // TODO: rename this function to make it more clear it is FORMULATION output contents, not simply BMI variables
+        const std::vector<std::string> &get_output_variable_units() const {
+            return output_variable_units;
+        }
+
     protected:
 
         /** Object to help with converting numeric output values to text. */

--- a/include/realizations/catchment/Bmi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Formulation.hpp
@@ -240,7 +240,7 @@ namespace realization {
             return output_variable_units;
         }
 
-        virtual const std::string get_bmi_native_units(const std::string &name) = 0;
+        virtual const std::string get_bmi_native_units(const std::string &name) const = 0;
 
     protected:
 

--- a/include/realizations/catchment/Bmi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Formulation.hpp
@@ -235,6 +235,8 @@ namespace realization {
          */
         virtual double get_var_value_as_double(const int& index, const std::string& var_name) = 0;
 
+        virtual void update(time_step_t t_index, time_step_t t_delta) = 0;
+
     protected:
 
         /** Object to help with converting numeric output values to text. */

--- a/include/realizations/catchment/Bmi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Formulation.hpp
@@ -147,16 +147,7 @@ namespace realization {
             return output_header_fields;
         }
 
-        /**
-         * Get the units for the output variables in the realization file organized as a vector of strings.
-         *
-         * @return The units of output variables in the realization file organized as a vector.
-         */
-        const std::vector<std::string> &get_output_variable_units() const {
-            return output_variable_units;
-        }
-
-        /**
+         /**
          * Get a header line appropriate for a file made up of entries from this type's implementation of
          * ``get_output_line_for_timestep``.
          *

--- a/include/realizations/catchment/Bmi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Formulation.hpp
@@ -240,7 +240,7 @@ namespace realization {
             return output_variable_units;
         }
 
-        virtual const std::string get_bmi_native_units(const std::string &name) const = 0;
+        virtual const std::string get_bmi_native_units(const std::string &name) = 0;
 
     protected:
 

--- a/include/realizations/catchment/Bmi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Formulation.hpp
@@ -148,6 +148,15 @@ namespace realization {
         }
 
         /**
+         * Get the units for the output variables in the realization file organized as a vector of strings.
+         *
+         * @return The units of output variables in the realization file organized as a vector.
+         */
+        const std::vector<std::string> &get_output_variable_units() const {
+            return output_variable_units;
+        }
+
+        /**
          * Get a header line appropriate for a file made up of entries from this type's implementation of
          * ``get_output_line_for_timestep``.
          *

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -253,7 +253,7 @@ namespace realization {
 
         const std::vector<std::string> get_bmi_input_variables() const override;
         const std::vector<std::string> get_bmi_output_variables() const override;
-        const std::string get_bmi_native_units(const std::string &name) const override;
+        const std::string get_bmi_native_units(const std::string &name) override;
 
         const boost::span<char> get_serialization_state() const;
         void load_serialization_state(const boost::span<char> state) const;

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -259,12 +259,12 @@ namespace realization {
 
         const std::vector<std::string> get_bmi_input_variables() const override;
         const std::vector<std::string> get_bmi_output_variables() const override;
-        const std::string get_bmi_native_units(const std::string &name) const override;
-
+        
         const boost::span<char> get_serialization_state() const;
         void load_serialization_state(const boost::span<char> state) const;
         void free_serialization_state() const;
         void set_realization_file_format(bool is_legacy_format);
+        void set_variable_map_availability(bool is_variable_map_available);
         
     protected:
 
@@ -478,6 +478,8 @@ namespace realization {
 
         bool is_realization_legacy_format() const;
 
+        bool is_variable_mapping_provided() const;
+
     private:
         /**
          * Whether model ``Update`` calls are allowed and handled in some way by the backing model for time steps after
@@ -502,6 +504,8 @@ namespace realization {
 
         /** Whether the realization file follows legacy format or the new format. */
         bool legacy_json_format = false;
+
+        bool variable_names_map_provided = false;
 
         std::vector<std::string> OPTIONAL_PARAMETERS = {
                 BMI_REALIZATION_CFG_PARAM_OPT__USES_FORCINGS

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -264,8 +264,7 @@ namespace realization {
         void load_serialization_state(const boost::span<char> state) const;
         void free_serialization_state() const;
         void set_realization_file_format(bool is_legacy_format);
-        void set_variable_map_availability(bool is_variable_map_available);
-        
+                
     protected:
 
         /**
@@ -478,8 +477,6 @@ namespace realization {
 
         bool is_realization_legacy_format() const;
 
-        bool is_variable_mapping_provided() const;
-
     private:
         /**
          * Whether model ``Update`` calls are allowed and handled in some way by the backing model for time steps after
@@ -505,7 +502,7 @@ namespace realization {
         /** Whether the realization file follows legacy format or the new format. */
         bool legacy_json_format = false;
 
-        bool variable_names_map_provided = false;
+        std::vector<std::string> output_var_units;
 
         std::vector<std::string> OPTIONAL_PARAMETERS = {
                 BMI_REALIZATION_CFG_PARAM_OPT__USES_FORCINGS

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -510,6 +510,8 @@ namespace realization {
                 BMI_REALIZATION_CFG_PARAM_REQ__MODEL_TYPE,
         };
 
+        double get_var_value_as_double(const int& index, const std::string& var_name) override;
+
     };
 /*
     template<class M>

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -121,6 +121,8 @@ namespace realization {
          */
         double get_response(time_step_t t_index, time_step_t t_delta) override;
 
+        void update(time_step_t t_index, time_step_t t_delta) override;
+
         /**
          * Get the inclusive beginning of the period of time over which this instance can provide data for this forcing.
          *
@@ -509,21 +511,6 @@ namespace realization {
                 BMI_REALIZATION_CFG_PARAM_REQ__MAIN_OUT_VAR,
                 BMI_REALIZATION_CFG_PARAM_REQ__MODEL_TYPE,
         };
-
-        /**
-         * Get value for some BMI model variable at a specific index.
-         *
-         *
-         * @param index
-         * @param var_name
-         * @return
-         */
-        double get_var_value_as_double(const int& index, const std::string& var_name) override {
-            //Temporary for testing
-            LOG("Inside Bmi_Module_Formulation::get_var_value_as_double function: " + var_name, LogLevel::WARNING);
-            return -9999.0; //get_var_value_as_double(0,var_name);
-        }
-
     };
 /*
     template<class M>

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -511,6 +511,7 @@ namespace realization {
                 BMI_REALIZATION_CFG_PARAM_REQ__MAIN_OUT_VAR,
                 BMI_REALIZATION_CFG_PARAM_REQ__MODEL_TYPE,
         };
+
     };
 /*
     template<class M>

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -253,12 +253,13 @@ namespace realization {
 
         const std::vector<std::string> get_bmi_input_variables() const override;
         const std::vector<std::string> get_bmi_output_variables() const override;
+        const std::string get_bmi_native_units(const std::string &name) const override;
 
         const boost::span<char> get_serialization_state() const;
         void load_serialization_state(const boost::span<char> state) const;
         void free_serialization_state() const;
         void set_realization_file_format(bool is_legacy_format);
-
+        
     protected:
 
         /**

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -259,12 +259,12 @@ namespace realization {
 
         const std::vector<std::string> get_bmi_input_variables() const override;
         const std::vector<std::string> get_bmi_output_variables() const override;
-        
+
         const boost::span<char> get_serialization_state() const;
         void load_serialization_state(const boost::span<char> state) const;
         void free_serialization_state() const;
         void set_realization_file_format(bool is_legacy_format);
-                
+
     protected:
 
         /**

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -253,7 +253,7 @@ namespace realization {
 
         const std::vector<std::string> get_bmi_input_variables() const override;
         const std::vector<std::string> get_bmi_output_variables() const override;
-        const std::string get_bmi_native_units(const std::string &name) override;
+        const std::string get_bmi_native_units(const std::string &name) const override;
 
         const boost::span<char> get_serialization_state() const;
         void load_serialization_state(const boost::span<char> state) const;
@@ -268,7 +268,7 @@ namespace realization {
          * @param name
          * @param bmi_var_name
          */
-        void get_bmi_output_var_name(const std::string &name, std::string &bmi_var_name);
+        void get_bmi_output_var_name(const std::string &name, std::string &bmi_var_name) const;
 
         /**
          * Construct model and its shared pointer, potentially supplying input variable values from config.

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -62,6 +62,12 @@ namespace realization {
         boost::span<const std::string> get_available_variable_names() const override;
 
         /**
+         * Get the units of a forcing variable that this instance can provide.
+         * @param name The forcing variable for which the units are requested.
+         */
+        const std::string get_provider_units_for_variable(const std::string& name) const override;
+
+        /**
          * Get a delimited string with all the output variable values for the given time step.
          *
          * This method is useful for preparing calculated data in a representation useful for output files, such as
@@ -480,6 +486,7 @@ namespace realization {
         bool allow_model_exceed_end_time = false;
         /** The set of available "forcings" (output variables, plus their mapped aliases) that the model can provide. */
         std::vector<std::string> available_forcings;
+        std::map<std::string, std::string> available_forcing_units;
         std::string bmi_init_config;
         std::shared_ptr<models::bmi::Bmi_Adapter> bmi_model;
         /** Whether backing model has fixed time step size. */

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -510,7 +510,19 @@ namespace realization {
                 BMI_REALIZATION_CFG_PARAM_REQ__MODEL_TYPE,
         };
 
-        double get_var_value_as_double(const int& index, const std::string& var_name) override;
+        /**
+         * Get value for some BMI model variable at a specific index.
+         *
+         *
+         * @param index
+         * @param var_name
+         * @return
+         */
+        double get_var_value_as_double(const int& index, const std::string& var_name) override {
+            //Temporary for testing
+            LOG("Inside Bmi_Module_Formulation::get_var_value_as_double function: " + var_name, LogLevel::WARNING);
+            return -9999.0; //get_var_value_as_double(0,var_name);
+        }
 
     };
 /*

--- a/include/realizations/catchment/Bmi_Multi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Multi_Formulation.hpp
@@ -539,6 +539,8 @@ namespace realization {
             }
         }
 
+        void update(time_step_t t_index, time_step_t t_delta) override;
+
     protected:
 
         /**

--- a/include/realizations/catchment/Bmi_Multi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Multi_Formulation.hpp
@@ -448,8 +448,6 @@ namespace realization {
 
         void set_realization_file_format(bool is_legacy_format);
 
-        const std::string get_bmi_native_units(const std::string &name)const override;
-
         /**
          * Get whether a property's per-time-step values are each an aggregate sum over the entire time step.
          *
@@ -682,7 +680,7 @@ namespace realization {
 
             // Call create_formulation to perform the rest of the typical initialization steps for the formulation.
             mod->create_formulation(properties);
-
+            
             // Set this up for placing in the module_variable_maps member variable
             std::shared_ptr<std::map<std::string, std::string>> var_aliases;
             var_aliases = std::make_shared<std::map<std::string, std::string>>(std::map<std::string, std::string>());
@@ -713,6 +711,7 @@ namespace realization {
                     throw std::runtime_error(throw_msg);
                 }
                 availableData[framework_alias] = mod;
+                available_forcing_units[framework_alias] = mod->get_provider_units_for_variable(framework_alias);
             }
             module_variable_maps[mod_index] = var_aliases;
             return mod;

--- a/include/realizations/catchment/Bmi_Multi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Multi_Formulation.hpp
@@ -446,7 +446,7 @@ namespace realization {
 
         void set_realization_file_format(bool is_legacy_format);
 
-        const std::string get_bmi_native_units(const std::string &name) override;
+        const std::string get_bmi_native_units(const std::string &name)const override;
 
         /**
          * Get whether a property's per-time-step values are each an aggregate sum over the entire time step.

--- a/include/realizations/catchment/Bmi_Multi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Multi_Formulation.hpp
@@ -446,7 +446,7 @@ namespace realization {
 
         void set_realization_file_format(bool is_legacy_format);
 
-        const std::string get_bmi_native_units(const std::string &name) const override;
+        const std::string get_bmi_native_units(const std::string &name) override;
 
         /**
          * Get whether a property's per-time-step values are each an aggregate sum over the entire time step.

--- a/include/realizations/catchment/Bmi_Multi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Multi_Formulation.hpp
@@ -680,7 +680,7 @@ namespace realization {
 
             // Call create_formulation to perform the rest of the typical initialization steps for the formulation.
             mod->create_formulation(properties);
-            
+
             // Set this up for placing in the module_variable_maps member variable
             std::shared_ptr<std::map<std::string, std::string>> var_aliases;
             var_aliases = std::make_shared<std::map<std::string, std::string>>(std::map<std::string, std::string>());

--- a/include/realizations/catchment/Bmi_Multi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Multi_Formulation.hpp
@@ -124,6 +124,8 @@ namespace realization {
          */
         boost::span <const std::string> get_available_variable_names() const override;
 
+        const std::string get_provider_units_for_variable(const std::string& name) const override;
+
         /**
         * Get the input variables of 
         * the first nested BMI model.
@@ -776,6 +778,9 @@ namespace realization {
 
         /** The set of available "forcings" (output variables, plus their mapped aliases) this instance can provide. */
         std::vector<std::string> available_forcings;
+
+        std::map<std::string, std::string> available_forcing_units;
+
         /**
          * Any configured default values for outputs, keyed by framework alias (or var name if this is globally unique).
          */

--- a/include/realizations/catchment/Bmi_Multi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Multi_Formulation.hpp
@@ -780,6 +780,8 @@ namespace realization {
 
         std::map<std::string, std::string> available_forcing_units;
 
+        std::vector<std::string> output_var_units;
+
         /**
          * Any configured default values for outputs, keyed by framework alias (or var name if this is globally unique).
          */

--- a/include/realizations/catchment/Bmi_Multi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Multi_Formulation.hpp
@@ -704,8 +704,8 @@ namespace realization {
                 if (availableData.count(framework_alias) > 0) {
                     std::string throw_msg; throw_msg.assign(
                             "Multi BMI cannot be created with module " + mod->get_model_type_name() +
-                            " with output variable " + framework_alias +
-                            (var_name == framework_alias ? "" : " (an alias of BMI variable " + var_name + ")") +
+                            " with output variable '" + framework_alias + "'" +
+                            (var_name == framework_alias ? "" : " (an alias of BMI variable '" + var_name + "')") +
                             " because a previous module is using this output variable name/alias.");
                     LOG(throw_msg, LogLevel::WARNING);
                     throw std::runtime_error(throw_msg);

--- a/include/realizations/catchment/Bmi_Multi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Multi_Formulation.hpp
@@ -446,6 +446,8 @@ namespace realization {
 
         void set_realization_file_format(bool is_legacy_format);
 
+        const std::string get_bmi_native_units(const std::string &name) const override;
+
         /**
          * Get whether a property's per-time-step values are each an aggregate sum over the entire time step.
          *

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -598,6 +598,7 @@ int main(int argc, char* argv[]) {
         LOG(ss.str(), LogLevel::SEVERE);
         ss.str("");
     }
+
     // now create the layer objects
 
     // first make sure that the layer are listed in decreasing order
@@ -645,7 +646,7 @@ int main(int argc, char* argv[]) {
         }
     }
 
-    auto time_done_init = std::chrono::steady_clock::now();
+    auto time_done_init                             = std::chrono::steady_clock::now();
     std::chrono::duration<double> time_elapsed_init = time_done_init - time_start;
 
     // Now loop some time, iterate catchments, do stuff for total number of output times
@@ -741,7 +742,7 @@ int main(int argc, char* argv[]) {
         ss.str("");
     }
 
-    auto time_done_simulation = std::chrono::steady_clock::now();
+    auto time_done_simulation                             = std::chrono::steady_clock::now();
     std::chrono::duration<double> time_elapsed_simulation = time_done_simulation - time_done_init;
 
 #if NGEN_WITH_MPI

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -598,7 +598,6 @@ int main(int argc, char* argv[]) {
         LOG(ss.str(), LogLevel::SEVERE);
         ss.str("");
     }
-
     // now create the layer objects
 
     // first make sure that the layer are listed in decreasing order
@@ -646,7 +645,7 @@ int main(int argc, char* argv[]) {
         }
     }
 
-    auto time_done_init                             = std::chrono::steady_clock::now();
+    auto time_done_init = std::chrono::steady_clock::now();
     std::chrono::duration<double> time_elapsed_init = time_done_init - time_start;
 
     // Now loop some time, iterate catchments, do stuff for total number of output times
@@ -742,7 +741,7 @@ int main(int argc, char* argv[]) {
         ss.str("");
     }
 
-    auto time_done_simulation                             = std::chrono::steady_clock::now();
+    auto time_done_simulation = std::chrono::steady_clock::now();
     std::chrono::duration<double> time_elapsed_simulation = time_done_simulation - time_done_init;
 
 #if NGEN_WITH_MPI

--- a/src/forcing/NetCDFPerFeatureDataProvider.cpp
+++ b/src/forcing/NetCDFPerFeatureDataProvider.cpp
@@ -238,6 +238,10 @@ boost::span<const std::string> NetCDFPerFeatureDataProvider::get_available_varia
     return variable_names;
 }
 
+const std::string NetCDFPerFeatureDataProvider::get_provider_units_for_variable(const std::string& name) const{
+    return get_ncvar_units(name);
+}
+
 const std::vector<std::string>& NetCDFPerFeatureDataProvider::get_ids() const
 {
     return loc_ids;
@@ -445,13 +449,13 @@ const netCDF::NcVar& NetCDFPerFeatureDataProvider::get_ncvar(const std::string& 
     if(cache_hit != ncvar_cache.end()){
         return cache_hit->second;
     }
-
-    std::string throw_msg; throw_msg.assign("Got request for variable " + name + " but it was not found in the cache. This should not happen." + SOURCE_LOC);
+    std::string throw_msg;
+    throw_msg.assign("Got request for variable " + name + " but it was not found in the cache. This should not happen." + SOURCE_LOC);
     LOG(throw_msg, LogLevel::WARNING);
     throw std::runtime_error(throw_msg);
 }
 
-const std::string& NetCDFPerFeatureDataProvider::get_ncvar_units(const std::string& name){
+const std::string& NetCDFPerFeatureDataProvider::get_ncvar_units(const std::string& name) const{
     auto cache_hit = units_cache.find(name);
     if(cache_hit != units_cache.end()){
         return cache_hit->second;

--- a/src/forcing/NullForcingProvider.cpp
+++ b/src/forcing/NullForcingProvider.cpp
@@ -49,3 +49,8 @@ inline bool NullForcingProvider::is_property_sum_over_time_step(const std::strin
 boost::span<const std::string> NullForcingProvider::get_available_variable_names() const {
     return {};
 }
+
+const std::string NullForcingProvider::get_provider_units_for_variable(const std::string& name) const
+{
+    return std::string{};
+}

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -125,7 +125,7 @@ namespace realization {
 
         double Bmi_Module_Formulation::get_response(time_step_t t_index, time_step_t t_delta) {
             update(t_index, t_delta);
-            double var_value;
+            double var_value; // = get_var_value_as_double(0, get_bmi_main_output_var());
                 try{
                     var_value = get_value(CatchmentAggrDataSelector(this->get_catchment_id(), get_bmi_main_output_var(), 0, 0, "m"),MEAN);
                 }
@@ -145,8 +145,8 @@ namespace realization {
                             << " raw value " << uce.unconverted_values[0] << "}"
                             << " message \"" << uce.what() << "\"";
                         LOG(ss.str(), LogLevel::WARNING); ss.str("");
-                        var_value = uce.unconverted_values[0];
                     }
+                    var_value = uce.unconverted_values[0];
                 }
             return var_value;
         }

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -376,7 +376,10 @@ namespace realization {
                 if (std::find(output_names.begin(), output_names.end(), mapped_name) != output_names.end()){
                     bmi_var_name = mapped_name;
                 }
-                //else not an output variable
+                else{//else not an output variable
+                    LOG("No matching BMI variable name found for " + name, LogLevel::WARNING);
+                    throw std::runtime_error("No matching BMI variable name found for " + name);
+                }
             }
         }
 
@@ -556,28 +559,15 @@ namespace realization {
             std::string blank_string = "";
             auto &names = get_output_variable_names();
             if(out_units.size() == 0){
-                out_units.resize(names.size());
-                for (int i = 0; i < names.size(); ++i) {
-                    std::string bmi_var_name;
-                    get_bmi_output_var_name(names[i], bmi_var_name);
-                    if(!bmi_var_name.empty()){
-                        out_units[i] = get_bmi_model()->GetVarUnits(bmi_var_name);
-                    }
-                }
-                set_output_variable_units(out_units);
+                out_units.resize(names.size(), blank_string);
             }
-            else if(std::find(out_units.begin(), out_units.end(), blank_string) != out_units.end()){
-                for (int i = 0; i < names.size(); ++i) {
-                    if (out_units[i] == blank_string){
-                        std::string bmi_var_name;
-                        get_bmi_output_var_name(names[i], bmi_var_name);
-                        if(!bmi_var_name.empty()){
-                            out_units[i] = get_bmi_model()->GetVarUnits(bmi_var_name);
-                        }
-                    }
+
+            for (int i = 0; i < names.size(); ++i) {
+                if (out_units[i] == blank_string){
+                    out_units[i] = get_bmi_native_units(names[i]);
                 }
-                set_output_variable_units(out_units);
             }
+            set_output_variable_units(out_units);
                                     
             // Output precision, if present
             auto out_precision_it = properties.find(BMI_REALIZATION_CFG_PARAM_OPT__OUTPUT_PRECISION);

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -43,7 +43,7 @@ namespace realization {
             return output_str;
         }
 
-        double Bmi_Module_Formulation::get_response(time_step_t t_index, time_step_t t_delta) {
+        void Bmi_Module_Formulation::update(time_step_t t_index, time_step_t t_delta) {
             if (get_bmi_model() == nullptr) {
                 throw std::runtime_error("Trying to process response of improperly created BMI formulation of type '" + get_formulation_type() + "'.");
             }
@@ -97,32 +97,12 @@ namespace realization {
                 // TODO: again, consider whether we should store any historic response, ts_delta, or other var values
                 next_time_step_index++;
             }
-            
-            //return get_var_value_as_double(0,get_bmi_main_output_var());
-
-            //get the output variable name and its units in the realization file using the get_bmi_main_output_var()
-            std::vector<std::string> out_var_names = get_output_variable_names();
-            auto it = std::find(out_var_names.begin(), out_var_names.end(), get_bmi_main_output_var());
-            if (it != out_var_names.end()){
-                //indicates that the matching variable name was found. 
-                int out_var_index = distance(out_var_names.begin(), it); //get the item index in the vector
-                try{
-                    std::string bmi_units = get_bmi_model()->GetVarUnits(out_var_names[out_var_index]);
-                    return get_value(CatchmentAggrDataSelector(this->get_catchment_id(), out_var_names[out_var_index], 0,0,bmi_units),MEAN);
-                } catch(std::exception &e){
-                    return get_value(CatchmentAggrDataSelector(this->get_catchment_id(), out_var_names[out_var_index], 0,0,"m"),MEAN);
-                }
-            }
-            else{
-                //indicates that the bmi main output doesn't match with any variables mentioned in the realization file.
-                try{
-                    std::string bmi_units = get_bmi_model()->GetVarUnits(get_bmi_main_output_var());
-                    return get_value(CatchmentAggrDataSelector(this->get_catchment_id(), get_bmi_main_output_var(), 0,0,bmi_units),MEAN);
-                } catch(std::exception &e){
-                    return get_value(CatchmentAggrDataSelector(this->get_catchment_id(), get_bmi_main_output_var(), 0,0,"m"),MEAN);
-                }
-            }
         }
+
+        double Bmi_Module_Formulation::get_response(time_step_t t_index, time_step_t t_delta) {
+            update(t_index, t_delta);
+            return get_value(CatchmentAggrDataSelector(this->get_catchment_id(), get_bmi_main_output_var(), 0,0,"m"),MEAN);
+        } 
 
         time_t Bmi_Module_Formulation::get_variable_time_begin(const std::string &variable_name) {
             // TODO: come back and implement if actually necessary for this type; for now don't use
@@ -237,15 +217,11 @@ namespace realization {
             long duration_s = selector.get_duration_secs();
             std::string output_units = selector.get_output_units();
 
-            LOG("Inside get_value for: " + output_name,LogLevel::WARNING);
-            double value = get_var_value_as_double(0, output_name);
-
-
             // First make sure this is an available output
-            // auto forcing_outputs = get_available_variable_names();
-            // if (std::find(forcing_outputs.begin(), forcing_outputs.end(), output_name) == forcing_outputs.end()) {
-            //     throw std::runtime_error(get_formulation_type() + " received invalid output forcing name " + output_name);
-            // }
+            auto forcing_outputs = get_available_variable_names();
+            if (std::find(forcing_outputs.begin(), forcing_outputs.end(), output_name) == forcing_outputs.end()) {
+                throw std::runtime_error(get_formulation_type() + " received invalid output forcing name " + output_name);
+            }
             // TODO: do this, or something better, later; right now, just assume anything using this as a provider is
             //  consistent with times
             /*

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -43,7 +43,7 @@ namespace realization {
                     var_value = get_value(CatchmentAggrDataSelector(this->get_catchment_id(), name, 0, 0, output_units), MEAN);
                 }
                 catch(data_access::unit_conversion_exception &uce){
-                    data_access::unit_error_log_key key{get_id(), name, uce.provider_model_name, uce.provider_bmi_var_name, uce.what()};
+                    data_access::unit_error_log_key key{"File output", name, uce.provider_model_name, uce.provider_bmi_var_name, uce.what()};
                     auto ret = data_access::unit_errors_reported.insert(key);
                     bool new_error = ret.second;
                     if (new_error) {

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -47,8 +47,7 @@ namespace realization {
             std::string output_str;
             for (int i = 0; i < get_output_variable_names().size(); ++i) {
                 std::string name = get_output_variable_names()[i];
-                std::string output_units = get_output_variable_units()[i];
-                std::string out_units_norm = (output_units.empty() || output_units == "none") ? "1" : output_units;
+                std::string out_units_norm = (output_var_units[i].empty() || output_var_units[i] == "none") ? "1" : output_var_units[i];
                 double var_value;
                 try{
                     var_value = get_value(CatchmentAggrDataSelector(this->get_catchment_id(), name, 0, 0, out_units_norm), MEAN);
@@ -63,7 +62,7 @@ namespace realization {
                             << " requester {'Get Output Line for Timestep (Module Formulation)"
                             << "' catchment '" << get_catchment_id()
                             << "' variable '" << name
-                            << "' units '" << output_units << "'}"
+                            << "' units '" << output_var_units[i] << "'}"
                             << " provider {'" << uce.provider_model_name 
                             << "' source variable '" << uce.provider_bmi_var_name << "'"
                             << " raw value " << uce.unconverted_values[0] << "}"
@@ -438,7 +437,6 @@ namespace realization {
                     bmi_var_names_map.insert(
                             std::pair<std::string, std::string>(names_it.first, names_it.second.as_string()));
                 }
-                set_variable_map_availability(true);
             }
 
             // Do this next, since after checking whether other input variables are present in the properties, we can
@@ -455,7 +453,6 @@ namespace realization {
 
             // Output variable subset and order, if present
             std::vector<std::string> out_headers;//define empty vector for headers
-            std::vector<std::string> out_units;//define empty vector for units for new json structure
             auto out_var_it = properties.find(BMI_REALIZATION_CFG_PARAM_OPT__OUT_VARS);
             if (out_var_it != properties.end()) {
                 std::vector<geojson::JSONProperty> out_vars_json_list = out_var_it->second.as_list();
@@ -478,7 +475,7 @@ namespace realization {
                 }
                 else{
                     out_headers.resize(out_vars_json_list.size()); //assumption: number of vars = number of headers
-                    out_units.resize(out_vars_json_list.size()); //assumption: number of vars = number of units
+                    output_var_units.resize(out_vars_json_list.size()); //assumption: number of vars = number of units
                     for (int i = 0; i < out_vars_json_list.size(); ++i) {
                         out_vars[i] = out_vars_json_list[i].at("name").as_string();
                         if(out_vars_json_list[i].has_key("header")){
@@ -495,16 +492,16 @@ namespace realization {
                         }
                         if(out_vars_json_list[i].has_key("units")){
                             //indicates that a valid unit is provided
-                            out_units[i] = out_vars_json_list[i].at("units").as_string();
+                            output_var_units[i] = out_vars_json_list[i].at("units").as_string();
                         }
                         else{
                            LOG("Units not provided for '" + out_vars[i] + "' in the realization file.",LogLevel::WARNING);
-                           out_units[i] = ""; //add an empty entry and populate it with BMI native units later.
+                           output_var_units[i] = ""; //add an empty entry and populate it with BMI native units later.
                         }
                     }
                     //check if the units can be parsed correctly and write a warning message
                     std::stringstream ss;
-                    for (const std::string& out_unit : out_units) {
+                    for (const std::string& out_unit : output_var_units) {
                         if (!UnitsHelper::can_parse(out_unit))
                         {
                             ss << "Unable to parse '" << out_unit << "' in units value." << std::endl;
@@ -515,9 +512,8 @@ namespace realization {
                         // empty array may be read as [""], so make everything empty
                         out_vars.pop_back();
                         out_headers.pop_back();
-                        out_units.pop_back();
+                        output_var_units.pop_back();
                     }
-                    set_output_variable_units(out_units);
                     set_output_header_fields(out_headers);
                 }
                 set_output_variable_names(out_vars);
@@ -566,28 +562,25 @@ namespace realization {
                 for (const std::string &output_var_name : get_bmi_model()->GetOutputVarNames()) {
                     available_forcings.push_back(output_var_name);
                     available_forcing_units[output_var_name] = get_bmi_model()->GetVarUnits(output_var_name);
-                    if (is_variable_mapping_provided()){
-                        if (bmi_var_names_map.find(output_var_name) != bmi_var_names_map.end()){
-                            available_forcings.push_back(bmi_var_names_map[output_var_name]);
-                            available_forcing_units[bmi_var_names_map[output_var_name]] = get_bmi_model()->GetVarUnits(output_var_name); //units come from the model output variable.
-                        }
-                    } 
+                    if (bmi_var_names_map.find(output_var_name) != bmi_var_names_map.end()){
+                        available_forcings.push_back(bmi_var_names_map[output_var_name]);
+                        available_forcing_units[bmi_var_names_map[output_var_name]] = get_bmi_model()->GetVarUnits(output_var_name); //units come from the model output variable.
+                    }
                 }
             }
 
             //check if units have not been specified. If not, default to native units.
             std::string blank_string = "";
             auto &names = get_output_variable_names();
-            if(out_units.size() == 0){
-                out_units.resize(names.size(), blank_string);
+            if(output_var_units.size() == 0){
+                output_var_units.resize(names.size(), blank_string);
             }
 
             for (int i = 0; i < names.size(); ++i) {
-                if (out_units[i] == blank_string){
-                    out_units[i] = get_provider_units_for_variable(names[i]);
+                if (output_var_units[i] == blank_string){
+                    output_var_units[i] = get_provider_units_for_variable(names[i]);
                 }
             }
-            set_output_variable_units(out_units);
         }
         /**
          * @brief Template function for copying iterator range into contiguous array.
@@ -782,10 +775,6 @@ namespace realization {
             return legacy_json_format;
         }
 
-        bool Bmi_Module_Formulation::is_variable_mapping_provided() const {
-            return variable_names_map_provided;
-        }
-
         void Bmi_Module_Formulation::set_allow_model_exceed_end_time(bool allow_exceed_end) {
             allow_model_exceed_end_time = allow_exceed_end;
         }
@@ -811,10 +800,6 @@ namespace realization {
 
         void Bmi_Module_Formulation::set_realization_file_format(bool is_legacy_format){
             legacy_json_format = is_legacy_format;
-        }
-
-        void Bmi_Module_Formulation::set_variable_map_availability(bool is_variable_map_available){
-            variable_names_map_provided = is_variable_map_available;
         }
 
         // TODO: need to modify this to support arrays properly, since in general that's what BMI modules deal with

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -461,6 +461,9 @@ namespace realization {
                     for (int i = 0; i < out_vars_json_list.size(); ++i) {
                         out_vars[i] = out_vars_json_list[i].as_string();
                     }
+                    // empty array may be read as [""], so make it empty
+                    if (out_vars.size() == 1 && out_vars[0].empty())
+                        out_vars.pop_back();
                 }
                 else{
                     out_headers.resize(out_vars_json_list.size()); //assumption: number of vars = number of headers
@@ -497,6 +500,12 @@ namespace realization {
                             LOG(ss.str(), LogLevel::WARNING); ss.str("");
                         }
                     }
+                    if (out_vars.size() == 1 && out_vars[0].empty()) {
+                        // empty array may be read as [""], so make everything empty
+                        out_vars.pop_back();
+                        out_headers.pop_back();
+                        out_units.pop_back();
+                    }
                     set_output_variable_units(out_units);
                     set_output_header_fields(out_headers);
                 }
@@ -510,7 +519,7 @@ namespace realization {
             // Output header fields, if present
             auto out_headers_it = properties.find(BMI_REALIZATION_CFG_PARAM_OPT__OUT_HEADER_FIELDS);
             if(is_realization_legacy_format()){
-                if (out_headers_it != properties.end()) {
+                if (out_headers_it != properties.end() && get_output_variable_names().size() > 0) {
                     std::vector<geojson::JSONProperty> out_headers_json_list = out_var_it->second.as_list();
                     std::vector<std::string> out_headers(out_headers_json_list.size());
                     for (int i = 0; i < out_headers_json_list.size(); ++i) {

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -39,8 +39,8 @@ namespace realization {
                 std::string name = get_output_variable_names()[i];
                 std::string output_units = get_output_variable_units()[i];
                 std::string out_units_norm = (output_units.empty() || output_units == "none") ? "1" : output_units;
-                output_str += (output_str.empty() ? "" : ",") + 
-                std::to_string(get_value(CatchmentAggrDataSelector(this->get_catchment_id(), name, 0,0,output_units),MEAN)); 
+                output_str += (output_str.empty() ? "" : ",") +
+                    std::to_string(get_value(CatchmentAggrDataSelector(this->get_catchment_id(), name, 0, 0, output_units), MEAN));
             }
             return output_str;
         }
@@ -103,8 +103,8 @@ namespace realization {
 
         double Bmi_Module_Formulation::get_response(time_step_t t_index, time_step_t t_delta) {
             update(t_index, t_delta);
-            return get_value(CatchmentAggrDataSelector(this->get_catchment_id(), get_bmi_main_output_var(), 0,0,"m"),MEAN);
-        } 
+            return get_value(CatchmentAggrDataSelector(this->get_catchment_id(), get_bmi_main_output_var(), 0, 0, "m"),MEAN);
+        }
 
         time_t Bmi_Module_Formulation::get_variable_time_begin(const std::string &variable_name) {
             // TODO: come back and implement if actually necessary for this type; for now don't use

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -102,12 +102,10 @@ namespace realization {
 
             //get the output variable name and its units in the realization file using the get_bmi_main_output_var()
             std::vector<std::string> out_var_names = get_output_variable_names();
-            LOG("Inside get_response.",LogLevel::WARNING);
             auto it = std::find(out_var_names.begin(), out_var_names.end(), get_bmi_main_output_var());
             if (it != out_var_names.end()){
                 //indicates that the matching variable name was found. 
                 int out_var_index = distance(out_var_names.begin(), it); //get the item index in the vector
-                LOG("Inside get_response - found variable",LogLevel::WARNING);
                 try{
                     std::string bmi_units = get_bmi_model()->GetVarUnits(out_var_names[out_var_index]);
                     return get_value(CatchmentAggrDataSelector(this->get_catchment_id(), out_var_names[out_var_index], 0,0,bmi_units),MEAN);
@@ -117,7 +115,6 @@ namespace realization {
             }
             else{
                 //indicates that the bmi main output doesn't match with any variables mentioned in the realization file.
-                LOG("Inside get_response - variable not found",LogLevel::WARNING);
                 try{
                     std::string bmi_units = get_bmi_model()->GetVarUnits(get_bmi_main_output_var());
                     return get_value(CatchmentAggrDataSelector(this->get_catchment_id(), get_bmi_main_output_var(), 0,0,bmi_units),MEAN);

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -130,7 +130,7 @@ namespace realization {
                     var_value = get_value(CatchmentAggrDataSelector(this->get_catchment_id(), get_bmi_main_output_var(), 0, 0, "m"),MEAN);
                 }
                 catch(data_access::unit_conversion_exception &uce){
-                    data_access::unit_error_log_key key{get_id(), get_bmi_main_output_var(), uce.provider_model_name, uce.provider_bmi_var_name, uce.what()};
+                    data_access::unit_error_log_key key{"Bmi_Module_Formulation::get_response", get_bmi_main_output_var(), uce.provider_model_name, uce.provider_bmi_var_name, uce.what()};
                     auto ret = data_access::unit_errors_reported.insert(key);
                     bool new_error = ret.second;
                     if (new_error) {

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -36,9 +36,10 @@ namespace realization {
 
             std::string output_str;
             int var_array_size = get_output_variable_names().size();
-            for (int i = 0; i < var_array_size; ++i) {
+            for (const std::string& name : get_output_variable_names()) {
+                //Shouldn't be using "m". Should we use get_bmi_model()->GetVarUnits(name)?
                 output_str += (output_str.empty() ? "" : ",") + 
-                std::to_string(get_value(CatchmentAggrDataSelector(this->get_catchment_id(), get_output_variable_names()[i], 0,0,"m"),MEAN));
+                std::to_string(get_value(CatchmentAggrDataSelector(this->get_catchment_id(), name, 0,0,"m"),MEAN)); 
             }
             return output_str;
         }

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -149,7 +149,7 @@ namespace realization {
                         << " requester {'Get Response (Module Formulation)"
                         << "' catchment '" << get_catchment_id()
                         << "' variable '" << get_bmi_main_output_var()
-                        << "' units 'm" << "'}"
+                        << "' units 'm'}"
                         << " provider {'" << uce.provider_model_name 
                         << "' source variable '" << uce.provider_bmi_var_name << "'"
                         << " raw value " << uce.unconverted_values[0] << "}"

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -40,7 +40,7 @@ namespace realization {
                 std::string out_units_norm = (output_units.empty() || output_units == "none") ? "1" : output_units;
                 double var_value;
                 try{
-                    var_value = get_value(CatchmentAggrDataSelector(this->get_catchment_id(), name, 0, 0, output_units), MEAN);
+                    var_value = get_value(CatchmentAggrDataSelector(this->get_catchment_id(), name, 0, 0, out_units_norm), MEAN);
                 }
                 catch(data_access::unit_conversion_exception &uce){
                     data_access::unit_error_log_key key{"File output", name, uce.provider_model_name, uce.provider_bmi_var_name, uce.what()};
@@ -193,6 +193,10 @@ namespace realization {
         size_t Bmi_Module_Formulation::get_ts_index_for_time(const time_t &epoch_time) const {
             // TODO: come back and implement if actually necessary for this type; for now don't use
             throw std::runtime_error("Bmi_Singular_Formulation does not yet implement get_ts_index_for_time");
+        }
+
+        const std::string Bmi_Module_Formulation::get_bmi_native_units(const std::string &name) const {
+            return get_bmi_model()->GetVarUnits(name);
         }
 
 	std::vector<double> Bmi_Module_Formulation::get_values(const CatchmentAggrDataSelector& selector, data_access::ReSampleMethod m)
@@ -475,7 +479,13 @@ namespace realization {
                             ss << "Header not provided for '" << out_vars[i] << "'. Using the variable name as header." << std::endl;
                             LOG(ss.str(), LogLevel::INFO); ss.str("");
                         }
-                        out_units[i] = out_vars_json_list[i].at("units").as_string();
+                        if(out_vars_json_list[i].has_key("units")){
+                            //indicates that a valid unit is provided
+                            out_units[i] = out_vars_json_list[i].at("units").as_string();
+                        }
+                        else{
+                           LOG("Units not provided for '" + out_vars[i] + "' in the realization file.",LogLevel::INFO);
+                        }
                     }
                     //check if the units can be parsed correctly and write a warning message
                     std::stringstream ss;
@@ -487,9 +497,9 @@ namespace realization {
                         }
                     }
                     set_output_variable_units(out_units);
+                    set_output_header_fields(out_headers);
                 }
                 set_output_variable_names(out_vars);
-                set_output_header_fields(out_headers);
             }
             // Otherwise, just take what literally is provided by the model
             else {
@@ -520,7 +530,20 @@ namespace realization {
                 // if new format and no output/headers are mentioned.
                 set_output_header_fields(get_output_variable_names());
             }
-
+            
+            //check if units have not been specified. If not, default to native units.
+            if(out_units.size() == 0){
+                out_units.resize(get_output_variable_names().size());
+                for (int i = 0; i < get_output_variable_names().size(); ++i) {
+                    std::string bmi_var_name;
+                    get_bmi_output_var_name(get_output_variable_names()[i], bmi_var_name);
+                    if(!bmi_var_name.empty()){
+                        out_units[i] = get_bmi_model()->GetVarUnits(bmi_var_name);
+                    }
+                }
+                set_output_variable_units(out_units);
+            }
+                                    
             // Output precision, if present
             auto out_precision_it = properties.find(BMI_REALIZATION_CFG_PARAM_OPT__OUTPUT_PRECISION);
             if (out_precision_it != properties.end()) {

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -35,8 +35,10 @@ namespace realization {
             }
 
             std::string output_str;
-            for (const std::string& name : get_output_variable_names()) {
-                output_str += (output_str.empty() ? "" : ",") + std::to_string(get_var_value_as_double(0, name));
+            int var_array_size = get_output_variable_names().size();
+            for (int i = 0; i < var_array_size; ++i) {
+                output_str += (output_str.empty() ? "" : ",") + 
+                std::to_string(get_value(CatchmentAggrDataSelector(this->get_catchment_id(), get_output_variable_names()[i], 0,0,get_output_variable_units()[i]),MEAN));
             }
             return output_str;
         }
@@ -95,7 +97,21 @@ namespace realization {
                 // TODO: again, consider whether we should store any historic response, ts_delta, or other var values
                 next_time_step_index++;
             }
-            return get_var_value_as_double(0, get_bmi_main_output_var());
+            //get the output variable name and its units in the realization file using the get_bmi_main_output_var()
+            std::vector<std::string> out_var_names = get_output_variable_names();
+            auto it = std::find(out_var_names.begin(), out_var_names.end(), get_bmi_main_output_var());
+            if (it != out_var_names.end()){
+                //indicates that the matching variable name was found. 
+                int out_var_index = distance(out_var_names.begin(), it); //get the item index in the vector
+                return get_value(CatchmentAggrDataSelector(this->get_catchment_id(), out_var_names[out_var_index], 0,0,get_output_variable_units()[out_var_index]),MEAN);
+            }
+            else{
+                //indicates that the bmi main output doesn't match with any variables mentioned in the realization file.
+                //we get the variable units from the bmi and pass it to get the value. no unit conversion will happen.
+                std::string units_in_bmi = get_bmi_model()->GetVarUnits(get_bmi_main_output_var());
+                std::string out_units  = (units_in_bmi.empty() || units_in_bmi == "none") ? "1" : units_in_bmi;
+                return get_value(CatchmentAggrDataSelector(this->get_catchment_id(), get_bmi_main_output_var(), 0,0,out_units),MEAN);
+            }
         }
 
         time_t Bmi_Module_Formulation::get_variable_time_begin(const std::string &variable_name) {

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -140,7 +140,7 @@ namespace realization {
                             << "' catchment '" << get_catchment_id()
                             << "' variable '" << get_bmi_main_output_var()
                             << "' units 'm" << "'}"
-                            << " provider {'" << uce.provider_bmi_var_name 
+                            << " provider {'" << uce.provider_model_name 
                             << "' source variable '" << uce.provider_bmi_var_name << "'"
                             << " raw value " << uce.unconverted_values[0] << "}"
                             << " message \"" << uce.what() << "\"";

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -38,7 +38,7 @@ namespace realization {
             int var_array_size = get_output_variable_names().size();
             for (int i = 0; i < var_array_size; ++i) {
                 output_str += (output_str.empty() ? "" : ",") + 
-                std::to_string(get_value(CatchmentAggrDataSelector(this->get_catchment_id(), get_output_variable_names()[i], 0,0,get_output_variable_units()[i]),MEAN));
+                std::to_string(get_value(CatchmentAggrDataSelector(this->get_catchment_id(), get_output_variable_names()[i], 0,0,"m"),MEAN));
             }
             return output_str;
         }
@@ -97,20 +97,33 @@ namespace realization {
                 // TODO: again, consider whether we should store any historic response, ts_delta, or other var values
                 next_time_step_index++;
             }
+            
+            //return get_var_value_as_double(0,get_bmi_main_output_var());
+
             //get the output variable name and its units in the realization file using the get_bmi_main_output_var()
             std::vector<std::string> out_var_names = get_output_variable_names();
+            LOG("Inside get_response.",LogLevel::WARNING);
             auto it = std::find(out_var_names.begin(), out_var_names.end(), get_bmi_main_output_var());
             if (it != out_var_names.end()){
                 //indicates that the matching variable name was found. 
                 int out_var_index = distance(out_var_names.begin(), it); //get the item index in the vector
-                return get_value(CatchmentAggrDataSelector(this->get_catchment_id(), out_var_names[out_var_index], 0,0,get_output_variable_units()[out_var_index]),MEAN);
+                LOG("Inside get_response - found variable",LogLevel::WARNING);
+                try{
+                    std::string bmi_units = get_bmi_model()->GetVarUnits(out_var_names[out_var_index]);
+                    return get_value(CatchmentAggrDataSelector(this->get_catchment_id(), out_var_names[out_var_index], 0,0,bmi_units),MEAN);
+                } catch(std::exception &e){
+                    return get_value(CatchmentAggrDataSelector(this->get_catchment_id(), out_var_names[out_var_index], 0,0,"m"),MEAN);
+                }
             }
             else{
                 //indicates that the bmi main output doesn't match with any variables mentioned in the realization file.
-                //we get the variable units from the bmi and pass it to get the value. no unit conversion will happen.
-                std::string units_in_bmi = get_bmi_model()->GetVarUnits(get_bmi_main_output_var());
-                std::string out_units  = (units_in_bmi.empty() || units_in_bmi == "none") ? "1" : units_in_bmi;
-                return get_value(CatchmentAggrDataSelector(this->get_catchment_id(), get_bmi_main_output_var(), 0,0,out_units),MEAN);
+                LOG("Inside get_response - variable not found",LogLevel::WARNING);
+                try{
+                    std::string bmi_units = get_bmi_model()->GetVarUnits(get_bmi_main_output_var());
+                    return get_value(CatchmentAggrDataSelector(this->get_catchment_id(), get_bmi_main_output_var(), 0,0,bmi_units),MEAN);
+                } catch(std::exception &e){
+                    return get_value(CatchmentAggrDataSelector(this->get_catchment_id(), get_bmi_main_output_var(), 0,0,"m"),MEAN);
+                }
             }
         }
 
@@ -227,11 +240,15 @@ namespace realization {
             long duration_s = selector.get_duration_secs();
             std::string output_units = selector.get_output_units();
 
+            LOG("Inside get_value for: " + output_name,LogLevel::WARNING);
+            double value = get_var_value_as_double(0, output_name);
+
+
             // First make sure this is an available output
-            auto forcing_outputs = get_available_variable_names();
-            if (std::find(forcing_outputs.begin(), forcing_outputs.end(), output_name) == forcing_outputs.end()) {
-                throw std::runtime_error(get_formulation_type() + " received invalid output forcing name " + output_name);
-            }
+            // auto forcing_outputs = get_available_variable_names();
+            // if (std::find(forcing_outputs.begin(), forcing_outputs.end(), output_name) == forcing_outputs.end()) {
+            //     throw std::runtime_error(get_formulation_type() + " received invalid output forcing name " + output_name);
+            // }
             // TODO: do this, or something better, later; right now, just assume anything using this as a provider is
             //  consistent with times
             /*

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -35,10 +35,12 @@ namespace realization {
             }
 
             std::string output_str;
-            for (const std::string& name : get_output_variable_names()) {
-                //Shouldn't be using "m". Should we use get_bmi_model()->GetVarUnits(name)?
+            for (int i = 0; i < get_output_variable_names().size(); ++i) {
+                std::string name = get_output_variable_names()[i];
+                std::string output_units = get_output_variable_units()[i];
+                std::string out_units_norm = (output_units.empty() || output_units == "none") ? "1" : output_units;
                 output_str += (output_str.empty() ? "" : ",") + 
-                std::to_string(get_value(CatchmentAggrDataSelector(this->get_catchment_id(), name, 0,0,"m"),MEAN)); 
+                std::to_string(get_value(CatchmentAggrDataSelector(this->get_catchment_id(), name, 0,0,output_units),MEAN)); 
             }
             return output_str;
         }

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -24,7 +24,10 @@ namespace realization {
             if(iter != available_forcing_units.end()){
                 return iter->second;
             }
-            //is there a possibility of key not found?
+            std::string throw_msg; 
+            throw_msg.assign("Got request to retrieve units for variable '" + name + "', but it was not found in the data provider. This should not happen." + SOURCE_LOC);
+            LOG(throw_msg, LogLevel::WARNING);
+            throw std::runtime_error(throw_msg);
         }
 
         std::string Bmi_Module_Formulation::get_output_line_for_timestep(int timestep, std::string delimiter) {
@@ -203,22 +206,7 @@ namespace realization {
             throw std::runtime_error("Bmi_Singular_Formulation does not yet implement get_ts_index_for_time");
         }
 
-        const std::string Bmi_Module_Formulation::get_bmi_native_units(const std::string &name) const {
-            // check if output is available from BMI
-            std::string bmi_var_name;
-            get_bmi_output_var_name(name, bmi_var_name);
-
-            if(!bmi_var_name.empty())
-            {
-                return get_bmi_model()->GetVarUnits(bmi_var_name);
-            }
-            else{
-                LOG("Correct BMI variable name not available for " + name + ". Units cannot be queried.", LogLevel::WARNING);
-                throw std::runtime_error("Correct BMI variable name not available for " + name + ". Units cannot be queried.");
-            }
-        }
-
-	    std::vector<double> Bmi_Module_Formulation::get_values(const CatchmentAggrDataSelector& selector, data_access::ReSampleMethod m)
+        std::vector<double> Bmi_Module_Formulation::get_values(const CatchmentAggrDataSelector& selector, data_access::ReSampleMethod m)
         {
             std::string output_name = selector.get_variable_name();
             time_t init_time = selector.get_init_time();
@@ -450,6 +438,7 @@ namespace realization {
                     bmi_var_names_map.insert(
                             std::pair<std::string, std::string>(names_it.first, names_it.second.as_string()));
                 }
+                set_variable_map_availability(true);
             }
 
             // Do this next, since after checking whether other input variables are present in the properties, we can
@@ -563,20 +552,6 @@ namespace realization {
                 set_output_header_fields(get_output_variable_names());
             }
             
-            //check if units have not been specified. If not, default to native units.
-            std::string blank_string = "";
-            auto &names = get_output_variable_names();
-            if(out_units.size() == 0){
-                out_units.resize(names.size(), blank_string);
-            }
-
-            for (int i = 0; i < names.size(); ++i) {
-                if (out_units[i] == blank_string){
-                    out_units[i] = get_bmi_native_units(names[i]);
-                }
-            }
-            set_output_variable_units(out_units);
-                                    
             // Output precision, if present
             auto out_precision_it = properties.find(BMI_REALIZATION_CFG_PARAM_OPT__OUTPUT_PRECISION);
             if (out_precision_it != properties.end()) {
@@ -591,12 +566,28 @@ namespace realization {
                 for (const std::string &output_var_name : get_bmi_model()->GetOutputVarNames()) {
                     available_forcings.push_back(output_var_name);
                     available_forcing_units[output_var_name] = get_bmi_model()->GetVarUnits(output_var_name);
-                    if (bmi_var_names_map.find(output_var_name) != bmi_var_names_map.end())
-                        available_forcings.push_back(bmi_var_names_map[output_var_name]);
-                        available_forcing_units[bmi_var_names_map[output_var_name]] = get_bmi_model()->GetVarUnits(output_var_name); //units come from the model output variable.
-                      
+                    if (is_variable_mapping_provided()){
+                        if (bmi_var_names_map.find(output_var_name) != bmi_var_names_map.end()){
+                            available_forcings.push_back(bmi_var_names_map[output_var_name]);
+                            available_forcing_units[bmi_var_names_map[output_var_name]] = get_bmi_model()->GetVarUnits(output_var_name); //units come from the model output variable.
+                        }
+                    } 
                 }
             }
+
+            //check if units have not been specified. If not, default to native units.
+            std::string blank_string = "";
+            auto &names = get_output_variable_names();
+            if(out_units.size() == 0){
+                out_units.resize(names.size(), blank_string);
+            }
+
+            for (int i = 0; i < names.size(); ++i) {
+                if (out_units[i] == blank_string){
+                    out_units[i] = get_provider_units_for_variable(names[i]);
+                }
+            }
+            set_output_variable_units(out_units);
         }
         /**
          * @brief Template function for copying iterator range into contiguous array.
@@ -791,6 +782,10 @@ namespace realization {
             return legacy_json_format;
         }
 
+        bool Bmi_Module_Formulation::is_variable_mapping_provided() const {
+            return variable_names_map_provided;
+        }
+
         void Bmi_Module_Formulation::set_allow_model_exceed_end_time(bool allow_exceed_end) {
             allow_model_exceed_end_time = allow_exceed_end;
         }
@@ -816,6 +811,10 @@ namespace realization {
 
         void Bmi_Module_Formulation::set_realization_file_format(bool is_legacy_format){
             legacy_json_format = is_legacy_format;
+        }
+
+        void Bmi_Module_Formulation::set_variable_map_availability(bool is_variable_map_available){
+            variable_names_map_provided = is_variable_map_available;
         }
 
         // TODO: need to modify this to support arrays properly, since in general that's what BMI modules deal with

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -204,6 +204,10 @@ namespace realization {
             {
                 return get_bmi_model()->GetVarUnits(bmi_var_name);
             }
+            else{
+                LOG("Correct BMI variable name not available for " + name + ". Units cannot be queried.", LogLevel::WARNING);
+                throw std::runtime_error("Correct BMI variable name not available for " + name + ". Units cannot be queried.");
+            }
         }
 
 	    std::vector<double> Bmi_Module_Formulation::get_values(const CatchmentAggrDataSelector& selector, data_access::ReSampleMethod m)

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -24,7 +24,7 @@ namespace realization {
             if(iter != available_forcing_units.end()){
                 return iter->second;
             }
-            std::string throw_msg; 
+            std::string throw_msg;
             throw_msg.assign("Got request to retrieve units for variable '" + name + "', but it was not found in the data provider. This should not happen." + SOURCE_LOC);
             LOG(throw_msg, LogLevel::WARNING);
             throw std::runtime_error(throw_msg);
@@ -36,6 +36,7 @@ namespace realization {
             if (timestep != (next_time_step_index - 1)) {
                 throw std::invalid_argument("Only current time step valid when getting output for BMI C++ formulation");
             }
+
             static bool no_conversion_message_logged = false;
             if (!no_conversion_message_logged) {
                 no_conversion_message_logged = true;
@@ -63,7 +64,7 @@ namespace realization {
                             << "' catchment '" << get_catchment_id()
                             << "' variable '" << name
                             << "' units '" << output_var_units[i] << "'}"
-                            << " provider {'" << uce.provider_model_name 
+                            << " provider {'" << uce.provider_model_name
                             << "' source variable '" << uce.provider_bmi_var_name << "'"
                             << " raw value " << uce.unconverted_values[0] << "}"
                             << " message \"" << uce.what() << "\"";
@@ -150,7 +151,7 @@ namespace realization {
                         << "' catchment '" << get_catchment_id()
                         << "' variable '" << get_bmi_main_output_var()
                         << "' units 'm'}"
-                        << " provider {'" << uce.provider_model_name 
+                        << " provider {'" << uce.provider_model_name
                         << "' source variable '" << uce.provider_bmi_var_name << "'"
                         << " raw value " << uce.unconverted_values[0] << "}"
                         << " message \"" << uce.what() << "\"";
@@ -547,7 +548,7 @@ namespace realization {
                 // if new format and no output/headers are mentioned.
                 set_output_header_fields(get_output_variable_names());
             }
-            
+
             // Output precision, if present
             auto out_precision_it = properties.find(BMI_REALIZATION_CFG_PARAM_OPT__OUTPUT_PRECISION);
             if (out_precision_it != properties.end()) {

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -19,6 +19,14 @@ namespace realization {
             return available_forcings;
         }
 
+        const std::string Bmi_Module_Formulation::get_provider_units_for_variable(const std::string& name) const{
+            auto iter = available_forcing_units.find(name);
+            if(iter != available_forcing_units.end()){
+                return iter->second;
+            }
+            //is there a possibility of key not found?
+        }
+
         std::string Bmi_Module_Formulation::get_output_line_for_timestep(int timestep, std::string delimiter) {
             // TODO: something must be added to store values if more than the current time step is wanted
             // TODO: if such a thing is added, it should probably be configurable to turn it off
@@ -582,8 +590,11 @@ namespace realization {
             if (model_initialized) {
                 for (const std::string &output_var_name : get_bmi_model()->GetOutputVarNames()) {
                     available_forcings.push_back(output_var_name);
+                    available_forcing_units[output_var_name] = get_bmi_model()->GetVarUnits(output_var_name);
                     if (bmi_var_names_map.find(output_var_name) != bmi_var_names_map.end())
                         available_forcings.push_back(bmi_var_names_map[output_var_name]);
+                        available_forcing_units[bmi_var_names_map[output_var_name]] = get_bmi_model()->GetVarUnits(output_var_name); //units come from the model output variable.
+                      
                 }
             }
         }

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -25,7 +25,6 @@ namespace realization {
             if (timestep != (next_time_step_index - 1)) {
                 throw std::invalid_argument("Only current time step valid when getting output for BMI C++ formulation");
             }
-
             static bool no_conversion_message_logged = false;
             if (!no_conversion_message_logged) {
                 no_conversion_message_logged = true;
@@ -39,8 +38,26 @@ namespace realization {
                 std::string name = get_output_variable_names()[i];
                 std::string output_units = get_output_variable_units()[i];
                 std::string out_units_norm = (output_units.empty() || output_units == "none") ? "1" : output_units;
+                double var_value;
+                try{
+                    var_value = get_value(CatchmentAggrDataSelector(this->get_catchment_id(), name, 0, 0, output_units), MEAN);
+                }
+                catch(data_access::unit_conversion_exception &uce){
+                    std::stringstream ss;
+                    ss << "Unit conversion failure:"
+                        << " requester {'Get Output Line for Timestep (Module Formulation)"
+                        << "' catchment '" << get_catchment_id()
+                        << "' variable '" << name
+                        << "' units '" << output_units << "'}"
+                        << " provider {'" << uce.provider_model_name 
+                        << "' source variable '" << uce.provider_bmi_var_name << "'"
+                        << " raw value " << uce.unconverted_values.back() << "}"
+                        << " message \"" << uce.what() << "\"";
+                    LOG(ss.str(), LogLevel::WARNING); ss.str("");
+                    var_value = uce.unconverted_values.back();
+                }
                 output_str += (output_str.empty() ? "" : ",") +
-                    std::to_string(get_value(CatchmentAggrDataSelector(this->get_catchment_id(), name, 0, 0, output_units), MEAN));
+                    std::to_string(var_value);
             }
             return output_str;
         }
@@ -103,7 +120,25 @@ namespace realization {
 
         double Bmi_Module_Formulation::get_response(time_step_t t_index, time_step_t t_delta) {
             update(t_index, t_delta);
-            return get_value(CatchmentAggrDataSelector(this->get_catchment_id(), get_bmi_main_output_var(), 0, 0, "m"),MEAN);
+            double var_value;
+                try{
+                    var_value = get_value(CatchmentAggrDataSelector(this->get_catchment_id(), get_bmi_main_output_var(), 0, 0, "m"),MEAN);
+                }
+                catch(data_access::unit_conversion_exception &uce){
+                    std::stringstream ss;
+                    ss << "Unit conversion failure:"
+                        << " requester {'Get Response (Module Formulation)"
+                        << "' catchment '" << get_catchment_id()
+                        << "' variable '" << get_bmi_main_output_var()
+                        << "' units 'm" << "'}"
+                        << " provider {'" << uce.provider_bmi_var_name 
+                        << "' source variable '" << uce.provider_bmi_var_name << "'"
+                        << " raw value " << uce.unconverted_values.back() << "}"
+                        << " message \"" << uce.what() << "\"";
+                    LOG(ss.str(), LogLevel::WARNING); ss.str("");
+                    var_value = uce.unconverted_values.back();
+                }
+            return var_value;
         }
 
         time_t Bmi_Module_Formulation::get_variable_time_begin(const std::string &variable_name) {

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -125,29 +125,29 @@ namespace realization {
 
         double Bmi_Module_Formulation::get_response(time_step_t t_index, time_step_t t_delta) {
             update(t_index, t_delta);
-            double var_value; // = get_var_value_as_double(0, get_bmi_main_output_var());
-                try{
-                    var_value = get_value(CatchmentAggrDataSelector(this->get_catchment_id(), get_bmi_main_output_var(), 0, 0, "m"),MEAN);
+            double var_value;
+            try{
+                var_value = get_value(CatchmentAggrDataSelector(this->get_catchment_id(), get_bmi_main_output_var(), 0, 0, "m"),MEAN);
+            }
+            catch(data_access::unit_conversion_exception &uce){
+                data_access::unit_error_log_key key{"Bmi_Module_Formulation::get_response", get_bmi_main_output_var(), uce.provider_model_name, uce.provider_bmi_var_name, uce.what()};
+                auto ret = data_access::unit_errors_reported.insert(key);
+                bool new_error = ret.second;
+                if (new_error) {
+                    std::stringstream ss;
+                    ss << "Unit conversion failure:"
+                        << " requester {'Get Response (Module Formulation)"
+                        << "' catchment '" << get_catchment_id()
+                        << "' variable '" << get_bmi_main_output_var()
+                        << "' units 'm" << "'}"
+                        << " provider {'" << uce.provider_model_name 
+                        << "' source variable '" << uce.provider_bmi_var_name << "'"
+                        << " raw value " << uce.unconverted_values[0] << "}"
+                        << " message \"" << uce.what() << "\"";
+                    LOG(ss.str(), LogLevel::WARNING); ss.str("");
                 }
-                catch(data_access::unit_conversion_exception &uce){
-                    data_access::unit_error_log_key key{"Bmi_Module_Formulation::get_response", get_bmi_main_output_var(), uce.provider_model_name, uce.provider_bmi_var_name, uce.what()};
-                    auto ret = data_access::unit_errors_reported.insert(key);
-                    bool new_error = ret.second;
-                    if (new_error) {
-                        std::stringstream ss;
-                        ss << "Unit conversion failure:"
-                            << " requester {'Get Response (Module Formulation)"
-                            << "' catchment '" << get_catchment_id()
-                            << "' variable '" << get_bmi_main_output_var()
-                            << "' units 'm" << "'}"
-                            << " provider {'" << uce.provider_model_name 
-                            << "' source variable '" << uce.provider_bmi_var_name << "'"
-                            << " raw value " << uce.unconverted_values[0] << "}"
-                            << " message \"" << uce.what() << "\"";
-                        LOG(ss.str(), LogLevel::WARNING); ss.str("");
-                    }
-                    var_value = uce.unconverted_values[0];
-                }
+                var_value = uce.unconverted_values[0];
+            }
             return var_value;
         }
 
@@ -195,11 +195,18 @@ namespace realization {
             throw std::runtime_error("Bmi_Singular_Formulation does not yet implement get_ts_index_for_time");
         }
 
-        const std::string Bmi_Module_Formulation::get_bmi_native_units(const std::string &name) const {
-            return get_bmi_model()->GetVarUnits(name);
+        const std::string Bmi_Module_Formulation::get_bmi_native_units(const std::string &name) {
+            // check if output is available from BMI
+            std::string bmi_var_name;
+            get_bmi_output_var_name(name, bmi_var_name);
+
+            if(!bmi_var_name.empty())
+            {
+                return get_bmi_model()->GetVarUnits(bmi_var_name);
+            }
         }
 
-	std::vector<double> Bmi_Module_Formulation::get_values(const CatchmentAggrDataSelector& selector, data_access::ReSampleMethod m)
+	    std::vector<double> Bmi_Module_Formulation::get_values(const CatchmentAggrDataSelector& selector, data_access::ReSampleMethod m)
         {
             std::string output_name = selector.get_variable_name();
             time_t init_time = selector.get_init_time();
@@ -487,7 +494,7 @@ namespace realization {
                             out_units[i] = out_vars_json_list[i].at("units").as_string();
                         }
                         else{
-                           LOG("Units not provided for '" + out_vars[i] + "' in the realization file.",LogLevel::INFO);
+                           LOG("Units not provided for '" + out_vars[i] + "' in the realization file.",LogLevel::WARNING);
                            out_units[i] = ""; //add an empty entry and populate it with BMI native units later.
                         }
                     }

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -485,6 +485,7 @@ namespace realization {
                         }
                         else{
                            LOG("Units not provided for '" + out_vars[i] + "' in the realization file.",LogLevel::INFO);
+                           out_units[i] = ""; //add an empty entry and populate it with BMI native units later.
                         }
                     }
                     //check if the units can be parsed correctly and write a warning message
@@ -532,13 +533,27 @@ namespace realization {
             }
             
             //check if units have not been specified. If not, default to native units.
+            std::string blank_string = "";
+            auto &names = get_output_variable_names();
             if(out_units.size() == 0){
-                out_units.resize(get_output_variable_names().size());
-                for (int i = 0; i < get_output_variable_names().size(); ++i) {
+                out_units.resize(names.size());
+                for (int i = 0; i < names.size(); ++i) {
                     std::string bmi_var_name;
-                    get_bmi_output_var_name(get_output_variable_names()[i], bmi_var_name);
+                    get_bmi_output_var_name(names[i], bmi_var_name);
                     if(!bmi_var_name.empty()){
                         out_units[i] = get_bmi_model()->GetVarUnits(bmi_var_name);
+                    }
+                }
+                set_output_variable_units(out_units);
+            }
+            else if(std::find(out_units.begin(), out_units.end(), blank_string) != out_units.end()){
+                for (int i = 0; i < names.size(); ++i) {
+                    if (out_units[i] == blank_string){
+                        std::string bmi_var_name;
+                        get_bmi_output_var_name(names[i], bmi_var_name);
+                        if(!bmi_var_name.empty()){
+                            out_units[i] = get_bmi_model()->GetVarUnits(bmi_var_name);
+                        }
                     }
                 }
                 set_output_variable_units(out_units);

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -35,7 +35,6 @@ namespace realization {
             }
 
             std::string output_str;
-            int var_array_size = get_output_variable_names().size();
             for (const std::string& name : get_output_variable_names()) {
                 //Shouldn't be using "m". Should we use get_bmi_model()->GetVarUnits(name)?
                 output_str += (output_str.empty() ? "" : ",") + 

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -43,18 +43,23 @@ namespace realization {
                     var_value = get_value(CatchmentAggrDataSelector(this->get_catchment_id(), name, 0, 0, output_units), MEAN);
                 }
                 catch(data_access::unit_conversion_exception &uce){
-                    std::stringstream ss;
-                    ss << "Unit conversion failure:"
-                        << " requester {'Get Output Line for Timestep (Module Formulation)"
-                        << "' catchment '" << get_catchment_id()
-                        << "' variable '" << name
-                        << "' units '" << output_units << "'}"
-                        << " provider {'" << uce.provider_model_name 
-                        << "' source variable '" << uce.provider_bmi_var_name << "'"
-                        << " raw value " << uce.unconverted_values.back() << "}"
-                        << " message \"" << uce.what() << "\"";
-                    LOG(ss.str(), LogLevel::WARNING); ss.str("");
-                    var_value = uce.unconverted_values.back();
+                    data_access::unit_error_log_key key{get_id(), name, uce.provider_model_name, uce.provider_bmi_var_name, uce.what()};
+                    auto ret = data_access::unit_errors_reported.insert(key);
+                    bool new_error = ret.second;
+                    if (new_error) {
+                        std::stringstream ss;
+                        ss << "Unit conversion failure:"
+                            << " requester {'Get Output Line for Timestep (Module Formulation)"
+                            << "' catchment '" << get_catchment_id()
+                            << "' variable '" << name
+                            << "' units '" << output_units << "'}"
+                            << " provider {'" << uce.provider_model_name 
+                            << "' source variable '" << uce.provider_bmi_var_name << "'"
+                            << " raw value " << uce.unconverted_values[0] << "}"
+                            << " message \"" << uce.what() << "\"";
+                        LOG(ss.str(), LogLevel::WARNING); ss.str("");
+                    }
+                    var_value = uce.unconverted_values[0];
                 }
                 output_str += (output_str.empty() ? "" : ",") +
                     std::to_string(var_value);
@@ -125,18 +130,23 @@ namespace realization {
                     var_value = get_value(CatchmentAggrDataSelector(this->get_catchment_id(), get_bmi_main_output_var(), 0, 0, "m"),MEAN);
                 }
                 catch(data_access::unit_conversion_exception &uce){
-                    std::stringstream ss;
-                    ss << "Unit conversion failure:"
-                        << " requester {'Get Response (Module Formulation)"
-                        << "' catchment '" << get_catchment_id()
-                        << "' variable '" << get_bmi_main_output_var()
-                        << "' units 'm" << "'}"
-                        << " provider {'" << uce.provider_bmi_var_name 
-                        << "' source variable '" << uce.provider_bmi_var_name << "'"
-                        << " raw value " << uce.unconverted_values.back() << "}"
-                        << " message \"" << uce.what() << "\"";
-                    LOG(ss.str(), LogLevel::WARNING); ss.str("");
-                    var_value = uce.unconverted_values.back();
+                    data_access::unit_error_log_key key{get_id(), get_bmi_main_output_var(), uce.provider_model_name, uce.provider_bmi_var_name, uce.what()};
+                    auto ret = data_access::unit_errors_reported.insert(key);
+                    bool new_error = ret.second;
+                    if (new_error) {
+                        std::stringstream ss;
+                        ss << "Unit conversion failure:"
+                            << " requester {'Get Response (Module Formulation)"
+                            << "' catchment '" << get_catchment_id()
+                            << "' variable '" << get_bmi_main_output_var()
+                            << "' units 'm" << "'}"
+                            << " provider {'" << uce.provider_bmi_var_name 
+                            << "' source variable '" << uce.provider_bmi_var_name << "'"
+                            << " raw value " << uce.unconverted_values[0] << "}"
+                            << " message \"" << uce.what() << "\"";
+                        LOG(ss.str(), LogLevel::WARNING); ss.str("");
+                        var_value = uce.unconverted_values[0];
+                    }
                 }
             return var_value;
         }

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -195,7 +195,7 @@ namespace realization {
             throw std::runtime_error("Bmi_Singular_Formulation does not yet implement get_ts_index_for_time");
         }
 
-        const std::string Bmi_Module_Formulation::get_bmi_native_units(const std::string &name) {
+        const std::string Bmi_Module_Formulation::get_bmi_native_units(const std::string &name) const {
             // check if output is available from BMI
             std::string bmi_var_name;
             get_bmi_output_var_name(name, bmi_var_name);
@@ -351,7 +351,7 @@ namespace realization {
             return get_bmi_model()->GetOutputVarNames();
         }
 
-        void Bmi_Module_Formulation::get_bmi_output_var_name(const std::string &name, std::string &bmi_var_name)
+        void Bmi_Module_Formulation::get_bmi_output_var_name(const std::string &name, std::string &bmi_var_name) const
         {
             //check standard output names first
             std::vector<std::string> output_names = get_bmi_model()->GetOutputVarNames();
@@ -362,7 +362,7 @@ namespace realization {
             {
                 //check mapped names
                 std::string mapped_name;
-                for (auto & iter : bmi_var_names_map) {
+                for (auto const& iter : bmi_var_names_map) {
                     if (iter.second == name) {
                         mapped_name = iter.first;
                         break;

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -442,8 +442,8 @@ std::string Bmi_Multi_Formulation::get_output_line_for_timestep(int timestep, st
                         << " raw value " << uce.unconverted_values[0] << "}"
                         << " message \"" << uce.what() << "\"";
                     LOG(ss.str(), LogLevel::WARNING); ss.str("");
-                    value = uce.unconverted_values[0];
                 }
+                value = uce.unconverted_values[0];
             }
             std::string var_value = std::to_string(value);
             if(i == 0){

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -209,10 +209,7 @@ void Bmi_Multi_Formulation::create_multi_formulation(geojson::PropertyMap proper
         }
         set_output_variable_units(out_units);
     }
-    else{
-        LOG("Out units size: " + std::to_string(out_units.size()),LogLevel::WARNING);
-    }
-    
+        
     // Output precision, if present
     auto out_precision_it = properties.find(BMI_REALIZATION_CFG_PARAM_OPT__OUTPUT_PRECISION);
     if (out_precision_it != properties.end()) {
@@ -361,14 +358,18 @@ const std::string &Bmi_Multi_Formulation::get_config_mapped_variable_name(const 
 }
 
 const std::string Bmi_Multi_Formulation::get_bmi_native_units(const std::string &name) const {
-    auto iter = availableData.find(name);
-    if(iter == availableData.end()){
-        //handle exception
-        LOG("Multi BMI formulation: No module found for variable " + name, LogLevel::WARNING);
-        throw std::runtime_error("Multi BMI formulation: No module found for variable " + name);
+
+    if(!is_out_vars_from_last_mod){
+        auto iter = availableData.find(name);
+        if(iter == availableData.end()){
+            //handle exception
+            LOG("Multi BMI formulation: No module found for variable " + name, LogLevel::WARNING);
+            throw std::runtime_error("Multi BMI formulation: No module found for variable " + name);
+        }
+        auto model = std::dynamic_pointer_cast<Bmi_Formulation>(iter->second);
+        return model->get_bmi_native_units(name);
     }
-    auto model = std::dynamic_pointer_cast<Bmi_Formulation>(iter->second);
-    return model->get_bmi_native_units(name);
+    return modules.back()->get_bmi_native_units(name);
 }
 
 std::string Bmi_Multi_Formulation::get_output_line_for_timestep(int timestep, std::string delimiter) {

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -452,12 +452,11 @@ std::string Bmi_Multi_Formulation::get_output_line_for_timestep(int timestep, st
                 }
                 value = uce.unconverted_values[0];
             }
-            std::string var_value = std::to_string(value);
             if(i == 0){
-                *output_text_stream << var_value; //without delimiter for first output variable.
+                *output_text_stream << value; //without delimiter for first output variable.
             }
             else{
-                *output_text_stream << delimiter << var_value; //with delimiter for the rest.
+                *output_text_stream << delimiter << value; //with delimiter for the rest.
             }
         }
         return output_text_stream->str();

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -376,18 +376,23 @@ std::string Bmi_Multi_Formulation::get_output_line_for_timestep(int timestep, st
                 value = get_value(CatchmentAggrDataSelector(get_catchment_id(), output_var_names[i], 0, 0, output_var_units[i]), MEAN);    
             }
             catch(data_access::unit_conversion_exception &uce){
-                std::stringstream ss;
-                ss << "Unit conversion failure:"
-                    << " requester {'Get Output Line for Timestep (Multi Formulation)"
-                    << "' catchment '" << get_catchment_id()
-                    << "' variable '" << output_var_names[i]
-                    << "' units '" << output_var_units[i] << "'}" 
-                    << " provider {'" << uce.provider_model_name 
-                    << "' source variable '" << uce.provider_bmi_var_name << "'"
-                    << " raw value " << uce.unconverted_values.back() << "}"
-                    << " message \"" << uce.what() << "\"";
-                LOG(ss.str(), LogLevel::WARNING); ss.str("");
-                value = uce.unconverted_values.back();
+                data_access::unit_error_log_key key{get_id(), get_bmi_main_output_var(), uce.provider_model_name, uce.provider_bmi_var_name, uce.what()};
+                auto ret = data_access::unit_errors_reported.insert(key);
+                bool new_error = ret.second;
+                if (new_error) {
+                    std::stringstream ss;
+                    ss << "Unit conversion failure:"
+                        << " requester {'Get Output Line for Timestep (Multi Formulation)"
+                        << "' catchment '" << get_catchment_id()
+                        << "' variable '" << output_var_names[i]
+                        << "' units '" << output_var_units[i] << "'}" 
+                        << " provider {'" << uce.provider_model_name 
+                        << "' source variable '" << uce.provider_bmi_var_name << "'"
+                        << " raw value " << uce.unconverted_values[0] << "}"
+                        << " message \"" << uce.what() << "\"";
+                    LOG(ss.str(), LogLevel::WARNING); ss.str("");
+                    value = uce.unconverted_values[0];
+                }
             }
             std::string var_value = std::to_string(value);
             if(i == 0){

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -148,9 +148,9 @@ void Bmi_Multi_Formulation::create_multi_formulation(geojson::PropertyMap proper
                 }
             }
             set_output_variable_units(out_units);
+            set_output_header_fields(out_headers);
         }
         set_output_variable_names(out_vars);
-        set_output_header_fields(out_headers);
     }
     // Otherwise, for multi BMI, the BMI output variables of the last nested module should be used.
     else {
@@ -198,6 +198,21 @@ void Bmi_Multi_Formulation::create_multi_formulation(geojson::PropertyMap proper
             //put out a message that this is ignored.
             LOG("Deprecated output_header_fields item found in realization file ignored.", LogLevel::WARNING);
         }
+    }
+
+    bool model_initialized = is_model_initialized();
+    
+    // //check if units have not been specified. If not, default to native units.
+    if(out_units.size() == 0){
+        auto &names = get_output_variable_names();
+        out_units.resize(names.size());
+        for (int i = 0; i < names.size(); ++i) {
+            out_units[i] = get_bmi_native_units(names[i]);
+        }
+        set_output_variable_units(out_units);
+    }
+    else{
+        LOG("Out units size: " + std::to_string(out_units.size()),LogLevel::WARNING);
     }
     
     // Output precision, if present
@@ -347,6 +362,17 @@ const std::string &Bmi_Multi_Formulation::get_config_mapped_variable_name(const 
     return output_var_name;
 }
 
+const std::string Bmi_Multi_Formulation::get_bmi_native_units(const std::string &name) const {
+    auto iter = availableData.find(name);
+    if(iter == availableData.end()){
+        //handle exception
+        LOG("Multi BMI formulation: No module found for variable " + name, LogLevel::WARNING);
+        throw std::runtime_error("Multi BMI formulation: No module found for variable " + name);
+    }
+    auto model = std::dynamic_pointer_cast<Bmi_Formulation>(iter->second);
+    return model->get_bmi_native_units(name);
+}
+
 std::string Bmi_Multi_Formulation::get_output_line_for_timestep(int timestep, std::string delimiter) {
     // TODO: have to do some figuring out to make sure this isn't ambiguous (i.e., same output var name from two modules)
     // TODO: need to verify that output variable names are valid, or else warn and return default
@@ -373,10 +399,10 @@ std::string Bmi_Multi_Formulation::get_output_line_for_timestep(int timestep, st
         for (int i = 0; i < output_var_names.size(); ++i) {
             double value;
             try{
-                value = get_value(CatchmentAggrDataSelector(get_catchment_id(), output_var_names[i], 0, 0, output_var_units[i]), MEAN);    
+                value = get_value(CatchmentAggrDataSelector(get_catchment_id(), output_var_names[i], 0, 0, output_var_units[i]), MEAN);
             }
             catch(data_access::unit_conversion_exception &uce){
-                data_access::unit_error_log_key key{get_id(), get_bmi_main_output_var(), uce.provider_model_name, uce.provider_bmi_var_name, uce.what()};
+                data_access::unit_error_log_key key{"File Output Multi", output_var_names[i], uce.provider_model_name, uce.provider_bmi_var_name, uce.what()};
                 auto ret = data_access::unit_errors_reported.insert(key);
                 bool new_error = ret.second;
                 if (new_error) {

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -220,21 +220,15 @@ void Bmi_Multi_Formulation::create_multi_formulation(geojson::PropertyMap proper
     std::string blank_string = "";
     auto &names = get_output_variable_names();
     if(out_units.size() == 0){
-        out_units.resize(names.size());
-        for (int i = 0; i < names.size(); ++i) {
+        out_units.resize(names.size(), blank_string);
+    }
+
+    for (int i = 0; i < names.size(); ++i) {
+        if (out_units[i] == blank_string){
             out_units[i] = get_bmi_native_units(names[i]);
-        } 
-        set_output_variable_units(out_units);
-    }
-    else if(std::find(out_units.begin(), out_units.end(), blank_string) != out_units.end()){
-        //this condition is when the user has not specified units for an output variable.
-        for (int i = 0; i < names.size(); ++i) {
-            if (out_units[i] == blank_string){
-                out_units[i] = get_bmi_native_units(names[i]);
-            }
         }
-        set_output_variable_units(out_units);
     }
+    set_output_variable_units(out_units);
 
     // Output precision, if present
     auto out_precision_it = properties.find(BMI_REALIZATION_CFG_PARAM_OPT__OUTPUT_PRECISION);

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -371,7 +371,24 @@ std::string Bmi_Multi_Formulation::get_output_line_for_timestep(int timestep, st
         if (output_var_names.empty()) { return ""; }
 
         for (int i = 0; i < output_var_names.size(); ++i) {
-            double value = get_value(CatchmentAggrDataSelector(get_catchment_id(), output_var_names[i], 0, 0, output_var_units[i]), MEAN);
+            double value;
+            try{
+                value = get_value(CatchmentAggrDataSelector(get_catchment_id(), output_var_names[i], 0, 0, output_var_units[i]), MEAN);    
+            }
+            catch(data_access::unit_conversion_exception &uce){
+                std::stringstream ss;
+                ss << "Unit conversion failure:"
+                    << " requester {'Get Output Line for Timestep (Multi Formulation)"
+                    << "' catchment '" << get_catchment_id()
+                    << "' variable '" << output_var_names[i]
+                    << "' units '" << output_var_units[i] << "'}" 
+                    << " provider {'" << uce.provider_model_name 
+                    << "' source variable '" << uce.provider_bmi_var_name << "'"
+                    << " raw value " << uce.unconverted_values.back() << "}"
+                    << " message \"" << uce.what() << "\"";
+                LOG(ss.str(), LogLevel::WARNING); ss.str("");
+                value = uce.unconverted_values.back();
+            }
             std::string var_value = std::to_string(value);
             if(i == 0){
                 *output_text_stream << var_value; //without delimiter for first output variable.

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -365,17 +365,21 @@ std::string Bmi_Multi_Formulation::get_output_line_for_timestep(int timestep, st
         output_text_stream->str(std::string());
 
         const std::vector<std::string> &output_var_names = get_output_variable_names();
+        const std::vector<std::string> &output_var_units = get_output_variable_units();
+
         // This almost certainly should never happen, but just to be safe ...
         if (output_var_names.empty()) { return ""; }
-
-        // Do the first separately, without the leading comma
-        *output_text_stream << get_var_value_as_double(0, output_var_names[0]);
-
-        // Do the rest with a leading comma
-        for (int i = 1; i < output_var_names.size(); ++i) {
-            *output_text_stream << delimiter << get_var_value_as_double(0, output_var_names[i]);
+        
+        for (int i = 0; i < output_var_names.size(); ++i) {
+            std::string var_value = std::to_string(get_value(CatchmentAggrDataSelector(get_catchment_id(), output_var_names[i], 0,0,output_var_units[i]),MEAN));    
+            if(i == 0){
+                *output_text_stream << var_value; //without delimiter for first output variable.
+            }
+            else{
+                *output_text_stream << delimiter << var_value; //with delimiter for the rest.
+            }
         }
-        return output_text_stream->str();
+         return output_text_stream->str();
     }
     // Otherwise, use the default behavior, which means we either
     //   - were originally set to use the default of getting the output of the last module

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -383,7 +383,7 @@ std::string Bmi_Multi_Formulation::get_output_line_for_timestep(int timestep, st
     return modules.back()->get_output_line_for_timestep(timestep, delimiter);
 }
 
-double Bmi_Multi_Formulation::get_response(time_step_t t_index, time_step_t t_delta) {
+void Bmi_Multi_Formulation::update(time_step_t t_index, time_step_t t_delta) {
     if (modules.empty()) {
         Logger::logMsgAndThrowError("Trying to get response of improperly created empty BMI multi-module formulation.");
     }
@@ -428,10 +428,14 @@ double Bmi_Multi_Formulation::get_response(time_step_t t_index, time_step_t t_de
     while (next_time_step_index <= t_index) {
         for (nested_module_ptr &module : modules) {
             // By setting up in create function, these will now have their own providers
-            module->get_response(t_index, t_delta);
+            module->update(t_index, t_delta);
         }
         next_time_step_index++;
     }
+}
+
+double Bmi_Multi_Formulation::get_response(time_step_t t_index, time_step_t t_delta) {
+    update(t_index, t_delta);
     // Find the right module for the main output, checking primary first
     int index = get_index_for_primary_module();
     std::vector<std::string> out_var_names = modules[index]->get_output_variable_names();
@@ -447,7 +451,8 @@ double Bmi_Multi_Formulation::get_response(time_step_t t_index, time_step_t t_de
         }
     }
 
-    return modules[index]->get_var_value_as_double(0, get_bmi_main_output_var());
+    //return modules[index]->get_var_value_as_double(0, get_bmi_main_output_var());
+    return modules[index]->get_value(CatchmentAggrDataSelector(this->get_catchment_id(), get_bmi_main_output_var(), 0,0,"m"),MEAN);
 }
 
 bool Bmi_Multi_Formulation::is_bmi_input_variable(const std::string &var_name) const {

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -369,9 +369,10 @@ std::string Bmi_Multi_Formulation::get_output_line_for_timestep(int timestep, st
 
         // This almost certainly should never happen, but just to be safe ...
         if (output_var_names.empty()) { return ""; }
-        
+
         for (int i = 0; i < output_var_names.size(); ++i) {
-            std::string var_value = std::to_string(get_value(CatchmentAggrDataSelector(get_catchment_id(), output_var_names[i], 0,0,output_var_units[i]),MEAN));    
+            double value = get_value(CatchmentAggrDataSelector(get_catchment_id(), output_var_names[i], 0, 0, output_var_units[i]), MEAN);
+            std::string var_value = std::to_string(value);
             if(i == 0){
                 *output_text_stream << var_value; //without delimiter for first output variable.
             }
@@ -454,7 +455,7 @@ double Bmi_Multi_Formulation::get_response(time_step_t t_index, time_step_t t_de
             }
         }
     }
-    return modules[index]->get_value(CatchmentAggrDataSelector(this->get_catchment_id(), get_bmi_main_output_var(), 0,0,"m"),MEAN);
+    return modules[index]->get_value(CatchmentAggrDataSelector(this->get_catchment_id(), get_bmi_main_output_var(), 0, 0, "m"), MEAN);
 }
 
 bool Bmi_Multi_Formulation::is_bmi_input_variable(const std::string &var_name) const {

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -450,8 +450,6 @@ double Bmi_Multi_Formulation::get_response(time_step_t t_index, time_step_t t_de
             }
         }
     }
-
-    //return modules[index]->get_var_value_as_double(0, get_bmi_main_output_var());
     return modules[index]->get_value(CatchmentAggrDataSelector(this->get_catchment_id(), get_bmi_main_output_var(), 0,0,"m"),MEAN);
 }
 

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -396,6 +396,10 @@ const std::string Bmi_Multi_Formulation::get_bmi_native_units(const std::string 
         if(model != nullptr){
             return model->get_bmi_native_units(name);
         }
+        else{
+            LOG("Unable to obtain a valid formulation for " + name + ". Units cannot be queried.", LogLevel::WARNING);
+            throw std::runtime_error("Unable to obtain a valid formulation for " + name + ". Units cannot be queried.");
+        }
     }
     return modules.back()->get_bmi_native_units(name);
 }

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -379,7 +379,10 @@ const std::string &Bmi_Multi_Formulation::get_config_mapped_variable_name(const 
 
 const std::string Bmi_Multi_Formulation::get_bmi_native_units(const std::string &name) const {
 
-    if(!is_out_vars_from_last_mod){
+    if(is_out_vars_from_last_mod){
+        return modules.back()->get_bmi_native_units(name);
+    }
+    else{
         auto iter = availableData.find(name);
         if(iter == availableData.end()){
             //handle exception
@@ -394,8 +397,7 @@ const std::string Bmi_Multi_Formulation::get_bmi_native_units(const std::string 
             LOG("Unable to obtain a valid formulation for " + name + ". Units cannot be queried.", LogLevel::WARNING);
             throw std::runtime_error("Unable to obtain a valid formulation for " + name + ". Units cannot be queried.");
         }
-    }
-    return modules.back()->get_bmi_native_units(name);
+    }    
 }
 
 std::string Bmi_Multi_Formulation::get_output_line_for_timestep(int timestep, std::string delimiter) {

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -26,6 +26,7 @@ void Bmi_Multi_Formulation::create_multi_formulation(geojson::PropertyMap proper
     std::shared_ptr<data_access::WrappedDataProvider> forcing_provider = std::make_shared<data_access::WrappedDataProvider>(forcing.get());
     for (const std::string &forcing_name_or_alias : forcing->get_available_variable_names()) {
         availableData[forcing_name_or_alias] = forcing_provider;
+        available_forcing_units[forcing_name_or_alias] = forcing->get_provider_units_for_variable(forcing_name_or_alias);
     }
 
     // Pull default output values, if any present
@@ -225,7 +226,7 @@ void Bmi_Multi_Formulation::create_multi_formulation(geojson::PropertyMap proper
 
     for (int i = 0; i < names.size(); ++i) {
         if (out_units[i] == blank_string){
-            out_units[i] = get_bmi_native_units(names[i]);
+            out_units[i] = get_provider_units_for_variable(names[i]);
         }
     }
     set_output_variable_units(out_units);
@@ -291,14 +292,19 @@ boost::span<const std::string> Bmi_Multi_Formulation::get_available_variable_nam
 }
 
 const std::string Bmi_Multi_Formulation::get_provider_units_for_variable(const std::string& name) const{
-    auto iter = available_forcing_units.find(name);
-    if(iter != available_forcing_units.end()){
-        return iter->second;
+    if(is_out_vars_from_last_mod){
+        return modules.back()->get_provider_units_for_variable(name);
     }
-    std::string throw_msg; 
-    throw_msg.assign("Got request to retrieve units for variable '" + name + "', but it was not found in the data provider. This should not happen." + SOURCE_LOC);
-    LOG(throw_msg, LogLevel::WARNING);
-    throw std::runtime_error(throw_msg);
+    else{
+        auto iter = available_forcing_units.find(name);
+        if(iter != available_forcing_units.end()){
+            return iter->second;
+        }
+        std::string throw_msg; 
+        throw_msg.assign("Got request to retrieve units for variable '" + name + "', but it was not found in the data provider. This should not happen." + SOURCE_LOC);
+        LOG(throw_msg, LogLevel::WARNING);
+        throw std::runtime_error(throw_msg);
+    }
 }
 
 const time_t &Bmi_Multi_Formulation::get_bmi_model_start_time_forcing_offset_s() const {
@@ -388,38 +394,6 @@ const std::string &Bmi_Multi_Formulation::get_config_mapped_variable_name(const 
             return mapped_s;
     }
     return output_var_name;
-}
-
-const std::string Bmi_Multi_Formulation::get_bmi_native_units(const std::string &name) const {
-
-    if(is_out_vars_from_last_mod){
-        return modules.back()->get_bmi_native_units(name);
-    }
-    else{
-        auto iter = availableData.find(name);
-        if(iter == availableData.end()){
-            //handle exception
-            LOG("Multi BMI formulation: No module found for variable " + name, LogLevel::WARNING);
-            throw std::runtime_error("Multi BMI formulation: No module found for variable " + name);
-        }
-        std::string units = forcing->get_provider_units_for_variable(name);
-        if(units != "none"){
-            return units;
-        }
-        else{
-            LOG("Units for '" + name + "' not found in the forcing data.", LogLevel::WARNING);
-            throw std::runtime_error("Units for '" + name + "' not found in the forcing data.");
-        }
-
-        // auto model = std::dynamic_pointer_cast<Bmi_Formulation>(iter->second);
-        // if(model != nullptr){
-        //     return model->get_bmi_native_units(name);
-        // }
-        // else{
-        //     LOG("Unable to obtain a valid formulation for " + name + ". Units cannot be queried.", LogLevel::WARNING);
-        //     throw std::runtime_error("Unable to obtain a valid formulation for " + name + ". Units cannot be queried.");
-        // }
-    }    
 }
 
 std::string Bmi_Multi_Formulation::get_output_line_for_timestep(int timestep, std::string delimiter) {

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -144,7 +144,7 @@ void Bmi_Multi_Formulation::create_multi_formulation(geojson::PropertyMap proper
                     out_units[i] = out_vars_json_list[i].at("units").as_string();
                 }
                 else{
-                    LOG("Units not provided for '" + out_vars[i] + "' in the realization file.",LogLevel::INFO);
+                    LOG("Units not provided for '" + out_vars[i] + "' in the realization file.",LogLevel::WARNING);
                     out_units[i] = ""; //add an empty entry and populate it with BMI native units later.
                 }
             }
@@ -383,7 +383,7 @@ const std::string &Bmi_Multi_Formulation::get_config_mapped_variable_name(const 
     return output_var_name;
 }
 
-const std::string Bmi_Multi_Formulation::get_bmi_native_units(const std::string &name) const {
+const std::string Bmi_Multi_Formulation::get_bmi_native_units(const std::string &name) {
 
     if(!is_out_vars_from_last_mod){
         auto iter = availableData.find(name);
@@ -393,7 +393,9 @@ const std::string Bmi_Multi_Formulation::get_bmi_native_units(const std::string 
             throw std::runtime_error("Multi BMI formulation: No module found for variable " + name);
         }
         auto model = std::dynamic_pointer_cast<Bmi_Formulation>(iter->second);
-        return model->get_bmi_native_units(name);
+        if(model != nullptr){
+            return model->get_bmi_native_units(name);
+        }
     }
     return modules.back()->get_bmi_native_units(name);
 }

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -528,7 +528,30 @@ double Bmi_Multi_Formulation::get_response(time_step_t t_index, time_step_t t_de
             }
         }
     }
-    return modules[index]->get_value(CatchmentAggrDataSelector(this->get_catchment_id(), get_bmi_main_output_var(), 0, 0, "m"), MEAN);
+    double var_value;
+    try{
+        var_value = modules[index]->get_value(CatchmentAggrDataSelector(this->get_catchment_id(), get_bmi_main_output_var(), 0, 0, "m"), MEAN);
+    }
+    catch(data_access::unit_conversion_exception &uce){
+        data_access::unit_error_log_key key{"Bmi_Multi_Formulation::get_response", get_bmi_main_output_var(), uce.provider_model_name, uce.provider_bmi_var_name, uce.what()};
+        auto ret = data_access::unit_errors_reported.insert(key);
+        bool new_error = ret.second;
+        if (new_error) {
+            std::stringstream ss;
+            ss << "Unit conversion failure:"
+                << " requester {'Get Output Line for Timestep (Multi Formulation)"
+                << "' catchment '" << get_catchment_id()
+                << "' variable '" << get_bmi_main_output_var()
+                << "' units 'm'}" 
+                << " provider {'" << uce.provider_model_name 
+                << "' source variable '" << uce.provider_bmi_var_name << "'"
+                << " raw value " << uce.unconverted_values[0] << "}"
+                << " message \"" << uce.what() << "\"";
+            LOG(ss.str(), LogLevel::WARNING); ss.str("");
+        }
+        var_value = uce.unconverted_values[0];
+    }
+    return var_value;
 }
 
 bool Bmi_Multi_Formulation::is_bmi_input_variable(const std::string &var_name) const {

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -200,8 +200,6 @@ void Bmi_Multi_Formulation::create_multi_formulation(geojson::PropertyMap proper
         }
     }
 
-    bool model_initialized = is_model_initialized();
-    
     // //check if units have not been specified. If not, default to native units.
     if(out_units.size() == 0){
         auto &names = get_output_variable_names();

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -410,9 +410,14 @@ std::string Bmi_Multi_Formulation::get_output_line_for_timestep(int timestep, st
         throw std::invalid_argument("Only current time step valid when getting multi-module BMI formulation output");
     }
 
-    // Start by first checking whether we are NOT just using the last module's values
-    if (!is_out_vars_from_last_mod) {
-
+    // Start by first checking whether we are just using the last module's values
+    if (is_out_vars_from_last_mod) {
+        // The default behavior, which means we either
+        //   - were originally set to use the default of getting the output of the last module
+        //   - tried a more complex config, but ran into an error, and are needing to revert to the default
+        return modules.back()->get_output_line_for_timestep(timestep, delimiter);
+    }
+    else{    
         // TODO: see Github issue 355: this design (and formulation output handling in general) needs to be reworked
         // Clear anything currently in the multi formulation's stream buffer
         output_text_stream->str(std::string());
@@ -457,10 +462,6 @@ std::string Bmi_Multi_Formulation::get_output_line_for_timestep(int timestep, st
         }
         return output_text_stream->str();
     }
-    // Otherwise, use the default behavior, which means we either
-    //   - were originally set to use the default of getting the output of the last module
-    //   - tried a more complex config, but ran into an error, and are needing to revert to the default
-    return modules.back()->get_output_line_for_timestep(timestep, delimiter);
 }
 
 void Bmi_Multi_Formulation::update(time_step_t t_index, time_step_t t_delta) {

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -105,66 +105,68 @@ void Bmi_Multi_Formulation::create_multi_formulation(geojson::PropertyMap proper
     auto out_var_it = properties.find(BMI_REALIZATION_CFG_PARAM_OPT__OUT_VARS);
     if (out_var_it != properties.end()) {
         std::vector<geojson::JSONProperty> out_vars_json_list = out_var_it->second.as_list();
-        //The first condition below occurs when output_variables is a empty list  in realization config i.e, "output_variables": [],
-        if ((out_vars_json_list.size() == 1 && out_vars_json_list[0].as_string().empty()) || out_vars_json_list.size() == 0){
-            LOG("Output variables list for BMI Multi formulation is empty in the realization file. Using the output variable from last module.", LogLevel::WARNING);
-            is_out_vars_from_last_mod = true;
-            set_output_variable_names(modules.back()->get_output_variable_names());
-        }
-        else if (out_vars_json_list.size() > 0){
-            //Check if the first item is an object type or string type.
-            //string type: old format; object type: new format
+        //Check if the first item is an object type or string type.
+        //string type: old format; object type: new format
+        if (out_vars_json_list.size() > 0){
             std::string item_type = get_propertytype_name(out_vars_json_list[0].get_type());
             if (item_type == "String"){
                 set_realization_file_format(true);
             }
-        
-            std::vector<std::string> out_vars(out_vars_json_list.size());
-            if (is_realization_legacy_format()){
-                for (int i = 0; i < out_vars_json_list.size(); ++i) {
-                    out_vars[i] = out_vars_json_list[i].as_string();
-                }
-            }
-            else{
-                out_headers.resize(out_vars_json_list.size()); //assumption: number of vars = number of headers
-                out_units.resize(out_vars_json_list.size()); //assumption: number of vars = number of units
-                for (int i = 0; i < out_vars_json_list.size(); ++i) {
-                    out_vars[i] = out_vars_json_list[i].at("name").as_string();
-                    if(out_vars_json_list[i].has_key("header")){
-                        //indicates that a valid header is provided
-                        out_headers[i] = out_vars_json_list[i].at("header").as_string();
-                    }
-                    else{
-                        //indicates that header is not provided. The error actually returns a string.
-                        //in such cases, we assign variable name to the header.
-                        out_headers[i] = out_vars[i];
-                        std::stringstream ss;
-                        ss << "Header not provided for " << out_vars[i] << ". Using the variable name as header." << std::endl;
-                        LOG(ss.str(), LogLevel::WARNING); ss.str("");
-                    }
-                    if(out_vars_json_list[i].has_key("units")){
-                        //indicates that a valid unit is provided
-                        out_units[i] = out_vars_json_list[i].at("units").as_string();
-                    }
-                    else{
-                        LOG("Units not provided for '" + out_vars[i] + "' in the realization file.",LogLevel::INFO);
-                        out_units[i] = ""; //add an empty entry and populate it with BMI native units later.
-                    }
-                }
-                //check if the units can be parsed correctly and write a warning message
-                std::stringstream ss;
-                for (const std::string& out_unit : out_units) {
-                    if (!UnitsHelper::can_parse(out_unit))
-                    {
-                        ss << "Unable to parse '" << out_unit << "' in units value." << std::endl;
-                        LOG(ss.str(), LogLevel::WARNING); ss.str("");
-                    }
-                }
-                set_output_variable_units(out_units);
-                set_output_header_fields(out_headers);
-            }
-            set_output_variable_names(out_vars);
         }
+        std::vector<std::string> out_vars(out_vars_json_list.size());
+        if (is_realization_legacy_format()){
+            for (int i = 0; i < out_vars_json_list.size(); ++i) {
+                out_vars[i] = out_vars_json_list[i].as_string();
+            }
+            // empty array may be read as [""], so make it empty
+            if (out_vars.size() == 1 && out_vars[0].empty())
+                out_vars.pop_back();
+        }
+        else{
+            out_headers.resize(out_vars_json_list.size()); //assumption: number of vars = number of headers
+            out_units.resize(out_vars_json_list.size()); //assumption: number of vars = number of units
+            for (int i = 0; i < out_vars_json_list.size(); ++i) {
+                out_vars[i] = out_vars_json_list[i].at("name").as_string();
+                if(out_vars_json_list[i].has_key("header")){
+                    //indicates that a valid header is provided
+                    out_headers[i] = out_vars_json_list[i].at("header").as_string();
+                }
+                else{
+                    //indicates that header is not provided. The error actually returns a string.
+                    //in such cases, we assign variable name to the header.
+                    out_headers[i] = out_vars[i];
+                    std::stringstream ss;
+                    ss << "Header not provided for " << out_vars[i] << ". Using the variable name as header." << std::endl;
+                    LOG(ss.str(), LogLevel::WARNING); ss.str("");
+                }
+                if(out_vars_json_list[i].has_key("units")){
+                    //indicates that a valid unit is provided
+                    out_units[i] = out_vars_json_list[i].at("units").as_string();
+                }
+                else{
+                    LOG("Units not provided for '" + out_vars[i] + "' in the realization file.",LogLevel::INFO);
+                    out_units[i] = ""; //add an empty entry and populate it with BMI native units later.
+                }
+            }
+            //check if the units can be parsed correctly and write a warning message
+            std::stringstream ss;
+            for (const std::string& out_unit : out_units) {
+                if (!UnitsHelper::can_parse(out_unit))
+                {
+                    ss << "Unable to parse '" << out_unit << "' in units value." << std::endl;
+                    LOG(ss.str(), LogLevel::WARNING); ss.str("");
+                }
+            }
+            if (out_vars.size() == 1 && out_vars[0].empty()) {
+                // empty array may be read as [""], so make everything empty
+                out_vars.pop_back();
+                out_headers.pop_back();
+                out_units.pop_back();
+            }
+            set_output_variable_units(out_units);
+            set_output_header_fields(out_headers);
+        }
+        set_output_variable_names(out_vars);
     }
     // Otherwise, for multi BMI, the BMI output variables of the last nested module should be used.
     else {
@@ -179,7 +181,7 @@ void Bmi_Multi_Formulation::create_multi_formulation(geojson::PropertyMap proper
     // Output header fields, if present
     auto out_headers_it = properties.find(BMI_REALIZATION_CFG_PARAM_OPT__OUT_HEADER_FIELDS);
     if(is_realization_legacy_format()){
-        if (out_headers_it != properties.end()) {
+        if (out_headers_it != properties.end() && get_output_variable_names().size() != 0) {
             std::vector<geojson::JSONProperty> out_headers_json_list = out_headers_it->second.as_list();
             std::vector<std::string> out_headers(out_headers_json_list.size());
             for (int i = 0; i < out_headers_json_list.size(); ++i) {

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -102,7 +102,6 @@ void Bmi_Multi_Formulation::create_multi_formulation(geojson::PropertyMap proper
 
     // Setup formulation output variable subset and order, if present
     std::vector<std::string> out_headers;//define empty vector for headers
-    std::vector<std::string> out_units;//define empty vector for units for new json structure
     auto out_var_it = properties.find(BMI_REALIZATION_CFG_PARAM_OPT__OUT_VARS);
     if (out_var_it != properties.end()) {
         std::vector<geojson::JSONProperty> out_vars_json_list = out_var_it->second.as_list();
@@ -125,7 +124,7 @@ void Bmi_Multi_Formulation::create_multi_formulation(geojson::PropertyMap proper
         }
         else{
             out_headers.resize(out_vars_json_list.size()); //assumption: number of vars = number of headers
-            out_units.resize(out_vars_json_list.size()); //assumption: number of vars = number of units
+            output_var_units.resize(out_vars_json_list.size()); //assumption: number of vars = number of units
             for (int i = 0; i < out_vars_json_list.size(); ++i) {
                 out_vars[i] = out_vars_json_list[i].at("name").as_string();
                 if(out_vars_json_list[i].has_key("header")){
@@ -142,16 +141,16 @@ void Bmi_Multi_Formulation::create_multi_formulation(geojson::PropertyMap proper
                 }
                 if(out_vars_json_list[i].has_key("units")){
                     //indicates that a valid unit is provided
-                    out_units[i] = out_vars_json_list[i].at("units").as_string();
+                    output_var_units[i] = out_vars_json_list[i].at("units").as_string();
                 }
                 else{
                     LOG("Units not provided for '" + out_vars[i] + "' in the realization file.",LogLevel::WARNING);
-                    out_units[i] = ""; //add an empty entry and populate it with BMI native units later.
+                    output_var_units[i] = ""; //add an empty entry and populate it with BMI native units later.
                 }
             }
             //check if the units can be parsed correctly and write a warning message
             std::stringstream ss;
-            for (const std::string& out_unit : out_units) {
+            for (const std::string& out_unit : output_var_units) {
                 if (!UnitsHelper::can_parse(out_unit))
                 {
                     ss << "Unable to parse '" << out_unit << "' in units value." << std::endl;
@@ -162,9 +161,8 @@ void Bmi_Multi_Formulation::create_multi_formulation(geojson::PropertyMap proper
                 // empty array may be read as [""], so make everything empty
                 out_vars.pop_back();
                 out_headers.pop_back();
-                out_units.pop_back();
+                output_var_units.pop_back();
             }
-            set_output_variable_units(out_units);
             set_output_header_fields(out_headers);
         }
         set_output_variable_names(out_vars);
@@ -220,17 +218,16 @@ void Bmi_Multi_Formulation::create_multi_formulation(geojson::PropertyMap proper
     //check if units have not been specified. If not, default to native units.
     std::string blank_string = "";
     auto &names = get_output_variable_names();
-    if(out_units.size() == 0){
-        out_units.resize(names.size(), blank_string);
+    if(output_var_units.size() == 0){
+        output_var_units.resize(names.size(), blank_string);
     }
 
     for (int i = 0; i < names.size(); ++i) {
-        if (out_units[i] == blank_string){
-            out_units[i] = get_provider_units_for_variable(names[i]);
+        if (output_var_units[i] == blank_string){
+            output_var_units[i] = get_provider_units_for_variable(names[i]);
         }
     }
-    set_output_variable_units(out_units);
-
+    
     // Output precision, if present
     auto out_precision_it = properties.find(BMI_REALIZATION_CFG_PARAM_OPT__OUTPUT_PRECISION);
     if (out_precision_it != properties.end()) {
@@ -419,8 +416,7 @@ std::string Bmi_Multi_Formulation::get_output_line_for_timestep(int timestep, st
         output_text_stream->str(std::string());
 
         const std::vector<std::string> &output_var_names = get_output_variable_names();
-        const std::vector<std::string> &output_var_units = get_output_variable_units();
-
+        
         // This almost certainly should never happen, but just to be safe ...
         if (output_var_names.empty()) { return ""; }
 

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -379,7 +379,7 @@ std::string Bmi_Multi_Formulation::get_output_line_for_timestep(int timestep, st
                 *output_text_stream << delimiter << var_value; //with delimiter for the rest.
             }
         }
-         return output_text_stream->str();
+        return output_text_stream->str();
     }
     // Otherwise, use the default behavior, which means we either
     //   - were originally set to use the default of getting the output of the last module

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -297,7 +297,7 @@ const std::string Bmi_Multi_Formulation::get_provider_units_for_variable(const s
         if(iter != available_forcing_units.end()){
             return iter->second;
         }
-        std::string throw_msg; 
+        std::string throw_msg;
         throw_msg.assign("Got request to retrieve units for variable '" + name + "', but it was not found in the data provider. This should not happen." + SOURCE_LOC);
         LOG(throw_msg, LogLevel::WARNING);
         throw std::runtime_error(throw_msg);
@@ -410,13 +410,13 @@ std::string Bmi_Multi_Formulation::get_output_line_for_timestep(int timestep, st
         //   - tried a more complex config, but ran into an error, and are needing to revert to the default
         return modules.back()->get_output_line_for_timestep(timestep, delimiter);
     }
-    else{    
+    else{
         // TODO: see Github issue 355: this design (and formulation output handling in general) needs to be reworked
         // Clear anything currently in the multi formulation's stream buffer
         output_text_stream->str(std::string());
 
         const std::vector<std::string> &output_var_names = get_output_variable_names();
-        
+
         // This almost certainly should never happen, but just to be safe ...
         if (output_var_names.empty()) { return ""; }
 
@@ -449,8 +449,8 @@ std::string Bmi_Multi_Formulation::get_output_line_for_timestep(int timestep, st
                         << " requester {'Get Output Line for Timestep (Multi Formulation)"
                         << "' catchment '" << get_catchment_id()
                         << "' variable '" << output_var_names[i]
-                        << "' units '" << output_var_units[i] << "'}" 
-                        << " provider {'" << uce.provider_model_name 
+                        << "' units '" << output_var_units[i] << "'}"
+                        << " provider {'" << uce.provider_model_name
                         << "' source variable '" << uce.provider_bmi_var_name << "'"
                         << " raw value " << uce.unconverted_values[0] << "}"
                         << " message \"" << uce.what() << "\"";
@@ -547,11 +547,11 @@ double Bmi_Multi_Formulation::get_response(time_step_t t_index, time_step_t t_de
         if (new_error) {
             std::stringstream ss;
             ss << "Unit conversion failure:"
-                << " requester {'Get Response (Multi Formulation)"  
+                << " requester {'Get Response (Multi Formulation)"
                 << "' catchment '" << get_catchment_id()
                 << "' variable '" << get_bmi_main_output_var()
-                << "' units 'm'}" 
-                << " provider {'" << uce.provider_model_name 
+                << "' units 'm'}"
+                << " provider {'" << uce.provider_model_name
                 << "' source variable '" << uce.provider_bmi_var_name << "'"
                 << " raw value " << uce.unconverted_values[0] << "}"
                 << " message \"" << uce.what() << "\"";

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -242,7 +242,9 @@ void Bmi_Multi_Formulation::create_multi_formulation(geojson::PropertyMap proper
     // initialize available_forcings from nested modules
     for (const nested_module_ptr &module: modules) {
         for (const std::string &out_var_name: module->get_bmi_output_variables()) {
-            available_forcings.push_back(module->get_config_mapped_variable_name(out_var_name));
+            std::string var_name = module->get_config_mapped_variable_name(out_var_name);
+            available_forcings.push_back(var_name);
+            available_forcing_units[var_name] = module->get_provider_units_for_variable(var_name);
         }
     }
 }
@@ -286,6 +288,17 @@ const bool &Bmi_Multi_Formulation::get_allow_model_exceed_end_time() const {
  */
 boost::span<const std::string> Bmi_Multi_Formulation::get_available_variable_names() const {
     return available_forcings;
+}
+
+const std::string Bmi_Multi_Formulation::get_provider_units_for_variable(const std::string& name) const{
+    auto iter = available_forcing_units.find(name);
+    if(iter != available_forcing_units.end()){
+        return iter->second;
+    }
+    std::string throw_msg; 
+    throw_msg.assign("Got request to retrieve units for variable '" + name + "', but it was not found in the data provider. This should not happen." + SOURCE_LOC);
+    LOG(throw_msg, LogLevel::WARNING);
+    throw std::runtime_error(throw_msg);
 }
 
 const time_t &Bmi_Multi_Formulation::get_bmi_model_start_time_forcing_offset_s() const {
@@ -389,14 +402,23 @@ const std::string Bmi_Multi_Formulation::get_bmi_native_units(const std::string 
             LOG("Multi BMI formulation: No module found for variable " + name, LogLevel::WARNING);
             throw std::runtime_error("Multi BMI formulation: No module found for variable " + name);
         }
-        auto model = std::dynamic_pointer_cast<Bmi_Formulation>(iter->second);
-        if(model != nullptr){
-            return model->get_bmi_native_units(name);
+        std::string units = forcing->get_provider_units_for_variable(name);
+        if(units != "none"){
+            return units;
         }
         else{
-            LOG("Unable to obtain a valid formulation for " + name + ". Units cannot be queried.", LogLevel::WARNING);
-            throw std::runtime_error("Unable to obtain a valid formulation for " + name + ". Units cannot be queried.");
+            LOG("Units for '" + name + "' not found in the forcing data.", LogLevel::WARNING);
+            throw std::runtime_error("Units for '" + name + "' not found in the forcing data.");
         }
+
+        // auto model = std::dynamic_pointer_cast<Bmi_Formulation>(iter->second);
+        // if(model != nullptr){
+        //     return model->get_bmi_native_units(name);
+        // }
+        // else{
+        //     LOG("Unable to obtain a valid formulation for " + name + ". Units cannot be queried.", LogLevel::WARNING);
+        //     throw std::runtime_error("Unable to obtain a valid formulation for " + name + ". Units cannot be queried.");
+        // }
     }    
 }
 

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -424,10 +424,24 @@ std::string Bmi_Multi_Formulation::get_output_line_for_timestep(int timestep, st
         // This almost certainly should never happen, but just to be safe ...
         if (output_var_names.empty()) { return ""; }
 
+        auto duration = record_duration();
+        time_t time_offset = get_model_current_time() - get_model_start_time();
+
         for (int i = 0; i < output_var_names.size(); ++i) {
             double value;
             try{
-                value = get_value(CatchmentAggrDataSelector(get_catchment_id(), output_var_names[i], 0, 0, output_var_units[i]), MEAN);
+                auto var_name = output_var_names[i];
+
+                auto source = availableData.find(var_name);
+                if (source == availableData.end()) {
+                    std::string throw_msg; throw_msg.assign(get_formulation_type() + " cannot find a source for output variable '" + var_name + "'");
+                    LOG(throw_msg, LogLevel::WARNING);
+                    throw std::runtime_error(throw_msg);
+                }
+                auto provider = source->second;
+
+                time_t init_time = provider->get_data_start_time() + time_offset;
+                value = provider->get_value(CatchmentAggrDataSelector(get_catchment_id(), var_name, init_time, duration, output_var_units[i]), MEAN);
             }
             catch(data_access::unit_conversion_exception &uce){
                 data_access::unit_error_log_key key{"File Output Multi", output_var_names[i], uce.provider_model_name, uce.provider_bmi_var_name, uce.what()};

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -547,7 +547,7 @@ double Bmi_Multi_Formulation::get_response(time_step_t t_index, time_step_t t_de
         if (new_error) {
             std::stringstream ss;
             ss << "Unit conversion failure:"
-                << " requester {'Get Output Line for Timestep (Multi Formulation)"
+                << " requester {'Get Response (Multi Formulation)"  
                 << "' catchment '" << get_catchment_id()
                 << "' variable '" << get_bmi_main_output_var()
                 << "' units 'm'}" 

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -105,52 +105,66 @@ void Bmi_Multi_Formulation::create_multi_formulation(geojson::PropertyMap proper
     auto out_var_it = properties.find(BMI_REALIZATION_CFG_PARAM_OPT__OUT_VARS);
     if (out_var_it != properties.end()) {
         std::vector<geojson::JSONProperty> out_vars_json_list = out_var_it->second.as_list();
-        //Check if the first item is an object type or string type.
-        //string type: old format; object type: new format
-        if (out_vars_json_list.size() > 0){
+        //The first condition below occurs when output_variables is a empty list  in realization config i.e, "output_variables": [],
+        if ((out_vars_json_list.size() == 1 && out_vars_json_list[0].as_string().empty()) || out_vars_json_list.size() == 0){
+            LOG("Output variables list for BMI Multi formulation is empty in the realization file. Using the output variable from last module.", LogLevel::WARNING);
+            is_out_vars_from_last_mod = true;
+            set_output_variable_names(modules.back()->get_output_variable_names());
+        }
+        else if (out_vars_json_list.size() > 0){
+            //Check if the first item is an object type or string type.
+            //string type: old format; object type: new format
             std::string item_type = get_propertytype_name(out_vars_json_list[0].get_type());
             if (item_type == "String"){
                 set_realization_file_format(true);
             }
-        }
-        std::vector<std::string> out_vars(out_vars_json_list.size());
-        if (is_realization_legacy_format()){
-            for (int i = 0; i < out_vars_json_list.size(); ++i) {
-                out_vars[i] = out_vars_json_list[i].as_string();
-            }
-        }
-        else{
-            out_headers.resize(out_vars_json_list.size()); //assumption: number of vars = number of headers
-            out_units.resize(out_vars_json_list.size()); //assumption: number of vars = number of units
-            for (int i = 0; i < out_vars_json_list.size(); ++i) {
-                out_vars[i] = out_vars_json_list[i].at("name").as_string();
-                if(out_vars_json_list[i].has_key("header")){
-                    //indicates that a valid header is provided
-                    out_headers[i] = out_vars_json_list[i].at("header").as_string();
-                }
-                else{
-                    //indicates that header is not provided. The error actually returns a string.
-                    //in such cases, we assign variable name to the header.
-                    out_headers[i] = out_vars[i];
-                    std::stringstream ss;
-                    ss << "Header not provided for " << out_vars[i] << ". Using the variable name as header." << std::endl;
-                    LOG(ss.str(), LogLevel::WARNING); ss.str("");
-                }
-                out_units[i] = out_vars_json_list[i].at("units").as_string();
-            }
-            //check if the units can be parsed correctly and write a warning message
-            std::stringstream ss;
-            for (const std::string& out_unit : out_units) {
-                if (!UnitsHelper::can_parse(out_unit))
-                {
-                    ss << "Unable to parse '" << out_unit << "' in units value." << std::endl;
-                    LOG(ss.str(), LogLevel::WARNING); ss.str("");
+        
+            std::vector<std::string> out_vars(out_vars_json_list.size());
+            if (is_realization_legacy_format()){
+                for (int i = 0; i < out_vars_json_list.size(); ++i) {
+                    out_vars[i] = out_vars_json_list[i].as_string();
                 }
             }
-            set_output_variable_units(out_units);
-            set_output_header_fields(out_headers);
+            else{
+                out_headers.resize(out_vars_json_list.size()); //assumption: number of vars = number of headers
+                out_units.resize(out_vars_json_list.size()); //assumption: number of vars = number of units
+                for (int i = 0; i < out_vars_json_list.size(); ++i) {
+                    out_vars[i] = out_vars_json_list[i].at("name").as_string();
+                    if(out_vars_json_list[i].has_key("header")){
+                        //indicates that a valid header is provided
+                        out_headers[i] = out_vars_json_list[i].at("header").as_string();
+                    }
+                    else{
+                        //indicates that header is not provided. The error actually returns a string.
+                        //in such cases, we assign variable name to the header.
+                        out_headers[i] = out_vars[i];
+                        std::stringstream ss;
+                        ss << "Header not provided for " << out_vars[i] << ". Using the variable name as header." << std::endl;
+                        LOG(ss.str(), LogLevel::WARNING); ss.str("");
+                    }
+                    if(out_vars_json_list[i].has_key("units")){
+                        //indicates that a valid unit is provided
+                        out_units[i] = out_vars_json_list[i].at("units").as_string();
+                    }
+                    else{
+                        LOG("Units not provided for '" + out_vars[i] + "' in the realization file.",LogLevel::INFO);
+                        out_units[i] = ""; //add an empty entry and populate it with BMI native units later.
+                    }
+                }
+                //check if the units can be parsed correctly and write a warning message
+                std::stringstream ss;
+                for (const std::string& out_unit : out_units) {
+                    if (!UnitsHelper::can_parse(out_unit))
+                    {
+                        ss << "Unable to parse '" << out_unit << "' in units value." << std::endl;
+                        LOG(ss.str(), LogLevel::WARNING); ss.str("");
+                    }
+                }
+                set_output_variable_units(out_units);
+                set_output_header_fields(out_headers);
+            }
+            set_output_variable_names(out_vars);
         }
-        set_output_variable_names(out_vars);
     }
     // Otherwise, for multi BMI, the BMI output variables of the last nested module should be used.
     else {
@@ -200,12 +214,22 @@ void Bmi_Multi_Formulation::create_multi_formulation(geojson::PropertyMap proper
         }
     }
 
-    // //check if units have not been specified. If not, default to native units.
+    //check if units have not been specified. If not, default to native units.
+    std::string blank_string = "";
+    auto &names = get_output_variable_names();
     if(out_units.size() == 0){
-        auto &names = get_output_variable_names();
         out_units.resize(names.size());
         for (int i = 0; i < names.size(); ++i) {
             out_units[i] = get_bmi_native_units(names[i]);
+        }
+        set_output_variable_units(out_units);
+    }
+    else if(std::find(out_units.begin(), out_units.end(), blank_string) != out_units.end()){
+        //this condition is when the user has not specified units for an output variable.
+        for (int i = 0; i < names.size(); ++i) {
+            if (out_units[i] == blank_string){
+                out_units[i] = get_bmi_native_units(names[i]);
+            }
         }
         set_output_variable_units(out_units);
     }

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -223,7 +223,7 @@ void Bmi_Multi_Formulation::create_multi_formulation(geojson::PropertyMap proper
         out_units.resize(names.size());
         for (int i = 0; i < names.size(); ++i) {
             out_units[i] = get_bmi_native_units(names[i]);
-        }
+        } 
         set_output_variable_units(out_units);
     }
     else if(std::find(out_units.begin(), out_units.end(), blank_string) != out_units.end()){
@@ -235,7 +235,7 @@ void Bmi_Multi_Formulation::create_multi_formulation(geojson::PropertyMap proper
         }
         set_output_variable_units(out_units);
     }
-        
+
     // Output precision, if present
     auto out_precision_it = properties.find(BMI_REALIZATION_CFG_PARAM_OPT__OUTPUT_PRECISION);
     if (out_precision_it != properties.end()) {
@@ -383,7 +383,7 @@ const std::string &Bmi_Multi_Formulation::get_config_mapped_variable_name(const 
     return output_var_name;
 }
 
-const std::string Bmi_Multi_Formulation::get_bmi_native_units(const std::string &name) {
+const std::string Bmi_Multi_Formulation::get_bmi_native_units(const std::string &name) const {
 
     if(!is_out_vars_from_last_mod){
         auto iter = availableData.find(name);

--- a/test/forcing/GridDataSelector_Test.cpp
+++ b/test/forcing/GridDataSelector_Test.cpp
@@ -24,6 +24,9 @@ struct TestGridDataProvider
     boost::span<const std::string> get_available_variable_names() const override
     { return { &variable_, 1 }; }
 
+    const std::string get_provider_units_for_variable(const std::string& name) const override
+    {return variable_;}
+
     long get_data_start_time() const override
     { return 0; }
 

--- a/test/forcing/TrivialForcingProvider.hpp
+++ b/test/forcing/TrivialForcingProvider.hpp
@@ -7,6 +7,7 @@
 
 
 #define OUTPUT_NAME_1 "output_name_1"
+#define OUTPUT_UNIT_1 "m"
 #define OUTPUT_VALUE_1 42.0
 #define OUTPUT_DEFAULT_1 36.8
 
@@ -26,6 +27,11 @@ namespace data_access {
             boost::span<const std::string> get_available_variable_names() const override {
                 return outputs;
             }
+            
+            const std::string get_provider_units_for_variable(const std::string& name) const override {
+                return OUTPUT_UNIT_1;
+            }
+            
 
             long get_data_start_time() const override {
                 return std::numeric_limits<long>::min();

--- a/test/forcing/TrivialForcingProvider.hpp
+++ b/test/forcing/TrivialForcingProvider.hpp
@@ -27,11 +27,10 @@ namespace data_access {
             boost::span<const std::string> get_available_variable_names() const override {
                 return outputs;
             }
-            
+
             const std::string get_provider_units_for_variable(const std::string& name) const override {
                 return OUTPUT_UNIT_1;
             }
-            
 
             long get_data_start_time() const override {
                 return std::numeric_limits<long>::min();


### PR DESCRIPTION
Update functionality to use the configured units for the overall output variables specified in the realization file. If units are not specified, as in the older 'legacy' realization file format, they will default to the units of the formulation or forcing providing them.

## Changes

- Updated `Bmi_{Module,Multi}_Formulation::get_output_line_for_timestep()` function to use the units specified in the realization file
- Add `virtual DataProvider::get_provider_units_for_variable()` and all of its implementations
- `Bmi_{Module,Multi}_Formulation::get_response` now ensures that its output is returned in units of meters `"m"`, as its caller `Layer` expects for catchment runoff values
- Separated `Bmi_{Module,Multi}_Formulation::get_response` into `update` and `get_response` for timestep advancement and getting the value for output variables, so that `Bmi_Multi_Formulation` could call `update` on intermediate modules without calling for a forced unit conversion to `"m"` of irrelevant 'main output variables' from those modules
- Detect failed unit conversions in the above cases, and log a warning the first time each such failure occurs

## Testing

1. Tested using CNF data (Sloth,NoahOWP, SMP, SFT, CFE, T-route) BMI-Multi formulation. No errors.
2. Tested using SACSMA, NoahOWP, T-route Multi formulation. No errors.
3. Built in `Bmi_Multi_Formulation_Test`, which identified numerous wrong or problematic ways to go about implementing this

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: