### PR TITLE
Ensure BMIs Destroyed Before Calling MPI_Finalize (NGWPC-9583)

### DIFF
--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -166,7 +166,7 @@ void write_nexus_outflow_csv_files(std::string const& output_root,
     }
 }
 
-int main(int argc, char* argv[]) {
+int run_ngen(int argc, char* argv[], int mpi_num_procs, int mpi_rank) {
     std::string catchmentDataFile         = "";
     std::string nexusDataFile             = "";
     std::string REALIZATION_CONFIG_PATH   = "";
@@ -174,18 +174,7 @@ int main(int argc, char* argv[]) {
     std::string PARTITION_PATH = "";
     std::stringstream ss("");
 
-     // This default value should lead to behavior matching the single-process case in the standalone or non-MPI case
-    int mpi_num_procs = 1;
-    // Define in the non-MPI case so that we don't need to conditionally compile `if (mpi_rank == 0)`
-    int mpi_rank = 0;
-
     if (argc > 1 && std::string{argv[1]} == "--info") {
-#if NGEN_WITH_MPI
-        MPI_Init(nullptr, nullptr);
-        MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
-        MPI_Comm_size(MPI_COMM_WORLD, &mpi_num_procs);
-#endif
-
         if (mpi_rank == 0) {
             std::ostringstream output;
             output << ngen::exec_info::build_summary;
@@ -201,11 +190,7 @@ int main(int argc, char* argv[]) {
             ss.str("");
         } // if (mpi_rank == 0)
 
-#if NGEN_WITH_MPI
-        MPI_Finalize();
-#endif
-
-        exit(1);
+        return 1;
     }
 
     auto time_start = std::chrono::steady_clock::now();
@@ -282,8 +267,8 @@ int main(int argc, char* argv[]) {
         ss << "  VIRTUAL_ENV environment variable: "
            << (std::getenv("VIRTUAL_ENV") == nullptr ? "(not set)" : std::getenv("VIRTUAL_ENV"))
            << std::endl;
-        ss << "  Discovered venv: " << _interp->getDiscoveredVenvPath() << std::endl;
-        auto paths = _interp->getSystemPath();
+        ss << "  Discovered venv: " << utils::ngenPy::InterpreterUtil::getInstance()->getDiscoveredVenvPath() << std::endl;
+        auto paths = utils::ngenPy::InterpreterUtil::getInstance()->getSystemPath();
         ss << "  System paths:" << std::endl;
         for (std::string& path : std::get<1>(paths)) {
             if (!path.empty()) {
@@ -295,7 +280,7 @@ int main(int argc, char* argv[]) {
         std::cout << ss.str() << std::endl;
         LOG(ss.str(), LogLevel::INFO);
         ss.str("");
-        exit(0); // Unsure if this path should have a non-zero exit code?
+        return 0; // Unsure if this path should have a non-zero exit code?
 
     } else if (argc < 6) {
         ss << "Missing required args:" << std::endl;
@@ -314,19 +299,13 @@ int main(int argc, char* argv[]) {
             ss.str("");
         }
 
-        exit(-1);
+        return -1;
     } else {
         catchmentDataFile       = argv[1];
         nexusDataFile           = argv[3];
         REALIZATION_CONFIG_PATH = argv[5];
 
 #if NGEN_WITH_MPI
-
-        // Initalize MPI
-        MPI_Init(NULL, NULL);
-        MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
-        MPI_Comm_size(MPI_COMM_WORLD, &mpi_num_procs);
-
         if (argc >= 7) {
             LOG("argc >= 7", LogLevel::INFO);
             ss.str("");
@@ -335,7 +314,7 @@ int main(int argc, char* argv[]) {
             ss << "Missing required argument for partition file path." << std::endl;
             LOG(ss.str(), LogLevel::WARNING);
             ss.str("");
-            exit(-1);
+            return -1;
         }
 
         if (argc >= 8) {
@@ -348,7 +327,7 @@ int main(int argc, char* argv[]) {
                    << std::endl;
                 LOG(ss.str(), LogLevel::WARNING);
                 ss.str("");
-                exit(-1);
+                return -1;
             }
         }
 #endif // NGEN_WITH_MPI
@@ -408,7 +387,7 @@ int main(int argc, char* argv[]) {
 #endif // NGEN_WITH_MPI
 
         if (error)
-            exit(-1);
+            return -1;
 
         // split the subset strings into vectors
         boost::split(catchment_subset_ids, argv[2], [](char c) { return c == ','; });
@@ -804,9 +783,46 @@ int main(int argc, char* argv[]) {
         ss.str("");
     }
 
+    return 0;
+}
+
+/**
+ * This function acts as a wrapper around the main executing body of NGEN.
+ * Currently, the end of the `run_ngen` triggers the destruction of the catchment BMIs.
+ * A future improvement would be to turn `run_ngen` into `main` and have a cleaner ownership model of the BMIs
+ * so they can be finalized explicitly instead of when their `shared_ptr` reference count goes to zero.
+ */
+int main(int argc, char* argv[]) {
+     // This default value should lead to behavior matching the single-process case in the standalone or non-MPI case
+    int mpi_num_procs = 1;
+    // Define in the non-MPI case so that we don't need to conditionally compile `if (mpi_rank == 0)`
+    int mpi_rank = 0;
+
+#if NGEN_WITH_MPI
+    // initialize MPI if needed
+    MPI_Init(nullptr, nullptr);
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpi_num_procs);
+#endif
+
+#if NGEN_WITH_PYTHON
+    // Start Python interpreter via the manager singleton
+    // Need to bind to a variable so that the underlying reference count
+    // is incremented, this essentially becomes the global reference to keep
+    // the interpreter alive till the end of `main`
+    auto _interp = utils::ngenPy::InterpreterUtil::getInstance();
+#endif // NGEN_WITH_PYTHON
+
+    int result = run_ngen(argc, argv, mpi_num_procs, mpi_rank);
+
+#if NGEN_WITH_PYTHON
+    // explicitly destroy the interpreter before calling MPI_Finalize
+    _interp.reset();
+#endif
+
 #if NGEN_WITH_MPI
     MPI_Finalize();
 #endif
 
-    return 0;
+    return result;
 }


### PR DESCRIPTION
The ownership model of the BMIs created a problem with the python interpreter. Either the interpreter could be destroyed before the BMIs, but that would cause any python BMI to be unmanaged when trying to call its `finalize` method. Or, the interpreter could be destroyed at the end of `main` when `_interp` fell out of scope after the BMIs, but Forcing Engine's ESMF package was calling MPI functions on destruction, which conflicted with `main`'s call to `MPI_Finalize`.

As a quick solution, the previous `main` was renamed to `run_ngen` and wrapped in a new `main`. The new `main` exists to make sure the order of operations is: init MPI -> start python interpreter -> create all BMIs -> call all BMI's `Finalize` -> destroy interpreter -> finalize MPI

## Changes

- Previous `main` function renamed to `run_ngen`.
- MPI and global python interpreter lock moved to new `main` function.

## Testing

1. AWS Workspace run with and without MPI on CSV forcing and T-route
2. AWS Workspace run with LSTM catchment BMI and Forcing Engine for forcing

## Screenshots


## Notes

- In the long run, a better solution would be to change the ownership model of the BMIs so `Finalize` can be explicitly called and the memory released instead of letting the destructors handle that function when the BMIs' `shared_ptr` reference count goes to 0.

## Todos

-

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [x] Linux
