### PR TITLE
Update setup-trivy action to v0.2.6

### DIFF
--- a/.github/workflows/ngwpc-cicd.yml
+++ b/.github/workflows/ngwpc-cicd.yml
@@ -286,7 +286,7 @@ jobs:
       - build
     steps:
       - name: Install Trivy
-        uses: aquasecurity/setup-trivy@v0.2.5
+        uses: aquasecurity/setup-trivy@v0.2.6
         with:
           cache: true
           version: v0.69.3


### PR DESCRIPTION
## Summary
- Updates `aquasecurity/setup-trivy` from `v0.2.5` to `v0.2.6` to fix a workflow failure
- `v0.2.5` was causing the container-scanning job to fail; `v0.2.6` resolves the issue