### PR TITLE
Optional Catchment Output CSVs

### DIFF
--- a/include/core/DomainLayer.hpp
+++ b/include/core/DomainLayer.hpp
@@ -43,7 +43,8 @@ namespace ngen
                 std::shared_ptr<realization::Catchment_Formulation> formulation):
                     Layer(desc, s_t, features, idx), formulation(formulation)
         {
-            formulation->write_output("Time Step,""Time,"+formulation->get_output_header_line(",")+"\n");
+            if (formulation->get_output_header_count() > 0)
+                formulation->write_output("Time Step,""Time,"+formulation->get_output_header_line(",")+"\n");
         }
 
         /***

--- a/include/realizations/catchment/Bmi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Formulation.hpp
@@ -159,6 +159,10 @@ namespace realization {
             return boost::algorithm::join(get_output_header_fields(), delimiter);
         }
 
+        size_t get_output_header_count() const override {
+            return get_output_header_fields().size();
+        }
+
         /**
          * Get the names of variables in formulation output.
          *

--- a/include/realizations/catchment/Catchment_Formulation.hpp
+++ b/include/realizations/catchment/Catchment_Formulation.hpp
@@ -85,6 +85,19 @@ namespace realization {
             virtual ~Catchment_Formulation() = default;
 
             /**
+             * Get get a count of fields that will be included by ``get_output_header_line``.
+             *
+             * Note that like the output generating function, this line does not include anything for time step.
+             *
+             * A default implementation is provided for inheritors of this type, which includes only "Total Discharge."
+             *
+             * @return The number of fields included in the header output.
+             */
+            virtual size_t get_output_header_count() const {
+                return 1;
+            }
+
+            /**
              * Release resources of the given forcing provider
              */
             void finalize();

--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -98,7 +98,10 @@ namespace realization {
                                     output_stream
                                 )
                             );
-                            domain_formulations.at(layer_desc.id)->set_output_stream(get_output_root() + layer_desc.name + "_layer_"+std::to_string(layer_desc.id) + ".csv");
+                            auto formulation = domain_formulations.at(layer_desc.id);
+                            if (formulation->get_output_header_count() > 0) {
+                                formulation->set_output_stream(get_output_root() + layer_desc.name + "_layer_"+std::to_string(layer_desc.id) + ".csv");
+                            }
                         }
                         //TODO for each layer, create deferred providers for use by other layers
                         //VERY SIMILAR TO NESTED MODULE INIT

--- a/src/core/HY_Features.cpp
+++ b/src/core/HY_Features.cpp
@@ -34,10 +34,13 @@ HY_Features::HY_Features(network::Network network, std::shared_ptr<Formulation_M
         {
           //Find and prepare formulation
           auto formulation = formulations->get_formulation(feat_id);
-          formulation->set_output_stream(formulations->get_output_root() + feat_id + ".csv");
-          // TODO: add command line or config option to have this be omitted
-          //FIXME why isn't default param working here??? get_output_header_line() fails.
-          formulation->write_output("Time Step,""Time,"+formulation->get_output_header_line(",")+"\n");
+          if (formulation->get_output_header_count() > 0) {
+            // only create an output stream if there are output variables to be recorded
+            formulation->set_output_stream(formulations->get_output_root() + feat_id + ".csv");
+            // TODO: add command line or config option to have this be omitted
+            //FIXME why isn't default param working here??? get_output_header_line() fails.
+            formulation->write_output("Time Step,""Time,"+formulation->get_output_header_line(",")+"\n");
+          }
           //Find upstream nexus ids
           origins = network.get_origination_ids(feat_id);
 

--- a/src/core/HY_Features_MPI.cpp
+++ b/src/core/HY_Features_MPI.cpp
@@ -40,10 +40,12 @@ HY_Features_MPI::HY_Features_MPI( PartitionData partition_data, geojson::GeoJSON
         {
           //Find and prepare formulation
           auto formulation = formulations->get_formulation(feat_id);
-          formulation->set_output_stream(formulations->get_output_root() + feat_id + ".csv");
-          // TODO: add command line or config option to have this be omitted
-          //FIXME why isn't default param working here??? get_output_header_line() fails.
-          formulation->write_output("Time Step,""Time,"+formulation->get_output_header_line(",")+"\n");
+          if (formulation->get_output_header_count() > 0) {
+            formulation->set_output_stream(formulations->get_output_root() + feat_id + ".csv");
+            // TODO: add command line or config option to have this be omitted
+            //FIXME why isn't default param working here??? get_output_header_line() fails.
+            formulation->write_output("Time Step,""Time,"+formulation->get_output_header_line(",")+"\n");
+          }
           
           // get the catchment layer from the hydro fabric
           const auto& cat_json_node = linked_hydro_fabric->get_feature(feat_id);

--- a/src/core/Layer.cpp
+++ b/src/core/Layer.cpp
@@ -40,9 +40,12 @@ void ngen::Layer::update_models(boost::span<double> catchment_outflows,
         int results_index = catchment_indexes[id];
         catchment_outflows[results_index] += response;
 #endif // NGEN_WITH_ROUTING
-        std::string output = std::to_string(output_time_index)+","+current_timestamp+","+
-            r_c->get_output_line_for_timestep(output_time_index)+"\n";
-        r_c->write_output(output);
+        if (r_c->get_output_header_count() > 0) {
+            // only write output if config specifies output values
+            std::string output = std::to_string(output_time_index)+","+current_timestamp+","+
+                r_c->get_output_line_for_timestep(output_time_index)+"\n";
+            r_c->write_output(output);
+        }
         //TODO put this somewhere else.  For now, just trying to ensure we get m^3/s into nexus output
         double area;
         try {

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -419,6 +419,9 @@ namespace realization {
                     for (int i = 0; i < out_vars_json_list.size(); ++i) {
                         out_vars[i] = out_vars_json_list[i].as_string();
                     }
+                    // empty array may be read as [""], so make it empty
+                    if (out_vars.size() == 1 && out_vars[0].empty())
+                        out_vars.pop_back();
                 }
                 else{
                     out_headers.resize(out_vars_json_list.size()); //assumption: number of vars = number of headers
@@ -448,6 +451,12 @@ namespace realization {
                             LOG(ss.str(), LogLevel::WARNING); ss.str("");
                         }
                     }
+                    if (out_vars.size() == 1 && out_vars[0].empty()) {
+                        // empty array may be read as [""], so make everything empty
+                        out_vars.pop_back();
+                        out_headers.pop_back();
+                        out_units.pop_back();
+                    }
                     set_output_variable_units(out_units);
                 }
                 set_output_variable_names(out_vars);
@@ -461,7 +470,7 @@ namespace realization {
             // Output header fields, if present
             auto out_headers_it = properties.find(BMI_REALIZATION_CFG_PARAM_OPT__OUT_HEADER_FIELDS);
             if(is_realization_legacy_format()){
-                if (out_headers_it != properties.end()) {
+                if (out_headers_it != properties.end() && get_output_variable_names().size() > 0) {
                     std::vector<geojson::JSONProperty> out_headers_json_list = out_var_it->second.as_list();
                     std::vector<std::string> out_headers(out_headers_json_list.size());
                     for (int i = 0; i < out_headers_json_list.size(); ++i) {

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -118,6 +118,9 @@ void Bmi_Multi_Formulation::create_multi_formulation(geojson::PropertyMap proper
             for (int i = 0; i < out_vars_json_list.size(); ++i) {
                 out_vars[i] = out_vars_json_list[i].as_string();
             }
+            // empty array may be read as [""], so make it empty
+            if (out_vars.size() == 1 && out_vars[0].empty())
+                out_vars.pop_back();
         }
         else{
             out_headers.resize(out_vars_json_list.size()); //assumption: number of vars = number of headers
@@ -147,6 +150,12 @@ void Bmi_Multi_Formulation::create_multi_formulation(geojson::PropertyMap proper
                     LOG(ss.str(), LogLevel::WARNING); ss.str("");
                 }
             }
+            if (out_vars.size() == 1 && out_vars[0].empty()) {
+                // empty array may be read as [""], so make everything empty
+                out_vars.pop_back();
+                out_headers.pop_back();
+                out_units.pop_back();
+            }
             set_output_variable_units(out_units);
         }
         set_output_variable_names(out_vars);
@@ -165,7 +174,7 @@ void Bmi_Multi_Formulation::create_multi_formulation(geojson::PropertyMap proper
     // Output header fields, if present
     auto out_headers_it = properties.find(BMI_REALIZATION_CFG_PARAM_OPT__OUT_HEADER_FIELDS);
     if(is_realization_legacy_format()){
-        if (out_headers_it != properties.end()) {
+        if (out_headers_it != properties.end() && get_output_variable_names().size() != 0) {
             std::vector<geojson::JSONProperty> out_headers_json_list = out_headers_it->second.as_list();
             std::vector<std::string> out_headers(out_headers_json_list.size());
             for (int i = 0; i < out_headers_json_list.size(); ++i) {


### PR DESCRIPTION
This update allows the catchment CSVs to not be made if the realization config files formulations's output_variables is an empty list. To keep compatibility, omitting the output_variables parameter will have NGEN use the BMI's default output variables.

## Additions

- Virtual class function on Catchment_Formulation for getting the number of output header fields: get_output_header_count
- Override for get_output_header_count. This is used to check whether catchment files should be created and written to.

## Changes

- Bmi_Module_Formulation and Bmi_Multi_Formulation can read empty lists for the output_variables.
- HY_Features and DomainLayer will not create a catchment output CSV if the catchment's formulation has no output fields.
- Layer will not attempt to write outputs if its formulation has no output fields. 

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [x] Linux
