### PR TITLE
Add logic and structures for parsing state saving configuration from realization config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -318,6 +318,7 @@ add_subdirectory("src/geojson")
 add_subdirectory("src/bmi")
 add_subdirectory("src/realizations/catchment")
 add_subdirectory("src/forcing")
+add_subdirectory("src/state_save_restore")
 add_subdirectory("src/utilities")
 add_subdirectory("src/utilities/mdarray")
 add_subdirectory("src/utilities/mdframe")
@@ -336,6 +337,7 @@ target_link_libraries(ngen
         NGen::core_mediator
         NGen::logging
         NGen::parallel
+        NGen::state_save_restore
 )
 
 if(NGEN_WITH_SQLITE)

--- a/data/example_state_saving_config.json
+++ b/data/example_state_saving_config.json
@@ -1,0 +1,109 @@
+{
+    "global": {
+      "formulations": [
+        {
+          "name": "bmi_c++",
+          "params": {
+            "model_type_name": "test_bmi_cpp",
+            "library_file": "./extern/test_bmi_cpp/cmake_build/libtestbmicppmodel.so",
+            "init_config": "./data/bmi/c/test/test_bmi_c_config.ini",
+            "main_output_variable": "OUTPUT_VAR_2",
+            "variables_names_map" : {
+              "INPUT_VAR_2": "TMP_2maboveground",
+              "INPUT_VAR_1": "precip_rate"
+            },
+            "create_function": "bmi_model_create",
+            "destroy_function": "bmi_model_destroy",
+            "uses_forcing_file": false
+          }
+        }
+      ],
+      "forcing": {
+          "file_pattern": ".*{{id}}.*.csv",
+          "path": "./data/forcing/"
+      }
+    },
+    "state_saving": {
+        "label": "end",
+        "path": "state_end",
+        "type": "FilePerUnit",
+        "when": "EndOfRun"
+    },
+    "time": {
+        "start_time": "2015-12-01 00:00:00",
+        "end_time": "2015-12-30 23:00:00",
+        "output_interval": 3600
+    },
+    "output_root": "./output_dir/",
+    "catchments": {
+        "cat-27": {
+          "formulations": [
+            {
+              "name": "bmi_c++",
+              "params": {
+                "model_type_name": "test_bmi_cpp",
+                "library_file": "./extern/test_bmi_cpp/cmake_build/libtestbmicppmodel.so",
+                "init_config": "./data/bmi/c/test/test_bmi_c_config.ini",
+                "main_output_variable": "OUTPUT_VAR_2",
+                "variables_names_map" : {
+                  "INPUT_VAR_2": "TMP_2maboveground",
+                  "INPUT_VAR_1": "precip_rate"
+                },
+                "create_function": "bmi_model_create",
+                "destroy_function": "bmi_model_destroy",
+                "uses_forcing_file": false
+              }
+            }
+          ],
+          "forcing": {
+              "path": "./data/forcing/cat-27_2015-12-01 00_00_00_2015-12-30 23_00_00.csv"
+          }
+        },
+        "cat-52": {
+          "formulations": [
+            {
+              "name": "bmi_c++",
+              "params": {
+                "model_type_name": "test_bmi_cpp",
+                "library_file": "./extern/test_bmi_cpp/cmake_build/libtestbmicppmodel.so",
+                "init_config": "./data/bmi/c/test/test_bmi_c_config.ini",
+                "main_output_variable": "OUTPUT_VAR_2",
+                "variables_names_map" : {
+                  "INPUT_VAR_2": "TMP_2maboveground",
+                  "INPUT_VAR_1": "precip_rate"
+                },
+                "create_function": "bmi_model_create",
+                "destroy_function": "bmi_model_destroy",
+                "uses_forcing_file": false
+              }
+            }
+          ],
+          "forcing": {
+              "path": "./data/forcing/cat-52_2015-12-01 00_00_00_2015-12-30 23_00_00.csv"
+          }
+        },
+        "cat-67": {
+          "formulations": [
+            {
+              "name": "bmi_c++",
+              "params": {
+                "model_type_name": "test_bmi_cpp",
+                "library_file": "./extern/test_bmi_cpp/cmake_build/libtestbmicppmodel.so",
+                "init_config": "./data/bmi/c/test/test_bmi_c_config.ini",
+                "main_output_variable": "OUTPUT_VAR_2",
+                "variables_names_map" : {
+                  "INPUT_VAR_2": "TMP_2maboveground",
+                  "INPUT_VAR_1": "precip_rate"
+                },
+                "create_function": "bmi_model_create",
+                "destroy_function": "bmi_model_destroy",
+                "uses_forcing_file": false
+              }
+            }
+          ],
+          "forcing": {
+              "path": "./data/forcing/cat-67_2015-12-01 00_00_00_2015-12-30 23_00_00.csv"
+          }
+        }
+    }
+}

--- a/include/state_save_restore/State_Save_Restore.hpp
+++ b/include/state_save_restore/State_Save_Restore.hpp
@@ -3,9 +3,37 @@
 
 #include <NGenConfig.h>
 
+#include <boost/property_tree/ptree_fwd.hpp>
+#include <boost/core/span.hpp>
+
 #include <chrono>
 #include <cstdint>
 #include <memory>
+#include <string>
+#include <vector>
+
+class State_Save_Config
+{
+public:
+    /**
+     * Expects the tree @param config that potentially contains a "state_saving" key
+     *
+     *
+     */
+    State_Save_Config(boost::property_tree::ptree const& config);
+
+    struct instance
+    {
+        instance(std::string const& label, std::string const& path, std::string const& mechanism, std::string const& timing);
+
+        std::string label_;
+        std::string path_;
+        std::string mechanism_;
+        std::string timing_;
+    };
+
+    std::vector<instance> instances_;
+};
 
 class State_Snapshot_Saver;
 

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -54,6 +54,8 @@
 #include <Layer.hpp>
 #include <SurfaceLayer.hpp>
 
+#include <state_save_restore/State_Save_Restore.hpp>
+
 void ngen::exec_info::runtime_summary(std::ostream& stream) noexcept {
     stream << "Runtime configuration summary:\n";
 
@@ -535,8 +537,9 @@ int main(int argc, char* argv[]) {
     }
 
     auto simulation_time_config = realization::config::Time(*possible_simulation_time).make_params();
-
     sim_time = std::make_shared<Simulation_Time>(simulation_time_config);
+
+    auto state_saving_config = State_Save_Config(realization_config);
 
     ss << "Initializing formulations" << std::endl;
     LOG(ss.str(), LogLevel::INFO);

--- a/src/state_save_restore/CMakeLists.txt
+++ b/src/state_save_restore/CMakeLists.txt
@@ -1,0 +1,17 @@
+include(${PROJECT_SOURCE_DIR}/cmake/dynamic_sourced_library.cmake)
+dynamic_sourced_cxx_library(state_save_restore "${CMAKE_CURRENT_SOURCE_DIR}")
+
+add_library(NGen::state_save_restore ALIAS state_save_restore)
+target_link_libraries(state_save_restore PUBLIC
+                           NGen::config_header
+                           Boost::boost                # Headers-only Boost
+                           )
+
+#target_link_libraries(core
+#        PRIVATE
+#                          )
+
+target_include_directories(state_save_restore PUBLIC
+        ${PROJECT_SOURCE_DIR}/include
+        )
+

--- a/src/state_save_restore/CMakeLists.txt
+++ b/src/state_save_restore/CMakeLists.txt
@@ -7,10 +7,6 @@ target_link_libraries(state_save_restore PUBLIC
                            Boost::boost                # Headers-only Boost
                            )
 
-#target_link_libraries(core
-#        PRIVATE
-#                          )
-
 target_include_directories(state_save_restore PUBLIC
         ${PROJECT_SOURCE_DIR}/include
         )

--- a/src/state_save_restore/State_Save_Restore.cpp
+++ b/src/state_save_restore/State_Save_Restore.cpp
@@ -1,0 +1,64 @@
+#include <state_save_restore/State_Save_Restore.hpp>
+
+#include <utilities/Logger.hpp>
+
+#include <boost/optional.hpp>
+#include <boost/property_tree/ptree.hpp>
+
+#include <string>
+
+State_Save_Config::State_Save_Config(boost::property_tree::ptree const& tree)
+{
+    auto maybe = tree.get_child_optional("state_saving");
+
+    // Default initialization will represent the "not enabled" case
+    if (!maybe) {
+        LOG("State saving not configured", LogLevel::INFO);
+        return;
+    }
+
+    auto subtree = *maybe;
+
+    try {
+        auto single_what = subtree.get<std::string>("label");
+        auto single_where = subtree.get<std::string>("path");
+        auto single_how = subtree.get<std::string>("type");
+        auto single_when = subtree.get<std::string>("when");
+
+        instance i{single_what, single_where, single_how, single_when};
+        instances_.push_back(i);
+    } catch (...) {
+        LOG("Bad state saving config", LogLevel::WARNING);
+        throw;
+    }
+
+    LOG("State saving configured", LogLevel::INFO);
+}
+
+State_Save_Config::instance::instance(std::string const& label, std::string const& path, std::string const& mechanism, std::string const& timing)
+    : label_(label)
+    , path_(path)
+    , mechanism_(mechanism)
+    , timing_(timing)
+{
+    if (mechanism_ == "FilePerUnit") {
+        // nothing to do here
+    } else {
+        Logger::logMsgAndThrowError("Unrecognized state saving mechanism '" + mechanism_ + "'");
+    }
+
+    if (timing_ == "EndOfRun") {
+        // nothing to do here
+    } else if (timing_ == "FirstOfMonth") {
+        // nothing to do here
+    } else {
+        Logger::logMsgAndThrowError("Unrecognized state saving timing '" + timing_ + "'");
+    }
+}
+
+State_Snapshot_Saver::State_Snapshot_Saver(State_Saver::snapshot_time_t epoch, State_Saver::State_Durability durability)
+    : epoch_(epoch)
+    , durability_(durability)
+{
+
+}


### PR DESCRIPTION
Incremental change to add configuration support to the state saving branch.

## Additions

- Class representing the configuration of state saving, and logic therein to parse that configuration from a realization config file
- Example realization config file modified to contain the expected state saving configuration

## Testing

1. Ran against existing example realization config files, and observed "not configured" line in log output
2. Ran against newly-committed example config file, and observed "configured" line in log output
3. Modified new example config file to leave `"state_saving"` empty, or to corrupt the two entries that are currently checked, and observed appropriate terminal errors.

## Notes

- Will add documentation of realization config format to `doc/REALIZATION_CONFIGURATION.md` in a separate PR when the functionality is more fully integrated, to avoid creating a false impression

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
