### PR TITLE
Revert HY_PointHydroNexusRemote Changes from OWP

### DIFF
--- a/include/core/nexus/HY_PointHydroNexusRemote.hpp
+++ b/include/core/nexus/HY_PointHydroNexusRemote.hpp
@@ -72,7 +72,6 @@ class HY_PointHydroNexusRemote : public HY_PointHydroNexus
 		communication_type get_communicator_type() { return type; }
 
     private:
-        void post_receives();
         void process_communications();
 
         int world_rank;

--- a/src/core/nexus/HY_PointHydroNexusRemote.cpp
+++ b/src/core/nexus/HY_PointHydroNexusRemote.cpp
@@ -18,7 +18,7 @@ void MPI_Handle_Error(int status)
     }
     else
     {
-        MPI_Abort(MPI_COMM_WORLD, status);
+        MPI_Abort(MPI_COMM_WORLD,1);
     }
 }
 
@@ -92,9 +92,9 @@ HY_PointHydroNexusRemote::HY_PointHydroNexusRemote(std::string nexus_id, Catchme
 
 HY_PointHydroNexusRemote::~HY_PointHydroNexusRemote()
 {
-    const unsigned int timeout = 120000; // timeout threshold in milliseconds
-    unsigned int wait_time = 0;
-    // This destructor might be called after MPI_Finalize so do not attempt communication if
+    long wait_time = 0;
+
+    // This destructore might be called after MPI_Finalize so do not attempt communication if
     // this has occured
     int mpi_finalized;
     MPI_Finalized(&mpi_finalized);
@@ -105,46 +105,14 @@ HY_PointHydroNexusRemote::~HY_PointHydroNexusRemote()
 
         process_communications();
 
-        if( wait_time < timeout && wait_time > 0 ){ // don't sleep if first call clears comms!
-            std::this_thread::sleep_for(std::chrono::milliseconds(1));
-        }
-        else
-        {
-            std::cerr << "HY_PointHydroNexusRemote: "<< id 
-                      << " destructor timed out after " << timeout/1000 
-                      << " seconds waiting on pending MPI communications\n";
-            // The return is is probably best, logging the error.
-            // There is no good way to recover from this.
-            // Throwing an exception from destructors is generally not a good idea
-            // as it can lead to undefined behavior.
-            // and using std::exit forces the program to terminate immediately,
-            // even if this situation is recoverable/acceptable in some cases.
-            return;
-        }
-        wait_time += 1;
-        MPI_Finalized(&mpi_finalized);
-    }
-}
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
 
-void HY_PointHydroNexusRemote::post_receives()
-{
-    // Post receives if not already posted (for pure receiver nexuses)
-    if (stored_receives.empty())
-    {
-        for (int rank : upstream_ranks)
+        wait_time += 1;
+
+        if ( wait_time > 120000 )
         {
-            stored_receives.push_back({});
-            stored_receives.back().buffer = std::make_shared<time_step_and_flow_t>();
-            int tag = extract(id);
-            
-            MPI_Handle_Error(MPI_Irecv(
-                stored_receives.back().buffer.get(),
-                1,
-                time_step_and_flow_type,
-                rank,
-                tag,
-                MPI_COMM_WORLD,
-                &stored_receives.back().mpi_request));
+            // TODO log warning message that some comunications could not complete
+
         }
     }
 }
@@ -162,15 +130,31 @@ double HY_PointHydroNexusRemote::get_downstream_flow(std::string catchment_id, t
     }
     else if ( type == receiver || type == sender_receiver )
     {
-        post_receives();
-        // Wait for receives to complete
-        // This ensures all upstream flows are received before returning
-        // and that we have matched all sends with receives for a given time step.
-        // As long as the functions are called appropriately, e.g. one call to
-        // `add_upstream_flow` per upstream catchment per time step, followed
-        // by a call to `get_downstream_flow` for each downstream catchment per time step,
-        // this loop will terminate and ensures the synchronization of flows between
-        // ranks.
+    	for ( int rank : upstream_ranks )
+    	{
+       		int status;
+
+                stored_receives.resize(stored_receives.size() + 1);
+                stored_receives.back().buffer = std::make_shared<time_step_and_flow_t>();
+
+       		int tag = extract(id);
+
+       		//Receive downstream_flow from Upstream Remote Nexus to this Downstream Remote Nexus
+       		status = MPI_Irecv(
+                        stored_receives.back().buffer.get(),
+          		1,
+          		time_step_and_flow_type,
+          		rank,
+          		tag,
+          		MPI_COMM_WORLD,
+                        &stored_receives.back().mpi_request);
+
+       		MPI_Handle_Error(status); 
+       		
+                //std::cerr << "Creating receive with target_rank=" << rank << " on tag=" << tag << "\n";
+    	}
+    	
+        //std::cerr << "Waiting on receives\n";
         while ( stored_receives.size() > 0 )
     	{
     		process_communications();
@@ -183,28 +167,6 @@ double HY_PointHydroNexusRemote::get_downstream_flow(std::string catchment_id, t
 
 void HY_PointHydroNexusRemote::add_upstream_flow(double val, std::string catchment_id, time_step_t t)
 {
-	// Process any completed communications to free resources
-    // If no communications are pending, this call will do nothing.
-	process_communications();
-    // NOTE: It is possible for a partition to get "too far" ahead since the sends are now
-    // truely asynchronous.  For pure receivers and sender_receivers, this isn't a problem
-    // because the get_downstream_flow function will block until all receives are processed.
-    // However, for pure senders, this could be a problem.
-    // We can use this spinlock here to limit how far ahead a partition can get.
-    // in this case, approximately 100 time steps per downstream catchment...
-    while( stored_sends.size() > downstream_ranks.size()*100 )
-    {
-        process_communications();
-        std::this_thread::sleep_for(std::chrono::milliseconds(1));
-    }
-	
-	// Post receives before sending to prevent deadlock
-	// When stored_receives is empty, we need to post for incoming messages
-	if ((type == receiver || type == sender_receiver) && stored_receives.empty())
-	{
-		post_receives();
-	}
-	
 	// first add flow to local copy
 	HY_PointHydroNexus::add_upstream_flow(val, catchment_id, t);
 	
@@ -243,25 +205,23 @@ void HY_PointHydroNexusRemote::add_upstream_flow(double val, std::string catchme
 		    int tag = extract(id);
 
 		    //Send downstream_flow from this Upstream Remote Nexus to the Downstream Remote Nexus
-		    MPI_Handle_Error(
-                MPI_Isend(
+		    MPI_Isend(
 		        stored_sends.back().buffer.get(),
 		        1,
 		        time_step_and_flow_type,
 		        *downstream_ranks.begin(), //TODO currently only support a SINGLE downstream message pairing
 		        tag,
 		        MPI_COMM_WORLD,
-		        &stored_sends.back().mpi_request)
-            );
+		        &stored_sends.back().mpi_request);
 		        
-		    //std::cerr << "Creating send with target_rank=" << *downstream_ranks.begin() << " on tag=" << tag << "\n";
+		    //std::cerr << "Creating send with target_rank=" << *downstream_ranks.begin() << " on tag=" << tag << "\n";	
+		        
 		    
-		    // Send is async, the next call to add_upstream_flow will test and ensure the send has completed
-            // and free the memory associated with the send.
-            // This prevents a potential deadlock situation where a send isn't able to complete
-            // because the remote receiver is also trying to send and the underlying mpi buffers/protocol
-            // are forced into a rendevous protocol.  So we ensure that we always post receives before sends.
-            // and that we always test for completed sends before freeing the memory associated with the send.
+		    while ( stored_sends.size() > 0 )
+		    {
+		    	process_communications();  
+		    	std::this_thread::sleep_for(std::chrono::milliseconds(1));
+		    }		
 		}
 	}
 }


### PR DESCRIPTION
The changes to the HY_PointHydroNexusRemote class from the merged updates from OWP caused the program to sometimes hang with higher numbers of partitions. This was probably the result of the new `post_receives` function allowing a desync between the number of `MPI_ISend` and `MPI_IRecv` calls between processes, leading to MPI ranks waiting forever for messages to come in.

## Changes

- Reverted the `HY_PointHydroNexusRemote` to its state before the OWP merge.

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [x] Linux
