### PR TITLE
Fix malloc error with T-Route (NGWPC-8969)

### DIFF
--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -537,7 +537,9 @@ int main(int argc, char* argv[]) {
         for (int i = 0; i < nexus_collection->get_size(); ++i) {
             auto const& feature = nexus_collection->get_feature(i);
             std::string feature_id = feature->get_id();
-            if (hy_features::identifiers::isNexus(feature_id.substr(0, 3))) {
+            if (hy_features::identifiers::isNexus(feature_id.substr(0, 3))
+                && nexus_indexes.find(feature_id) == nexus_indexes.end())
+            {
                 nexus_indexes[feature_id] = nexus_index;
                 nexus_index += 1;
             }


### PR DESCRIPTION
Fixes a malloc() error that was being thrown in T-Route. It was caused by the `nexus_collection` having multiple features with the same ID, leading to later code writing outside the bounds of a vector. The error would occur in T-Route as happenstance since that was the first thing to run after memory was corrupted.

## Changes

- Check if the nexus ID already exists in `nexus_indexes` before setting the index.


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing

Manual testing showed the error was alleviated, and reports from AddressSanitizer were eliminated.

### Target Environment support

- [x] Linux
