### PR TITLE
Break up PIP installations to reduce peak transient disk usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -188,14 +188,12 @@ ENV LD_LIBRARY_PATH="/usr/lib64/openmpi/lib:/usr/local/lib:/usr/local/lib64:${LD
 RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache \
     set -eux && \
     pip3 install --upgrade pip setuptools wheel && \
-    pip3 install \
-      'numpy==1.26.4' \
-      'netcdf4<=1.6.3' \
-      'bmipy' \
-      'pandas' \
-      'pyyml' \
-      'torch' \
-      --no-binary=mpi4py mpi4py && \
+    pip3 install 'numpy==1.26.4' && \
+    pip3 install 'netcdf4<=1.6.3' && \
+    pip3 install 'bmipy' && \
+    pip3 install 'pandas' && \
+    pip3 install 'pyyml' && \
+    pip3 install 'torch' --no-binary=mpi4py 'mpi4py' && \
     pip install /ngen-app/ngen-forcing/
 
 WORKDIR /ngen-app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -189,11 +189,12 @@ RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache \
     set -eux && \
     pip3 install --upgrade pip setuptools wheel && \
     pip3 install 'numpy==1.26.4' && \
+    pip3 install --no-binary=mpi4py 'mpi4py'&& \
     pip3 install 'netcdf4<=1.6.3' && \
     pip3 install 'bmipy' && \
     pip3 install 'pandas' && \
     pip3 install 'pyyml' && \
-    pip3 install 'torch' --no-binary=mpi4py 'mpi4py' && \
+    pip3 install 'torch' 'torchvision' 'torchaudio' && \
     pip install /ngen-app/ngen-forcing/
 
 WORKDIR /ngen-app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -194,7 +194,7 @@ RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache \
     pip3 install 'bmipy' && \
     pip3 install 'pandas' && \
     pip3 install 'pyyml' && \
-    pip3 install 'torch' 'torchvision' 'torchaudio' && \
+    pip3 install torch torchvision --index-url https://download.pytorch.org/whl/cpu && \
     pip install /ngen-app/ngen-forcing/
 
 WORKDIR /ngen-app/


### PR DESCRIPTION
Address recent CI build and test pipeline failures due to lack of disk space

## Changes

- Split the `pip3 install X Y Z A B C` into separate commands for each package, to reduce the peak amount of cached and transient usage of the overall process
- Switch PyTorch installation from the default package on PyPI to one that doesn't use CUDA directly from pytorch.org

## Testing

1. CI job "[CI/CD Pipeline / build (pull_request)](https://github.com/NGWPC/ngen/actions/runs/19170179727/job/54800438582?pr=75)" passes, where it previously failed due to lack of free space during `pip3 install ...`

## Notes

- There may be cybersecurity policy concerns about this, but I don't think they're any worse than the rest of the package downloads and builds that make up the entire preceding portion of this `Dockerfile`

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
