### PR TITLE
Log timing intervals as they're calculated

### DIFF
--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -649,6 +649,8 @@ int main(int argc, char* argv[]) {
     auto time_done_init                             = std::chrono::steady_clock::now();
     std::chrono::duration<double> time_elapsed_init = time_done_init - time_start;
 
+    LOG("[TIMING]: Init: " + std::to_string(time_elapsed_init.count()), LogLevel::INFO);
+
     // Now loop some time, iterate catchments, do stuff for total number of output times
     auto num_times = manager->Simulation_Time_Object->get_total_output_times();
 
@@ -744,6 +746,8 @@ int main(int argc, char* argv[]) {
 
     auto time_done_simulation                             = std::chrono::steady_clock::now();
     std::chrono::duration<double> time_elapsed_simulation = time_done_simulation - time_done_init;
+
+    LOG("[TIMING]: Catchment simulation: " + std::to_string(time_elapsed_simulation.count()), LogLevel::INFO);
 
 #if NGEN_WITH_MPI
     MPI_Barrier(MPI_COMM_WORLD);
@@ -868,6 +872,8 @@ int main(int argc, char* argv[]) {
     auto time_done_routing                             = std::chrono::steady_clock::now();
     std::chrono::duration<double> time_elapsed_routing = time_done_routing - time_done_simulation;
 
+    LOG("[TIMING]: Routing: " + std::to_string(time_elapsed_routing.count()), LogLevel::INFO);
+
     if (mpi_rank == 0) {
         ss << "NGen top-level timings:"
            << "\n\tNGen::init: " << time_elapsed_init.count()
@@ -881,6 +887,11 @@ int main(int argc, char* argv[]) {
     }
 
     _interp.reset();
+
+    auto time_done_total                               = std::chrono::steady_clock::now();
+    std::chrono::duration<double> time_elapsed_total   = time_done_total - time_start;
+
+    LOG("[TIMING]: Total: " + std::to_string(time_elapsed_total.count()), LogLevel::INFO);
 
 #if NGEN_WITH_MPI
     MPI_Finalize();


### PR DESCRIPTION
It would be useful to see execution time costs in runs as they progress, and potentially have them in the logs of runs that don't complete. So, log them once each interval has passed, rather than only at the end. Summary at the end is retained to allow easier reading.

## Additions

- Log statements in `main()` reporting the time elapsed for each of the major execution phases

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
