### PR TITLE
Fix NGEN logger. Catch missing header data in forcing csv file.

### DIFF
--- a/include/forcing/CsvPerFeatureForcingProvider.hpp
+++ b/include/forcing/CsvPerFeatureForcingProvider.hpp
@@ -344,7 +344,7 @@ class CsvPerFeatureForcingProvider : public data_access::GenericDataProvider
         std::vector<std::vector<std::string> > data_list = reader.getData();
 
         if (data_list.empty()) {
-            std::string msg = "Emply CSV file " + file_name;
+            std::string msg = "Empty CSV file " + file_name;
             LOG(msg, LogLevel::WARNING);
             throw std::runtime_error(msg);
         }

--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -34,14 +34,28 @@ namespace realization {
         public:
             Formulation_Manager(std::stringstream &data) {
                 boost::property_tree::ptree loaded_tree;
-                boost::property_tree::json_parser::read_json(data, loaded_tree);
-                this->tree = loaded_tree;
+                try {
+                    boost::property_tree::json_parser::read_json(data, loaded_tree);
+                    this->tree = loaded_tree;
+                }
+                catch (const std::exception& e) {
+                    std::string msg = std::string("Reading json data") + e.what();
+                    LOG(msg, LogLevel::FATAL);
+                    throw;
+                }
             }
 
             Formulation_Manager(const std::string &file_path) {
                 boost::property_tree::ptree loaded_tree;
-                boost::property_tree::json_parser::read_json(file_path, loaded_tree);
-                this->tree = loaded_tree;
+                try {
+                    boost::property_tree::json_parser::read_json(file_path, loaded_tree);
+                    this->tree = loaded_tree;
+                }
+                catch (const std::exception& e) {
+                    std::string msg = std::string("Reading json file ") + file_path + e.what();
+                    LOG(msg, LogLevel::FATAL);
+                    throw;
+                }
             }
 
             Formulation_Manager(boost::property_tree::ptree &loaded_tree) {

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -544,7 +544,15 @@ int main(int argc, char* argv[]) {
 
     std::shared_ptr<realization::Formulation_Manager> manager =
         std::make_shared<realization::Formulation_Manager>(realization_config);
-    manager->read(simulation_time_config, catchment_collection, utils::getStdOut());
+    try {
+        manager->read(simulation_time_config, catchment_collection, utils::getStdOut());
+    }
+    catch (const std::exception& e) {
+        std::string msg = std::string("Reading formulation data ") + e.what();
+        LOG(msg, LogLevel::FATAL);
+        throw;
+    }
+    LOG("Formulation Initialized", LogLevel::DEBUG);
 
 // TODO refactor manager->read so certain configs can be queried before the entire
 // realization collection is created

--- a/src/utilities/logging/Logger.cpp
+++ b/src/utilities/logging/Logger.cpp
@@ -263,6 +263,7 @@ bool Logger::ParseLoggerConfigFile(std::ifstream& jsonFile)
                                 << kv.first << "="
                                 << ConvertLogLevelToString(moduleLogLevels[moduleName])
                                 << std::endl;
+                        if (moduleName == "NGEN") logLevel = moduleLogLevels[moduleName];
                     } else {
                         std::cout << "[ERROR] " << MODULE_NAME << " Ignoring unknown module " << moduleName << std::endl;
                     }


### PR DESCRIPTION
While fixing a bug found when a forcing csv file was missing its header row, determined that the latest update to the ngen logger inadvertently eliminated setting the log level for ngen when setting the environment variables for all modules in the formulation. This PR fixes both issues.

## Additions

- try/catch blocks around critical methods
- Set the log level for ngen based on the value read from the config file

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) 