### PR TITLE
Dynamic Forcing Engine CAT-ID Data Type (NGWPC-9255)

### DIFF
--- a/include/bmi/Bmi_Py_Adapter.hpp
+++ b/include/bmi/Bmi_Py_Adapter.hpp
@@ -236,24 +236,31 @@ namespace models {
                  * this might cause trouble on certain systems, since (depending on the particular sizes of types) that
                  * could produce duplicate "case" values.
                  */
-                //TODO: include other numpy type strings, https://numpy.org/doc/stable/user/basics.types.html
-                if ( (py_type_name == "int" || py_type_name == "int16") && item_size == sizeof(short)) {
+                if (item_size == sizeof(signed char) && (py_type_name == "int8" || py_type_name == "numpy.int8")) {
+                    return "signed char";
+                } else if (item_size == sizeof(unsigned char) && (py_type_name == "uint8" || py_type_name == "numpy.uint8")) {
+                    return "unsigned char";
+                } else if (item_size == sizeof(short) && (py_type_name == "int" || py_type_name == "int16" || py_type_name == "numpy.int16")) {
                     return "short";
-                } else if ( (py_type_name == "int" || py_type_name == "int32" )&& item_size == sizeof(int)) {
+                } else if (item_size == sizeof(unsigned short) && (py_type_name == "uint16" || py_type_name == "numpy.uint16" || py_type_name == "ushort" || py_type_name == "numpy.ushort")) {
+                    return "unsigned short";
+                } else if (item_size == sizeof(int) && (py_type_name == "int" || py_type_name == "int32" || py_type_name == "numpy.int32" || py_type_name == "intc" || py_type_name == "numpy.intc")) {
                     return "int";
-                } else if (py_type_name == "int" && item_size == sizeof(long)) {
+                } else if (item_size == sizeof(unsigned int) && (py_type_name == "uint32" || py_type_name == "numpy.uint32" || py_type_name == "uintc" || py_type_name == "numpy.uintc")) {
+                    return "unsigned int";
+                } else if (item_size == sizeof(long) && (py_type_name == "int" || py_type_name == "int64" || py_type_name == "numpy.int64" || py_type_name == "long" || py_type_name == "numpy.long")) {
                     return "long";
-                } else if ( (py_type_name == "int" || py_type_name == "int64") && item_size == sizeof(long long)) {
+                } else if (item_size == sizeof(unsigned long) && (py_type_name == "uint64" || py_type_name == "numpy.uint64" || py_type_name == "uint32" || py_type_name == "numpy.uint32" || py_type_name == "ulong" || py_type_name == "numpy.ulong")) {
+                    return "unsigned long";
+                } else if (item_size == sizeof(long long) && (py_type_name == "int" || py_type_name == "int64" || py_type_name == "numpy.int64" || py_type_name == "longlong")) {
                     return "long long";
-                } else if (py_type_name == "longlong" && item_size == sizeof(long long)) {
-                    return "long long"; //numpy type
-                } else if ( (py_type_name == "float" || py_type_name == "float32" || py_type_name == "np.float32" ||
-                           py_type_name == "numpy.float32" || py_type_name == "np.single" ||  py_type_name == "numpy.single") && item_size == sizeof(float)) {
+                } else if (item_size == sizeof(unsigned long long) && (py_type_name == "ulonglong" || py_type_name == "numpy.ulonglong")) {
+                    return "unsigned long long";
+                } else if (item_size == sizeof(float) && (py_type_name == "float" || py_type_name == "float32" || py_type_name == "numpy.float32" || py_type_name == "single" || py_type_name == "numpy.single")) {
                     return "float";
-                } else if ((py_type_name == "float" || py_type_name == "float64" || py_type_name == "np.float64" ||
-                            py_type_name == "numpy.float64") && item_size == sizeof(double)) {
+                } else if (item_size == sizeof(double) && (py_type_name == "float" || py_type_name == "float64" || py_type_name == "numpy.float64" || py_type_name == "double" || py_type_name == "numpy.double")) {
                     return "double";
-                } else if (py_type_name == "float" && item_size == sizeof(long double)) {
+                } else if (item_size == sizeof(long double) && (py_type_name == "float" || py_type_name == "float128" || py_type_name == "numpy.float128" || py_type_name == "longdouble" || py_type_name == "numpy.longdouble")) {
                     return "long double";
                 } else {
                     std::string throw_msg; throw_msg.assign(

--- a/include/forcing/ForcingsEngineLumpedDataProvider.hpp
+++ b/include/forcing/ForcingsEngineLumpedDataProvider.hpp
@@ -42,6 +42,10 @@ struct ForcingsEngineLumpedDataProvider final :
   private:
     std::size_t divide_id_;
     std::size_t divide_idx_;
+
+    // Search an array of numbers for the first instance of the current `divide_id_` and set the `divide_idx_` to that index if found
+    template <typename T>
+    void find_divide_id(const void *cat_id_ptr, const std::size_t size_id_dimension);
 };
 
 } // namespace data_access

--- a/src/forcing/ForcingsEngineLumpedDataProvider.cpp
+++ b/src/forcing/ForcingsEngineLumpedDataProvider.cpp
@@ -128,7 +128,7 @@ Provider::ForcingsEngineLumpedDataProvider(
     } else {
         ss.str(""); 
         ss << " Divide ID " << divide_id << " found at index: " << divide_idx_;
-        LOG(ss.str(), LogLevel::INFO);
+        LOG(ss.str(), LogLevel::DEBUG);
     }
 
     ss.str(""); 
@@ -143,19 +143,9 @@ inline void Provider::find_divide_id(const void *cat_id_ptr, const std::size_t s
         static_cast<const T*>(cat_id_ptr),
         size_id_dimension
     );
-    // round values if type if float or double 
-    if (std::is_floating_point<T>::value) {
-        for (std::size_t i = 0; i < size_id_dimension; ++i) {
-            if (static_cast<std::size_t>(std::lround(cat_id_span[i])) == divide_id_) {
-                divide_idx_ = i;
-                break;
-            }
-        }
-    } else {
-        auto loc = std::find(cat_id_span.begin(), cat_id_span.end(), divide_id_);
-        if (loc != cat_id_span.end()) {
-            divide_idx_ = std::distance(cat_id_span.begin(), loc);
-        }
+    auto loc = std::find(cat_id_span.begin(), cat_id_span.end(), divide_id_);
+    if (loc != cat_id_span.end()) {
+        divide_idx_ = std::distance(cat_id_span.begin(), loc);
     }
 }
 

--- a/src/forcing/ForcingsEngineLumpedDataProvider.cpp
+++ b/src/forcing/ForcingsEngineLumpedDataProvider.cpp
@@ -91,7 +91,8 @@ Provider::ForcingsEngineLumpedDataProvider(
     const std::string cat_id_cpp_type = bmi_->get_analogous_cxx_type(cat_id_type, cat_id_item_size);
     void *cat_id_ptr = bmi_->GetValuePtr("CAT-ID");
 
-    // copy CAT-ID values of whatever type into local std::size_t container
+    // locate the index of the CAT-ID in the provider
+    // max value of divide_idx_ assumed as an error state
     divide_idx_ = std::numeric_limits<std::size_t>::max();
     if (cat_id_cpp_type == "short") {
         this->find_divide_id<short>(cat_id_ptr, size_id_dimension);

--- a/src/forcing/ForcingsEngineLumpedDataProvider.cpp
+++ b/src/forcing/ForcingsEngineLumpedDataProvider.cpp
@@ -92,28 +92,40 @@ Provider::ForcingsEngineLumpedDataProvider(
     void *cat_id_ptr = bmi_->GetValuePtr("CAT-ID");
 
     // copy CAT-ID values of whatever type into local std::size_t container
-    std::vector<std::size_t> cat_id_values(size_id_dimension);
+    divide_idx_ = std::numeric_limits<std::size_t>::max();
     if (cat_id_cpp_type == "int") {
         auto cat_id_span = boost::span<const int>(
             static_cast<const int*>(cat_id_ptr),
             size_id_dimension
         );
-        for (std::size_t i = 0; i < size_id_dimension; ++i)
-            cat_id_values[i] = static_cast<std::size_t>(cat_id_span[i]);
+        for (std::size_t i = 0; i < size_id_dimension; ++i) {
+            if (static_cast<std::size_t>(cat_id_span[i]) == divide_id_) {
+                divide_idx_ = i;
+                break;
+            }
+        }
     } else if (cat_id_cpp_type == "long") {
         auto cat_id_span = boost::span<const long>(
             static_cast<const long*>(cat_id_ptr),
             size_id_dimension
         );
-        for (std::size_t i = 0; i < size_id_dimension; ++i)
-            cat_id_values[i] = static_cast<std::size_t>(cat_id_span[i]);
+        for (std::size_t i = 0; i < size_id_dimension; ++i) {
+            if (static_cast<std::size_t>(cat_id_span[i]) == divide_id_) {
+                divide_idx_ = i;
+                break;
+            }
+        }
     } else if (cat_id_cpp_type == "double") {
         auto cat_id_span = boost::span<const double>(
             static_cast<const double*>(cat_id_ptr),
             size_id_dimension
         );
-        for (std::size_t i = 0; i < size_id_dimension; ++i)
-            cat_id_values[i] = static_cast<std::size_t>(cat_id_span[i]);
+        for (std::size_t i = 0; i < size_id_dimension; ++i) {
+            if (static_cast<std::size_t>(cat_id_span[i]) == divide_id_) {
+                divide_idx_ = i;
+                break;
+            }
+        }
     } else {
         ss.str("");
         ss << "(ForcingEngineLumpedDataProvider) Unable to interpret CAT-ID type of C++ type '"
@@ -122,15 +134,12 @@ Provider::ForcingsEngineLumpedDataProvider(
         LOG(ss.str(), LogLevel::SEVERE);
     }
 
-    auto divide_id_pos = std::find(cat_id_values.begin(), cat_id_values.end(), divide_id_);
-    if (divide_id_pos == cat_id_values.end()) {
+    if (divide_idx_ == std::numeric_limits<std::size_t>::max()) {
         ss.str(""); 
         ss << "Unable to find divide ID `" << divide_id
             << "` in the given Forcings Engine domain" << std::endl;
         LOG(ss.str(), LogLevel::SEVERE);
-        divide_idx_ = static_cast<std::size_t>(-1);
     } else {
-        divide_idx_ = std::distance(cat_id_values.begin(), divide_id_pos);
         ss.str(""); 
         ss << " Divide ID found at index: " << divide_idx_ << std::endl;
         LOG(ss.str(), LogLevel::INFO);

--- a/src/forcing/ForcingsEngineLumpedDataProvider.cpp
+++ b/src/forcing/ForcingsEngineLumpedDataProvider.cpp
@@ -115,7 +115,9 @@ Provider::ForcingsEngineLumpedDataProvider(
         ss << "(ForcingEngineLumpedDataProvider) Unable to interpret CAT-ID type of C++ type '"
             << cat_id_cpp_type << "' (python type '"
             << cat_id_type << "')";
-        LOG(ss.str(), LogLevel::SEVERE);
+        std::string error = ss.str();
+        LOG(error, LogLevel::FATAL);
+        throw std::runtime_error(error);
     }
 
     if (divide_idx_ == std::numeric_limits<std::size_t>::max()) {

--- a/src/forcing/ForcingsEngineLumpedDataProvider.cpp
+++ b/src/forcing/ForcingsEngineLumpedDataProvider.cpp
@@ -79,28 +79,58 @@ Provider::ForcingsEngineLumpedDataProvider(
 
     var_output_names_.erase(cat_id_pos);
 
+    const std::size_t cat_id_item_size = static_cast<std::size_t>(bmi_->GetVarItemsize("CAT-ID"));
     const auto size_id_dimension = static_cast<std::size_t>(
-        bmi_->GetVarNbytes("CAT-ID") / bmi_->GetVarItemsize("CAT-ID")
+        bmi_->GetVarNbytes("CAT-ID") / cat_id_item_size
     );
     ss.str(""); 
     ss << " CAT-ID size: " << size_id_dimension << std::endl;
     LOG(ss.str(), LogLevel::DEBUG);
 
-    // Copy CAT-ID values into instance vector
-    const auto cat_id_span = boost::span<const int>(
-        static_cast<const int*>(bmi_->GetValuePtr("CAT-ID")),
-        size_id_dimension
-    );
+    const std::string cat_id_type = bmi_->GetVarType("CAT-ID");
+    const std::string cat_id_cpp_type = bmi_->get_analogous_cxx_type(cat_id_type, cat_id_item_size);
+    void *cat_id_ptr = bmi_->GetValuePtr("CAT-ID");
 
-    auto divide_id_pos = std::find(cat_id_span.begin(), cat_id_span.end(), divide_id_);
-    if (divide_id_pos == cat_id_span.end()) {
+    // copy CAT-ID values of whatever type into local std::size_t container
+    std::vector<std::size_t> cat_id_values(size_id_dimension);
+    if (cat_id_cpp_type == "int") {
+        auto cat_id_span = boost::span<const int>(
+            static_cast<const int*>(cat_id_ptr),
+            size_id_dimension
+        );
+        for (std::size_t i = 0; i < size_id_dimension; ++i)
+            cat_id_values[i] = static_cast<std::size_t>(cat_id_span[i]);
+    } else if (cat_id_cpp_type == "long") {
+        auto cat_id_span = boost::span<const long>(
+            static_cast<const long*>(cat_id_ptr),
+            size_id_dimension
+        );
+        for (std::size_t i = 0; i < size_id_dimension; ++i)
+            cat_id_values[i] = static_cast<std::size_t>(cat_id_span[i]);
+    } else if (cat_id_cpp_type == "double") {
+        auto cat_id_span = boost::span<const double>(
+            static_cast<const double*>(cat_id_ptr),
+            size_id_dimension
+        );
+        for (std::size_t i = 0; i < size_id_dimension; ++i)
+            cat_id_values[i] = static_cast<std::size_t>(cat_id_span[i]);
+    } else {
+        ss.str("");
+        ss << "(ForcingEngineLumpedDataProvider) Unable to interpret CAT-ID type of C++ type '"
+            << cat_id_cpp_type << "' (python type '"
+            << cat_id_type << "')";
+        LOG(ss.str(), LogLevel::SEVERE);
+    }
+
+    auto divide_id_pos = std::find(cat_id_values.begin(), cat_id_values.end(), divide_id_);
+    if (divide_id_pos == cat_id_values.end()) {
         ss.str(""); 
         ss << "Unable to find divide ID `" << divide_id
             << "` in the given Forcings Engine domain" << std::endl;
         LOG(ss.str(), LogLevel::SEVERE);
         divide_idx_ = static_cast<std::size_t>(-1);
     } else {
-        divide_idx_ = std::distance(cat_id_span.begin(), divide_id_pos);
+        divide_idx_ = std::distance(cat_id_values.begin(), divide_id_pos);
         ss.str(""); 
         ss << " Divide ID found at index: " << divide_idx_ << std::endl;
         LOG(ss.str(), LogLevel::INFO);

--- a/src/forcing/ForcingsEngineLumpedDataProvider.cpp
+++ b/src/forcing/ForcingsEngineLumpedDataProvider.cpp
@@ -93,39 +93,22 @@ Provider::ForcingsEngineLumpedDataProvider(
 
     // copy CAT-ID values of whatever type into local std::size_t container
     divide_idx_ = std::numeric_limits<std::size_t>::max();
-    if (cat_id_cpp_type == "int") {
-        auto cat_id_span = boost::span<const int>(
-            static_cast<const int*>(cat_id_ptr),
-            size_id_dimension
-        );
-        for (std::size_t i = 0; i < size_id_dimension; ++i) {
-            if (static_cast<std::size_t>(cat_id_span[i]) == divide_id_) {
-                divide_idx_ = i;
-                break;
-            }
-        }
+    if (cat_id_cpp_type == "short") {
+        this->find_divide_id<short>(cat_id_ptr, size_id_dimension);
+    } else if (cat_id_cpp_type == "unsigned short") {
+        this->find_divide_id<unsigned short>(cat_id_ptr, size_id_dimension);
+    } else if (cat_id_cpp_type == "int") {
+        this->find_divide_id<int>(cat_id_ptr, size_id_dimension);
+    } else if (cat_id_cpp_type == "unsigned int") {
+        this->find_divide_id<unsigned int>(cat_id_ptr, size_id_dimension);
     } else if (cat_id_cpp_type == "long") {
-        auto cat_id_span = boost::span<const long>(
-            static_cast<const long*>(cat_id_ptr),
-            size_id_dimension
-        );
-        for (std::size_t i = 0; i < size_id_dimension; ++i) {
-            if (static_cast<std::size_t>(cat_id_span[i]) == divide_id_) {
-                divide_idx_ = i;
-                break;
-            }
-        }
+        this->find_divide_id<long>(cat_id_ptr, size_id_dimension);
+    } else if (cat_id_cpp_type == "unsigned long") {
+        this->find_divide_id<unsigned long>(cat_id_ptr, size_id_dimension);
+    } else if (cat_id_cpp_type == "float") {
+        this->find_divide_id<float>(cat_id_ptr, size_id_dimension);
     } else if (cat_id_cpp_type == "double") {
-        auto cat_id_span = boost::span<const double>(
-            static_cast<const double*>(cat_id_ptr),
-            size_id_dimension
-        );
-        for (std::size_t i = 0; i < size_id_dimension; ++i) {
-            if (static_cast<std::size_t>(std::lround(cat_id_span[i])) == divide_id_) {
-                divide_idx_ = i;
-                break;
-            }
-        }
+        this->find_divide_id<double>(cat_id_ptr, size_id_dimension);
     } else {
         ss.str("");
         ss << "(ForcingEngineLumpedDataProvider) Unable to interpret CAT-ID type of C++ type '"
@@ -148,6 +131,40 @@ Provider::ForcingsEngineLumpedDataProvider(
     ss.str(""); 
     ss << " ForcingsEngineLumpedDataProvider initialization complete" << std::endl;
     LOG(LogLevel::DEBUG, ss.str());
+}
+
+template <typename T>
+inline void Provider::find_divide_id(const void *cat_id_ptr, const std::size_t size_id_dimension) {
+    // create span for viewing that data of type T
+    auto cat_id_span = boost::span<const T>(
+        static_cast<const T*>(cat_id_ptr),
+        size_id_dimension
+    );
+#if __cplusplus < 201703L
+    // if C++ < 17, create local value for whether to round floating points to whole numbers
+    bool round = std::is_same<T, double>::value || std::is_same<T, float>::value;
+#endif
+    std::size_t candidate;
+    for (std::size_t i = 0; i < size_id_dimension; ++i) {
+#if __cplusplus >= 201703L
+        // round if floating point type
+        if constexpr (std::is_floating_point_v<T>) {
+            candidate = static_cast<std::size_t>(std::lround(cat_id_span[i]));
+        } else {
+            candidate = static_cast<std::size_t>(cat_id_span[i]);
+        }
+#else
+        if (round) {
+            candidate = static_cast<std::size_t>(std::lround(cat_id_span[i]));
+        } else {
+            candidate = static_cast<std::size_t>(cat_id_span[i]);
+        }
+#endif
+        if (candidate == divide_id_) {
+            divide_idx_ = i;
+            break;
+        }
+    }
 }
 
 std::size_t Provider::divide() const noexcept

--- a/src/forcing/ForcingsEngineLumpedDataProvider.cpp
+++ b/src/forcing/ForcingsEngineLumpedDataProvider.cpp
@@ -141,7 +141,7 @@ Provider::ForcingsEngineLumpedDataProvider(
         LOG(ss.str(), LogLevel::SEVERE);
     } else {
         ss.str(""); 
-        ss << " Divide ID found at index: " << divide_idx_ << std::endl;
+        ss << " Divide ID " << divide_id << " found at index: " << divide_idx_;
         LOG(ss.str(), LogLevel::INFO);
     }
 

--- a/src/forcing/ForcingsEngineLumpedDataProvider.cpp
+++ b/src/forcing/ForcingsEngineLumpedDataProvider.cpp
@@ -121,7 +121,7 @@ Provider::ForcingsEngineLumpedDataProvider(
             size_id_dimension
         );
         for (std::size_t i = 0; i < size_id_dimension; ++i) {
-            if (static_cast<std::size_t>(cat_id_span[i]) == divide_id_) {
+            if (static_cast<std::size_t>(std::lround(cat_id_span[i])) == divide_id_) {
                 divide_idx_ = i;
                 break;
             }

--- a/src/forcing/ForcingsEngineLumpedDataProvider.cpp
+++ b/src/forcing/ForcingsEngineLumpedDataProvider.cpp
@@ -141,29 +141,23 @@ inline void Provider::find_divide_id(const void *cat_id_ptr, const std::size_t s
         static_cast<const T*>(cat_id_ptr),
         size_id_dimension
     );
-#if __cplusplus < 201703L
-    // if C++ < 17, create local value for whether to round floating points to whole numbers
-    bool round = std::is_same<T, double>::value || std::is_same<T, float>::value;
-#endif
-    std::size_t candidate;
-    for (std::size_t i = 0; i < size_id_dimension; ++i) {
+    // round values if type if float or double 
+    // if constexpr syntax only available in C++ 17 or greater
 #if __cplusplus >= 201703L
-        // round if floating point type
-        if constexpr (std::is_floating_point_v<T>) {
-            candidate = static_cast<std::size_t>(std::lround(cat_id_span[i]));
-        } else {
-            candidate = static_cast<std::size_t>(cat_id_span[i]);
-        }
+    if constexpr (std::is_floating_point_v<T>) {
 #else
-        if (round) {
-            candidate = static_cast<std::size_t>(std::lround(cat_id_span[i]));
-        } else {
-            candidate = static_cast<std::size_t>(cat_id_span[i]);
-        }
+    if (std::is_same<T, double>::value || std::is_same<T, float>::value) {
 #endif
-        if (candidate == divide_id_) {
-            divide_idx_ = i;
-            break;
+        for (std::size_t i = 0; i < size_id_dimension; ++i) {
+            if (static_cast<std::size_t>(std::lround(cat_id_span[i])) == divide_id_) {
+                divide_idx_ = i;
+                break;
+            }
+        }
+    } else {
+        auto loc = std::find(cat_id_span.begin(), cat_id_span.end(), divide_id_);
+        if (loc != cat_id_span.end()) {
+            divide_idx_ = std::distance(cat_id_span.begin(), loc);
         }
     }
 }

--- a/src/forcing/ForcingsEngineLumpedDataProvider.cpp
+++ b/src/forcing/ForcingsEngineLumpedDataProvider.cpp
@@ -142,12 +142,7 @@ inline void Provider::find_divide_id(const void *cat_id_ptr, const std::size_t s
         size_id_dimension
     );
     // round values if type if float or double 
-    // if constexpr syntax only available in C++ 17 or greater
-#if __cplusplus >= 201703L
-    if constexpr (std::is_floating_point_v<T>) {
-#else
-    if (std::is_same<T, double>::value || std::is_same<T, float>::value) {
-#endif
+    if (std::is_floating_point<T>::value) {
         for (std::size_t i = 0; i < size_id_dimension; ++i) {
             if (static_cast<std::size_t>(std::lround(cat_id_span[i])) == divide_id_) {
                 divide_idx_ = i;


### PR DESCRIPTION
The CAT-ID `dtype` should not be assumed to any specific value, so the search for the data index can now accept multiple data types.

## Changes

- Forcing Engine provider's search for the catchment index is more permissive on the data type of the CAT-ID data.

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [ ] Linux
