### PR TITLE
Remove separate pip install directive for `nextgen_forcings_ewts`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -195,8 +195,7 @@ RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache \
     pip3 install 'pandas' && \
     pip3 install 'pyyml' && \
     pip3 install torch torchvision --index-url https://download.pytorch.org/whl/cpu && \
-    pip install /ngen-app/ngen-forcing/ && \
-    pip install /ngen-app/ngen-forcing/nextgen_forcings_ewts/
+    pip install /ngen-app/ngen-forcing
 
 WORKDIR /ngen-app/
 


### PR DESCRIPTION
This updates ngen's Dockerfile to match the changes in: https://github.com/NGWPC/ngen-forcing/pull/60