### PR TITLE
Freed Memory Safety Improvements (NGWPC-9493)

### DIFF
--- a/include/bmi/Bmi_Py_Adapter.hpp
+++ b/include/bmi/Bmi_Py_Adapter.hpp
@@ -47,7 +47,8 @@ namespace models {
             Bmi_Py_Adapter(Bmi_Py_Adapter&&) = delete;
 
             ~Bmi_Py_Adapter() override {
-                Finalize();
+                if (bmi_model != NULL)
+                    Finalize();
             }
 
             /**

--- a/include/bmi/Bmi_Py_Adapter.hpp
+++ b/include/bmi/Bmi_Py_Adapter.hpp
@@ -47,8 +47,7 @@ namespace models {
             Bmi_Py_Adapter(Bmi_Py_Adapter&&) = delete;
 
             ~Bmi_Py_Adapter() override {
-                if (bmi_model != NULL)
-                    Finalize();
+                Finalize();
             }
 
             /**

--- a/include/forcing/ForcingsEngineDataProvider.hpp
+++ b/include/forcing/ForcingsEngineDataProvider.hpp
@@ -108,7 +108,10 @@ struct ForcingsEngineDataProvider : public DataProvider<DataType, SelectionType>
     using clock_type = std::chrono::system_clock;
 
     ~ForcingsEngineDataProvider() override = default;
-    void finalize() override = default;
+    void finalize() override
+    {
+        bmi_.reset();
+    }
 
     boost::span<const std::string> get_available_variable_names() const override
     {

--- a/include/forcing/ForcingsEngineDataProvider.hpp
+++ b/include/forcing/ForcingsEngineDataProvider.hpp
@@ -78,11 +78,14 @@ struct ForcingsEngineStorage {
         data_[key] = value;
     }
 
-    //! Clear all references to Forcings Engine instances.
+    //! Clear all references to Forcings Engine instances and run the Finalize methods on each BMI instance.
     //! @note This will not necessarily destroy the Forcings Engine instances. Since they
     //!       are reference counted, it will only decrement their instance by one.
-    void clear()
+    void finalize()
     {
+        for (auto &provider : data_) {
+            provider.second->Finalize();
+        }
         data_.clear();
     }
 
@@ -105,13 +108,7 @@ struct ForcingsEngineDataProvider : public DataProvider<DataType, SelectionType>
     using clock_type = std::chrono::system_clock;
 
     ~ForcingsEngineDataProvider() override = default;
-    void finalize() override
-    {
-        if (bmi_ != nullptr) {
-            bmi_->Finalize();
-            bmi_ = nullptr;
-        }
-    }
+    void finalize() override = default;
 
     boost::span<const std::string> get_available_variable_names() const override
     {

--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -318,7 +318,7 @@ namespace realization {
                 data_access::NetCDFPerFeatureDataProvider::cleanup_shared_providers();
 #endif
 #if NGEN_WITH_PYTHON
-                data_access::detail::ForcingsEngineStorage::instances.clear();
+                data_access::detail::ForcingsEngineStorage::instances.finalize();
 #endif
                 ss.str(""); ss << "Formulation_Manager finalized" << std::endl;
                 LOG(ss.str(), LogLevel::DEBUG);

--- a/include/realizations/catchment/Formulation_Manager.hpp
+++ b/include/realizations/catchment/Formulation_Manager.hpp
@@ -724,12 +724,14 @@ namespace realization {
 
                 // Iterate over directory entries
                 if (directory != nullptr) {
+                    // handle closing the directory regardless of how the function returns
+                    auto closer = [](DIR *dir){ closedir(dir); };
+                    std::unique_ptr<DIR, decltype(closer)> _(directory, closer);
                     while ((entry = readdir(directory))) {
                         if (std::regex_match(entry->d_name, pattern)) {
                             // Check for regular files and symlinks
             #ifdef _DIRENT_HAVE_D_TYPE
                             if (entry->d_type == DT_REG || entry->d_type == DT_LNK) {
-                                closedir(directory);
                                 return forcing_params(
                                     path + entry->d_name,
                                     provider,
@@ -749,7 +751,6 @@ namespace realization {
                                 }
 
                                 if (S_ISREG(st.st_mode)) {
-                                    closedir(directory);
                                     return forcing_params(
                                         path + entry->d_name,
                                         provider,
@@ -768,7 +769,6 @@ namespace realization {
             #endif
                         }
                     }
-                    closedir(directory);
                 } else {
                     // The directory wasn't found or otherwise couldn't be opened; forcing data cannot be retrieved
                     std::string throw_msg = "Error opening forcing data dir '" + path + "' after " + std::to_string(attemptCount) + " attempts: " + errMsg;

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -782,8 +782,6 @@ int main(int argc, char* argv[]) {
     LOG("[TIMING]: Coastal: " + std::to_string(time_elapsed_coastal.count()), LogLevel::INFO);
 #endif
 
-    _interp.reset();
-
     auto time_done_total                               = std::chrono::steady_clock::now();
     std::chrono::duration<double> time_elapsed_total   = time_done_total - time_start;
 

--- a/test/forcing/ForcingsEngineLumpedDataProvider_Test.cpp
+++ b/test/forcing/ForcingsEngineLumpedDataProvider_Test.cpp
@@ -71,7 +71,7 @@ void TestFixture::SetUpTestSuite()
 
 void TestFixture::TearDownTestSuite()
 {
-    data_access::detail::ForcingsEngineStorage::instances.clear();
+    data_access::detail::ForcingsEngineStorage::instances.finalize();
     gil_.reset();
 
     #if NGEN_WITH_MPI


### PR DESCRIPTION
Use-after-free errors were encountered during the destruction of LSTM python adapters. This PR aims to correct all memory-related problems encountered during those runs.

This was originally merged in PR #98 but reverted due to a unit test failure, which has now been fixed with the latest commit. See that PR for review comment history.


## Removals

- `NGen.cpp` has the explicit call to release the python interpreter lock removed. Do this seemed to make it less likely to free data before running the python BMI finalize functions on freed python objects.

## Changes

- `Formulation_Manager::get_forcing_params` uses a `std::unique_ptr` for managing the call to `closedir`. This ensures that any open `DIR *` will be closed regardless of how the function terminates and fixes a use-after-free error when reading properties of a `dirent *` after closing the directory as it's currently written.
- `Bmi_Py_Adapter` checks for whether its `bmi_model` is null before attempting to call `Finalize`.
- ForcingsEngineLumpedDataProvider_Test's `TearDownTestSuite()` updated to use new tear down method name.

## Testing

1. Run to completion using an RTE Docker image built and run on AWS Workspaces.
2. Built on AWS Workspace with tests enabled.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [ ] Linux
