### PR TITLE
Checkpointing State Saving and Loading (NGWPC-10159)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,7 +211,7 @@ add_compile_definitions(NGEN_SHARED_LIB_EXTENSION)
 set(Boost_USE_STATIC_LIBS OFF)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.86.0 REQUIRED COMPONENTS system filesystem)
+find_package(Boost 1.86.0 REQUIRED COMPONENTS system filesystem serialization)
 
 # -----------------------------------------------------------------------------
 if(NGEN_WITH_SQLITE)

--- a/include/core/Layer.hpp
+++ b/include/core/Layer.hpp
@@ -142,6 +142,7 @@ namespace ngen
         friend class boost::serialization::access;
         template <class Archive>
         void serialize(Archive& ar, const unsigned int version) {
+            ar & this->output_time_index;
             ar & this->simulation_time;
         }
 

--- a/include/core/Layer.hpp
+++ b/include/core/Layer.hpp
@@ -8,16 +8,15 @@
 #include "Simulation_Time.hpp"
 #include "State_Exception.hpp"
 #include "geojson/FeatureBuilder.hpp"
+#include "state_save_restore/State_Save_Restore.hpp"
 #include <boost/core/span.hpp>
+#include <boost/serialization/serialization.hpp>
 
 namespace hy_features
 {
     class HY_Features;
     class HY_Features_MPI;
 }
-
-class State_Snapshot_Saver;
-class State_Snapshot_Loader;
 
 namespace ngen
 {
@@ -113,9 +112,19 @@ namespace ngen
                                    std::unordered_map<std::string, int> &nexus_indexes,
                                    int current_step);
 
-        virtual void save_state_snapshot(std::shared_ptr<State_Snapshot_Saver> snapshot_saver);
-        virtual void load_state_snapshot(std::shared_ptr<State_Snapshot_Loader> snapshot_loader);
+        /**
+         * Save the current state including metatdata related to current layer times
+         */
+        virtual void save_checkpoint(std::shared_ptr<State_Snapshot_Saver> snapshot_saver);
+        /**
+         * Save the current state excluding metatdata related to current layer times
+         */
+        virtual void save_end_of_run(std::shared_ptr<State_Snapshot_Saver> snapshot_saver);
+        virtual void load_checkpoint(std::shared_ptr<State_Snapshot_Loader> snapshot_loader);
         virtual void load_hot_start(std::shared_ptr<State_Snapshot_Loader> snapshot_loader);
+
+        std::string unit_name() const;
+        virtual std::vector<std::string> required_checkpoint_units() const;
 
         protected:
 
@@ -127,7 +136,14 @@ namespace ngen
         feature_type& features;
         //TODO is this really required at the top level? or can this be moved to SurfaceLayer?
         const geojson::GeoJSON catchment_data;
-        long output_time_index;       
+        long output_time_index;   
+
+        // Serialization template will be defined and instantiated in the .cpp file
+        friend class boost::serialization::access;
+        template <class Archive>
+        void serialize(Archive& ar, const unsigned int version) {
+            ar & this->simulation_time;
+        }
 
     };
 }

--- a/include/core/NgenSimulation.hpp
+++ b/include/core/NgenSimulation.hpp
@@ -24,6 +24,8 @@ class State_Snapshot_Loader;
 #include <unordered_map>
 #include <string>
 
+#include <boost/serialization/serialization.hpp>
+
 // Contains all of the dynamic state and logic to run a NextGen hydrologic simulation
 class NgenSimulation
 {
@@ -55,6 +57,9 @@ public:
      */
     void run_catchments();
 
+    // Alternative method of running catchments that includes saving checkpoints at a desired frequency.
+    void run_catchments(std::shared_ptr<State_Saver> checkpoint_saver, int frequency);
+
     // Tear down of any items stored on the NgenSimulation object that could throw errors and, thus, should be kept separate from the deconstructor.
     void finalize();
 
@@ -69,8 +74,6 @@ public:
     size_t get_num_output_times() const;
     std::string get_timestamp_for_step(int step) const;
 
-    void save_state_snapshot(std::shared_ptr<State_Snapshot_Saver> snapshot_saver);
-    void load_state_snapshot(std::shared_ptr<State_Snapshot_Loader> snapshot_loader);
     /**
      * Saves a snapshot state that's intended to be run at the end of a simulation.
      * 
@@ -79,6 +82,10 @@ public:
     void save_end_of_run(std::shared_ptr<State_Snapshot_Saver> snapshot_saver);
     // Load a snapshot of the end of a previous run. This will create a T-Route python adapter if the loader finds a unit for it and the config path is not empty.
     void load_hot_start(std::shared_ptr<State_Snapshot_Loader> snapshot_loader, const std::string &t_route_config_file_with_path);
+    // Load a snapshot of a checkpoint from a previous run. This will create a T-Route python adapter if the loader finds a unit for it (most likely to happen if the checkpoint is derived from )
+    void load_checkpoint(std::shared_ptr<State_Snapshot_Loader> checkpoint_loader);
+
+    std::vector<std::string> required_checkpoint_units() const;
 
 private:
     void advance_models_one_output_step();
@@ -123,8 +130,9 @@ private:
     int mpi_num_procs_;
 
     // Serialization template will be defined and instantiated in the .cpp file
+    friend class boost::serialization::access;
     template <class Archive>
-    void serialize(Archive& ar);
+    void serialize(Archive& ar, const unsigned int version);
 };
 
 #endif

--- a/include/core/NgenSimulation.hpp
+++ b/include/core/NgenSimulation.hpp
@@ -84,6 +84,8 @@ public:
     void load_hot_start(std::shared_ptr<State_Snapshot_Loader> snapshot_loader, const std::string &t_route_config_file_with_path);
     // Load a snapshot of a checkpoint from a previous run. This will create a T-Route python adapter if the loader finds a unit for it (most likely to happen if the checkpoint is derived from )
     void load_checkpoint(std::shared_ptr<State_Snapshot_Loader> checkpoint_loader);
+    // Save a snapshot that preserves data related to the current time and could be loaded to jump a simulation into the middle of a run.
+    void save_checkpoint(std::shared_ptr<State_Snapshot_Saver> snapshot_saver);
 
     std::vector<std::string> required_checkpoint_units() const;
 

--- a/include/core/NgenSimulation.hpp
+++ b/include/core/NgenSimulation.hpp
@@ -109,6 +109,8 @@ private:
         const NgenSimulation::hy_features_t &features
     );
 
+    inline void sync_mpi_ranks() const;
+
     int simulation_step_;
 
     std::shared_ptr<Simulation_Time> sim_time_;

--- a/include/core/NgenSimulation.hpp
+++ b/include/core/NgenSimulation.hpp
@@ -87,7 +87,12 @@ public:
     // Save a snapshot that preserves data related to the current time and could be loaded to jump a simulation into the middle of a run.
     void save_checkpoint(std::shared_ptr<State_Snapshot_Saver> snapshot_saver);
 
-    std::vector<std::string> required_checkpoint_units() const;
+    /**
+     * Get a vector of all the required units the NgenSimulation would need to load a checkpoint state.
+     * 
+     * @param merge_all_ranks Whether to also get the units from other MPI ranks. This should only be `true` when calling blocking MPI processes is safe for the program.
+     */
+    std::vector<std::string> required_checkpoint_units(bool merge_all_ranks) const;
 
 private:
     void advance_models_one_output_step();

--- a/include/forcing/ForcingsEngineDataProvider.hpp
+++ b/include/forcing/ForcingsEngineDataProvider.hpp
@@ -89,6 +89,17 @@ struct ForcingsEngineStorage {
         data_.clear();
     }
 
+    /** Advance all forcing engine instances to update to the requested time.
+     * @param time The amount of seconds from the beginning of the simulation the forcing models will be advanaced to.
+     * This should use `0.0` as the start time and allow the backing models to update their own times accordingly.
+     */
+    void advance_to(double time) {
+        for (auto &provider : data_) {
+            double bmi_start = provider.second->GetStartTime();
+            provider.second->UpdateUntil(time + bmi_start);
+        }
+    }
+
   private:
     //! Instance map of underlying BMI models.
     std::unordered_map<key_type, value_type> data_;

--- a/include/realizations/catchment/Bmi_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Formulation.hpp
@@ -95,6 +95,11 @@ namespace realization {
          */
         virtual void load_hot_start(std::shared_ptr<State_Snapshot_Loader> loader) = 0;
 
+        // Unit name used for identifying a save state ID
+        inline std::string save_state_unit_name() const {
+            return this->get_id();
+        }
+
         /**
          * Convert a time value from the model to an epoch time in seconds.
          *

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -55,6 +55,18 @@ namespace realization {
 
         void load_hot_start(std::shared_ptr<State_Snapshot_Loader> loader) override;
 
+        /** Create a vector representing Bmi_Module_Formulation metadata that should be included in state data on top of the backing BMI's state.
+         * 
+         * WARNING: Other parts of NGEN assume that the metadata should be copied and reset after loading a hot start.
+         */
+        std::vector<char> create_state_metadata() const;
+
+        /** Loads state metadata on the Bmi_Module_Formulation that is needed beyond the state known by the BMI.
+         * @param data vector storing byte data representing the metadata. The data will be read from the beginning of the vector.
+         * @return The number of bytes read from the data vector.
+         */
+        size_t load_state_metadata(const std::vector<char> &data);
+
         /**
          * Get the collection of forcing output property names this instance can provide.
          * For this type, this is the collection of BMI output variables, plus any aliases included in the formulation

--- a/include/simulation_time/Simulation_Time.hpp
+++ b/include/simulation_time/Simulation_Time.hpp
@@ -107,6 +107,15 @@ class Simulation_Time
     }   
 
     /**
+     * @brief Accessor to the the current simulation time
+     * @return start_date_time_epoch
+    */
+    time_t get_start_time()
+    {
+        return start_date_time_epoch;
+    }
+
+    /**
      * @brief Accessor to the current timestamp string
      * @return current_timestamp
      */ 

--- a/include/simulation_time/Simulation_Time.hpp
+++ b/include/simulation_time/Simulation_Time.hpp
@@ -8,6 +8,8 @@
 #include <string>
 #include <stdexcept>
 
+#include <boost/serialization/serialization.hpp>
+
 /**
  * @brief simulation_time_params providing configuration information for simulation time period.
  */
@@ -167,6 +169,12 @@ class Simulation_Time
 
 
     private:
+
+    friend class boost::serialization::access;
+    template <class Archive>
+    void serialize(Archive& ar, const unsigned int version) {
+        ar & this->current_date_time_epoch;
+    }
 
     int total_output_times;
     int simulation_total_time_seconds;

--- a/include/state_save_restore/File_Per_Unit.hpp
+++ b/include/state_save_restore/File_Per_Unit.hpp
@@ -13,6 +13,8 @@ public:
 
     std::shared_ptr<State_Snapshot_Saver> initialize_checkpoint_snapshot(int step, State_Durability durability) override;
 
+    void clear_cache(int mpi_rank) override;
+
     void finalize() override;
 
 private:
@@ -30,7 +32,7 @@ public:
 
     std::shared_ptr<State_Snapshot_Loader> initialize_snapshot() override;
 
-    std::shared_ptr<State_Snapshot_Loader> initialize_checkpoint_snapshot(const std::vector<std::string> &required_units, int *const checkpoint_step) override;
+    std::shared_ptr<State_Snapshot_Loader> initialize_checkpoint_snapshot(const std::vector<std::string> &required_units) override;
 private:
     std::string dir_path_;
 };

--- a/include/state_save_restore/File_Per_Unit.hpp
+++ b/include/state_save_restore/File_Per_Unit.hpp
@@ -11,7 +11,7 @@ public:
 
     std::shared_ptr<State_Snapshot_Saver> initialize_snapshot(State_Durability durability) override;
 
-    std::shared_ptr<State_Snapshot_Saver> initialize_checkpoint_snapshot(snapshot_time_t epoch, State_Durability durability) override;
+    std::shared_ptr<State_Snapshot_Saver> initialize_checkpoint_snapshot(int step, State_Durability durability) override;
 
     void finalize() override;
 
@@ -30,7 +30,7 @@ public:
 
     std::shared_ptr<State_Snapshot_Loader> initialize_snapshot() override;
 
-    std::shared_ptr<State_Snapshot_Loader> initialize_checkpoint_snapshot(State_Saver::snapshot_time_t epoch) override;
+    std::shared_ptr<State_Snapshot_Loader> initialize_checkpoint_snapshot(const std::vector<std::string> &required_units, int *const checkpoint_step) override;
 private:
     std::string dir_path_;
 };

--- a/include/state_save_restore/File_Per_Unit.hpp
+++ b/include/state_save_restore/File_Per_Unit.hpp
@@ -13,7 +13,7 @@ public:
 
     std::shared_ptr<State_Snapshot_Saver> initialize_checkpoint_snapshot(int step, State_Durability durability) override;
 
-    void clear_cache(int mpi_rank) override;
+    void clear_prior(int mpi_rank) override;
 
     void finalize() override;
 

--- a/include/state_save_restore/State_Save_Restore.hpp
+++ b/include/state_save_restore/State_Save_Restore.hpp
@@ -5,6 +5,9 @@
 
 #include <boost/property_tree/ptree_fwd.hpp>
 #include <boost/core/span.hpp>
+#include <boost/serialization/serialization.hpp>
+#include <boost/archive/binary_oarchive.hpp>
+#include <boost/archive/binary_iarchive.hpp>
 
 #include <chrono>
 #include <cstdint>
@@ -12,6 +15,7 @@
 #include <string>
 #include <vector>
 
+#include "vecbuf.hpp"
 #include "State_Save_Utils.hpp"
 
 class State_Saver;
@@ -49,15 +53,22 @@ public:
      */
     std::unique_ptr<State_Loader> hot_start() const;
 
+    std::unique_ptr<State_Loader> checkpoint_loader() const;
+
+    bool has_checkpoint_saver() const;
+
+    std::shared_ptr<State_Saver> checkpoint_saver(int *const frequency) const;
+
     struct instance
     {
-        instance(std::string const& direction, std::string const& label, std::string const& path, std::string const& mechanism, std::string const& timing);
+        instance(std::string const& direction, std::string const& label, std::string const& path, std::string const& mechanism, std::string const& timing, boost::optional<int> frequency);
 
         State_Save_Direction direction_;
         State_Save_Mechanism mechanism_;
         State_Save_When timing_;
         std::string label_;
         std::string path_;
+        int frequency_;
 
         std::string mechanism_string() const;
     };
@@ -69,8 +80,6 @@ private:
 class State_Saver
 {
 public:
-    using snapshot_time_t = std::chrono::time_point<std::chrono::system_clock, std::chrono::seconds>;
-
     // Flag type to indicate whether state saving needs to ensure
     // stability of saved data wherever it is stored before returning
     // success
@@ -78,8 +87,6 @@ public:
 
     State_Saver() = default;
     virtual ~State_Saver() = default;
-
-    static snapshot_time_t snapshot_time_now();
 
     /**
      * Return an object suitable for saving a simulation state as of a
@@ -91,7 +98,7 @@ public:
      */
     virtual std::shared_ptr<State_Snapshot_Saver> initialize_snapshot(State_Durability durability) = 0;
 
-    virtual std::shared_ptr<State_Snapshot_Saver> initialize_checkpoint_snapshot(snapshot_time_t epoch, State_Durability durability) = 0;
+    virtual std::shared_ptr<State_Snapshot_Saver> initialize_checkpoint_snapshot(int step, State_Durability durability) = 0;
 
     /**
      * Execute any logic necessary to cleanly finish usage, and
@@ -113,6 +120,18 @@ public:
      * Capture the data from a single unit of the simulation
      */
     virtual void save_unit(std::string const& unit_name, boost::span<char const> data) = 0;
+
+    /**
+     * Capture the data from a single unit that can be serialized with a Boost binary_oarchive
+     */
+    template <class T>
+    void archive_unit(const std::string &unit_name, T *item) {
+        vecbuf<char> buffer;
+        boost::archive::binary_oarchive archive(buffer);
+        archive << (*item);
+        boost::span<char> data(buffer.data(), buffer.size());
+        this->save_unit(unit_name, data);
+    }
 
     /**
      * Execute logic to complete the saving process
@@ -142,7 +161,13 @@ public:
      */
     virtual std::shared_ptr<State_Snapshot_Loader> initialize_snapshot() = 0;
 
-    virtual std::shared_ptr<State_Snapshot_Loader> initialize_checkpoint_snapshot(State_Saver::snapshot_time_t epoch) = 0;
+    /**
+     * Return an object suitable for loading a checkpoint simulation state with all the required units.
+     * 
+     * @param required_units Vector of all units that are required for a simulation state to be considered complete.
+     * @param checkpoint_step Pointer that will be set to the step number of the valid state.
+     */
+    virtual std::shared_ptr<State_Snapshot_Loader> initialize_checkpoint_snapshot(const std::vector<std::string> &required_units, int *const checkpoint_step) = 0;
 
     /**
      * Execute any logic necessary to cleanly finish usage, and
@@ -168,6 +193,18 @@ public:
      * Load data from whatever source, and pass it to @param unit_loader->load()
      */
     virtual void load_unit(const std::string &unit_name, std::vector<char> &data) = 0;
+
+    /**
+     * Load unit data and immediately dearchive it with a Boost binary_iarchive
+     */
+    template<class T>
+    void dearchive_unit(const std::string &unit_name, T *item) {
+        std::vector<char> buffer;
+        this->load_unit(unit_name, buffer);
+        membuf data(buffer.data(), buffer.size());
+        boost::archive::binary_iarchive archive(data);
+        archive >> (*item);
+    }
 
     /**
      * Execute logic to complete the saving process

--- a/include/state_save_restore/State_Save_Restore.hpp
+++ b/include/state_save_restore/State_Save_Restore.hpp
@@ -100,11 +100,11 @@ public:
 
     virtual std::shared_ptr<State_Snapshot_Saver> initialize_checkpoint_snapshot(int step, State_Durability durability) = 0;
 
-    /** Clear unneeded data that may be generated over the lifetime of a State_Saver's lifetime
+    /** Clear data related to states prior to the last save state associated with this State_Saver
      * 
      * @param mpi_rank The process' MPI rank that may be used for determining responsibility of cleanup.
      */
-    virtual void clear_cache(int mpi_rank) = 0;
+    virtual void clear_prior(int mpi_rank) = 0;
 
     /**
      * Execute any logic necessary to cleanly finish usage, and

--- a/include/state_save_restore/State_Save_Restore.hpp
+++ b/include/state_save_restore/State_Save_Restore.hpp
@@ -100,6 +100,12 @@ public:
 
     virtual std::shared_ptr<State_Snapshot_Saver> initialize_checkpoint_snapshot(int step, State_Durability durability) = 0;
 
+    /** Clear unneeded data that may be generated over the lifetime of a State_Saver's lifetime
+     * 
+     * @param mpi_rank The process' MPI rank that may be used for determining responsibility of cleanup.
+     */
+    virtual void clear_cache(int mpi_rank) = 0;
+
     /**
      * Execute any logic necessary to cleanly finish usage, and
      * potentially report errors, before destructors would
@@ -167,7 +173,7 @@ public:
      * @param required_units Vector of all units that are required for a simulation state to be considered complete.
      * @param checkpoint_step Pointer that will be set to the step number of the valid state.
      */
-    virtual std::shared_ptr<State_Snapshot_Loader> initialize_checkpoint_snapshot(const std::vector<std::string> &required_units, int *const checkpoint_step) = 0;
+    virtual std::shared_ptr<State_Snapshot_Loader> initialize_checkpoint_snapshot(const std::vector<std::string> &required_units) = 0;
 
     /**
      * Execute any logic necessary to cleanly finish usage, and

--- a/include/state_save_restore/State_Save_Utils.hpp
+++ b/include/state_save_restore/State_Save_Utils.hpp
@@ -23,8 +23,8 @@ enum class State_Save_Mechanism {
 enum class State_Save_When {
     None = 0,
     EndOfRun,
-    FirstOfMonth,
-    StartOfRun
+    StartOfRun,
+    Checkpoint
 };
 
 #endif

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -707,7 +707,7 @@ int run_ngen(int argc, char* argv[], int mpi_num_procs, int mpi_rank) {
         auto checkpoint_loader = state_saving_config.checkpoint_loader();
         if (checkpoint_loader) {
             LOG(LogLevel::INFO, "Loading checkpoint data from prior snapshot.");
-            const std::vector<std::string> required_units = simulation->required_checkpoint_units();
+            const std::vector<std::string> required_units = simulation->required_checkpoint_units(true);
             std::shared_ptr<State_Snapshot_Loader> snapshot_loader
                 = checkpoint_loader->initialize_checkpoint_snapshot(required_units);
             simulation->load_checkpoint(snapshot_loader);

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -703,7 +703,25 @@ int run_ngen(int argc, char* argv[], int mpi_num_procs, int mpi_rank) {
         }
     }
 
-    simulation->run_catchments();
+    int checkpoint_step = 0;
+    { // optionally load a checkpoint if configured
+        auto checkpoint_loader = state_saving_config.checkpoint_loader();
+        if (checkpoint_loader) {
+            LOG(LogLevel::INFO, "Loading checkpoint data from prior snapshot.");
+            const std::vector<std::string> required_units = simulation->required_checkpoint_units();
+            std::shared_ptr<State_Snapshot_Loader> snapshot_loader
+                = checkpoint_loader->initialize_checkpoint_snapshot(required_units, &checkpoint_step);
+            simulation->load_checkpoint(snapshot_loader);
+        }
+    }
+
+    if (state_saving_config.has_checkpoint_saver()) {
+        int checkpoint_frequency;
+        std::shared_ptr<State_Saver> checkpoint_saver = state_saving_config.checkpoint_saver(&checkpoint_frequency);
+        simulation->run_catchments(checkpoint_saver, checkpoint_frequency);
+    } else {
+        simulation->run_catchments();
+    }
 
 #if NGEN_WITH_MPI
     MPI_Barrier(MPI_COMM_WORLD);

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -703,14 +703,13 @@ int run_ngen(int argc, char* argv[], int mpi_num_procs, int mpi_rank) {
         }
     }
 
-    int checkpoint_step = 0;
     { // optionally load a checkpoint if configured
         auto checkpoint_loader = state_saving_config.checkpoint_loader();
         if (checkpoint_loader) {
             LOG(LogLevel::INFO, "Loading checkpoint data from prior snapshot.");
             const std::vector<std::string> required_units = simulation->required_checkpoint_units();
             std::shared_ptr<State_Snapshot_Loader> snapshot_loader
-                = checkpoint_loader->initialize_checkpoint_snapshot(required_units, &checkpoint_step);
+                = checkpoint_loader->initialize_checkpoint_snapshot(required_units);
             simulation->load_checkpoint(snapshot_loader);
         }
     }

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -9,6 +9,7 @@ target_link_libraries(core PUBLIC
 
 target_link_libraries(core PRIVATE
                            NGen::parallel
+                           NGen::state_save_restore
                            )
 
 if(USE_EWTS)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -10,6 +10,7 @@ target_link_libraries(core PUBLIC
 target_link_libraries(core PRIVATE
                            NGen::parallel
                            NGen::state_save_restore
+                           Boost::serialization        # needed for the NgenSimulation test to compile
                            )
 
 if(USE_EWTS)

--- a/src/core/Layer.cpp
+++ b/src/core/Layer.cpp
@@ -117,10 +117,30 @@ void ngen::Layer::update_models(boost::span<double> catchment_outflows,
     }       
 }
 
-void ngen::Layer::save_state_snapshot(std::shared_ptr<State_Snapshot_Saver> snapshot_saver)
-{
-    // XXX Handle any of this class's own state as a meta-data unit
+std::string ngen::Layer::unit_name() const {
+    return "lyr-" + std::to_string(this->get_id());
+}
 
+std::vector<std::string> ngen::Layer::required_checkpoint_units() const {
+    std::vector<std::string> units;
+    units.push_back(this->unit_name());
+    for (auto const& id : processing_units) {
+        auto r = features.catchment_at(id);
+        auto r_c = std::dynamic_pointer_cast<realization::Bmi_Formulation>(r);
+        units.push_back(r_c->save_state_unit_name());
+    }
+    return units;
+}
+
+void ngen::Layer::save_checkpoint(std::shared_ptr<State_Snapshot_Saver> snapshot_saver)
+{
+    snapshot_saver->archive_unit(this->unit_name(), this);
+    // assume save_end_of_run ist just the BMI save
+    this->save_end_of_run(snapshot_saver);
+}
+
+void ngen::Layer::save_end_of_run(std::shared_ptr<State_Snapshot_Saver> snapshot_saver)
+{
     for (auto const& id : processing_units) {
         auto r = features.catchment_at(id);
         auto r_c = std::dynamic_pointer_cast<realization::Bmi_Formulation>(r);
@@ -128,10 +148,9 @@ void ngen::Layer::save_state_snapshot(std::shared_ptr<State_Snapshot_Saver> snap
     }
 }
 
-void ngen::Layer::load_state_snapshot(std::shared_ptr<State_Snapshot_Loader> snapshot_loader)
+void ngen::Layer::load_checkpoint(std::shared_ptr<State_Snapshot_Loader> snapshot_loader)
 {
-    // XXX Handle any of this class's own state as a meta-data unit
-
+    snapshot_loader->dearchive_unit(this->unit_name(), this);
     for (auto const& id : processing_units) {
         auto r = features.catchment_at(id);
         auto r_c = std::dynamic_pointer_cast<realization::Bmi_Formulation>(r);
@@ -141,8 +160,7 @@ void ngen::Layer::load_state_snapshot(std::shared_ptr<State_Snapshot_Loader> sna
 
 void ngen::Layer::load_hot_start(std::shared_ptr<State_Snapshot_Loader> snapshot_loader)
 {
-    // XXX Handle any of this class's own state as a meta-data unit
-
+    // no Layer metadata needs to load for this
     for (auto const& id : processing_units) {
         auto r = features.catchment_at(id);
         auto r_c = std::dynamic_pointer_cast<realization::Bmi_Formulation>(r);

--- a/src/core/NgenSimulation.cpp
+++ b/src/core/NgenSimulation.cpp
@@ -80,22 +80,26 @@ void NgenSimulation::run_catchments(std::shared_ptr<State_Saver> checkpoint_save
         }
 
         if (simulation_step_ != 0 && simulation_step_ % frequency == 0) {
-#if NGEN_WITH_MPI
             // Remote data is currently handled by MPI, so saving a checkpoint without retreiving all messages could lose data.
             // An example would be checkpointing every 100 steps with two ranks. Rank 1 is faster than Rank 0, so it saves
             //   step 200 whilst Rank 1 has only saved step 100. If checkpoints are loaded, all data in MPI messages from Rank 1
             //   for steps 100-199 will be lost, and the program will likely hang as Rank 0 waits for those messages from Rank 1.
             // For now, set up a barrier to make sure all ranks can catch up before checkpointing.
             // A possible later improvement would be the ability to store and recreate the MPI messages when saving/loading checkpoints.
-            if (this->mpi_num_procs_ > 1) {
-                MPI_Barrier(MPI_COMM_WORLD);
-            }
-#endif // NGEN_WITH_MPI
+            this->sync_mpi_ranks();
             checkpoint_saver->clear_cache(this->mpi_rank_);
+            this->sync_mpi_ranks();
             auto step_saver = checkpoint_saver->initialize_checkpoint_snapshot(simulation_step_, State_Saver::State_Durability::strict);
             this->save_checkpoint(step_saver);
         }
     }
+}
+
+void NgenSimulation::sync_mpi_ranks() const {
+#if NGEN_WITH_MPI
+    if (this->mpi_num_procs_ > 1)
+        MPI_Barrier(MPI_COMM_WORLD);
+#endif // NGEN_WITH_MPI
 }
 
 void NgenSimulation::finalize() {

--- a/src/core/NgenSimulation.cpp
+++ b/src/core/NgenSimulation.cpp
@@ -8,8 +8,16 @@
 #include "HY_Features.hpp"
 #endif
 
+#include "state_save_restore/vecbuf.hpp"
 #include "state_save_restore/State_Save_Utils.hpp"
 #include "state_save_restore/State_Save_Restore.hpp"
+
+#include <boost/serialization/serialization.hpp>
+#include <boost/archive/binary_oarchive.hpp>
+#include <boost/archive/binary_iarchive.hpp>
+#include <boost/serialization/vector.hpp>
+#include <boost/serialization/unordered_map.hpp>
+
 #include "parallel_utils.h"
 
 namespace {
@@ -53,6 +61,27 @@ void NgenSimulation::run_catchments()
 
         if (simulation_step_ + 1 < num_times) {
             sim_time_->advance_timestep();
+        }
+    }
+}
+
+void NgenSimulation::run_catchments(std::shared_ptr<State_Saver> checkpoint_saver, int frequency) {
+    int num_times = get_num_output_times();
+
+    for (; simulation_step_ < num_times; simulation_step_++) {
+        // Make room for this output step's results
+        catchment_outflows_.resize(catchment_outflows_.size() + catchment_indexes_.size(), 0.0);
+        nexus_downstream_flows_.resize(nexus_downstream_flows_.size() + nexus_indexes_.size(), 0.0);
+        
+        advance_models_one_output_step();
+
+        if (simulation_step_ + 1 < num_times) {
+            sim_time_->advance_timestep();
+        }
+
+        if (simulation_step_ != 0 && simulation_step_ % frequency == 0) {
+            auto step_saver = checkpoint_saver->initialize_checkpoint_snapshot(simulation_step_, State_Saver::State_Durability::strict);
+            this->save_checkpoint(step_saver);
         }
     }
 }
@@ -120,20 +149,10 @@ void NgenSimulation::advance_models_one_output_step()
 
 }
 
-void NgenSimulation::save_state_snapshot(std::shared_ptr<State_Snapshot_Saver> snapshot_saver)
-{
-    // TODO: save the current nexus data
-    auto unit_name = this->unit_name();
-    // XXX Handle self, then recursively pass responsibility to Layers
-    for (auto& layer : layers_) {
-        layer->save_state_snapshot(snapshot_saver);
-    }
-}
-
 void NgenSimulation::save_end_of_run(std::shared_ptr<State_Snapshot_Saver> snapshot_saver)
 {
     for (auto& layer : layers_) {
-        layer->save_state_snapshot(snapshot_saver);
+        layer->save_end_of_run(snapshot_saver);
     }
 #if NGEN_WITH_ROUTING
     if (this->mpi_rank_ == 0 && this->py_troute_) {
@@ -148,11 +167,21 @@ void NgenSimulation::save_end_of_run(std::shared_ptr<State_Snapshot_Saver> snaps
 #endif // NGEN_WITH_ROUTING
 }
 
-void NgenSimulation::load_state_snapshot(std::shared_ptr<State_Snapshot_Loader> snapshot_loader) {
-    // TODO: load the state data related to nexus outflows
-    auto unit_name = this->unit_name();
+void NgenSimulation::save_checkpoint(std::shared_ptr<State_Snapshot_Saver> snapshot_saver) {
+#if NGEN_WITH_MPI
+    // Remote data is currently handled by MPI, so saving a checkpoint without retreiving all messages could lose data.
+    // An example would be checkpointing every 100 steps with two ranks. Rank 1 is faster than Rank 0, so it saves
+    //   step 200 whilst Rank 1 has only saved step 100. If checkpoints are loaded, all data in MPI messages from Rank 1
+    //   for steps 100-199 will be lost, and the program will likely hang as Rank 0 waits for those messages from Rank 1.
+    // For now, set up a barrier is set up to make sure all ranks can catch up before checkpointing.
+    // A possible later improvement would be the ability to store and recreate the MPI messages when saving/loading checkpoints.
+    if (this->mpi_num_procs_ > 1) {
+        MPI_Barrier(MPI_COMM_WORLD);
+    }
+#endif
+    snapshot_saver->archive_unit(this->unit_name(), this);
     for (auto& layer : layers_) {
-        layer->load_state_snapshot(snapshot_loader);
+        layer->save_checkpoint(snapshot_saver);
     }
 }
 
@@ -183,6 +212,24 @@ void NgenSimulation::load_hot_start(std::shared_ptr<State_Snapshot_Loader> snaps
         }
     }
 #endif // NGEN_WITH_ROUTING
+}
+
+void NgenSimulation::load_checkpoint(std::shared_ptr<State_Snapshot_Loader> checkpoint_loader) {
+    checkpoint_loader->dearchive_unit(this->unit_name(), this);
+    for (auto& layer : layers_) {
+        layer->load_checkpoint(checkpoint_loader);
+    }
+}
+
+std::vector<std::string> NgenSimulation::required_checkpoint_units() const {
+    std::vector<std::string> units;
+    units.push_back(this->unit_name());
+    for (const auto &layer : this->layers_) {
+        const auto layer_units = layer->required_checkpoint_units();
+        for (const auto &unit : layer_units)
+            units.push_back(unit);
+    }
+    return units;
 }
 
 
@@ -332,7 +379,7 @@ void NgenSimulation::run_routing(NgenSimulation::hy_features_t &features, std::s
         // case a future implementation needs these two values from the ngen framework.
         int delta_time = sim_time_->get_output_interval_seconds();
 
-        // model for routing
+        // if the t-route model was not created from a hot start load, make it now
         if (this->py_troute_ == NULL) {
             this->make_troute(t_route_config_file_with_path);
         }
@@ -369,16 +416,14 @@ std::string NgenSimulation::get_timestamp_for_step(int step) const
 }
 
 template <class Archive>
-void NgenSimulation::serialize(Archive& ar) {
+void NgenSimulation::serialize(Archive& ar, const unsigned int version) {
     /* Handle `catchment_formulation_manager` specially in the
      * overall checkpoint/restart logic, so that we can subset
      * individual catchments and do other tricky things */
     //ar & catchment_formulation_manager
 
     ar & simulation_step_;
-    ar & sim_time_;
-
-    // Layers will be reconstructed, but their internal time keeping needs to be serialized
+    ar & (*sim_time_);
 
     // Nexus and catchment indexes could be re-generated, but only if
     // the set of catchments remains consistent

--- a/src/core/NgenSimulation.cpp
+++ b/src/core/NgenSimulation.cpp
@@ -8,6 +8,10 @@
 #include "HY_Features.hpp"
 #endif
 
+#if NGEN_WITH_PYTHON
+#include <forcing/ForcingsEngineDataProvider.hpp>
+#endif
+
 #include "state_save_restore/vecbuf.hpp"
 #include "state_save_restore/State_Save_Utils.hpp"
 #include "state_save_restore/State_Save_Restore.hpp"
@@ -250,6 +254,12 @@ void NgenSimulation::load_checkpoint(std::shared_ptr<State_Snapshot_Loader> chec
     for (auto& layer : layers_) {
         layer->load_checkpoint(checkpoint_loader);
     }
+#if NGEN_WITH_PYTHON
+    // advance any forcing engine instances to make sure the first query doesn't get messy when catching up to the simulation's time
+    auto now = this->sim_time_->get_current_epoch_time();
+    auto start = this->sim_time_->get_start_time();
+    data_access::detail::ForcingsEngineStorage::instances.advance_to(now - start);
+#endif // NGEN_WITH_PYTHON
 }
 
 

--- a/src/core/NgenSimulation.cpp
+++ b/src/core/NgenSimulation.cpp
@@ -80,6 +80,18 @@ void NgenSimulation::run_catchments(std::shared_ptr<State_Saver> checkpoint_save
         }
 
         if (simulation_step_ != 0 && simulation_step_ % frequency == 0) {
+#if NGEN_WITH_MPI
+            // Remote data is currently handled by MPI, so saving a checkpoint without retreiving all messages could lose data.
+            // An example would be checkpointing every 100 steps with two ranks. Rank 1 is faster than Rank 0, so it saves
+            //   step 200 whilst Rank 1 has only saved step 100. If checkpoints are loaded, all data in MPI messages from Rank 1
+            //   for steps 100-199 will be lost, and the program will likely hang as Rank 0 waits for those messages from Rank 1.
+            // For now, set up a barrier to make sure all ranks can catch up before checkpointing.
+            // A possible later improvement would be the ability to store and recreate the MPI messages when saving/loading checkpoints.
+            if (this->mpi_num_procs_ > 1) {
+                MPI_Barrier(MPI_COMM_WORLD);
+            }
+#endif // NGEN_WITH_MPI
+            checkpoint_saver->clear_cache(this->mpi_rank_);
             auto step_saver = checkpoint_saver->initialize_checkpoint_snapshot(simulation_step_, State_Saver::State_Durability::strict);
             this->save_checkpoint(step_saver);
         }
@@ -168,17 +180,6 @@ void NgenSimulation::save_end_of_run(std::shared_ptr<State_Snapshot_Saver> snaps
 }
 
 void NgenSimulation::save_checkpoint(std::shared_ptr<State_Snapshot_Saver> snapshot_saver) {
-#if NGEN_WITH_MPI
-    // Remote data is currently handled by MPI, so saving a checkpoint without retreiving all messages could lose data.
-    // An example would be checkpointing every 100 steps with two ranks. Rank 1 is faster than Rank 0, so it saves
-    //   step 200 whilst Rank 1 has only saved step 100. If checkpoints are loaded, all data in MPI messages from Rank 1
-    //   for steps 100-199 will be lost, and the program will likely hang as Rank 0 waits for those messages from Rank 1.
-    // For now, set up a barrier is set up to make sure all ranks can catch up before checkpointing.
-    // A possible later improvement would be the ability to store and recreate the MPI messages when saving/loading checkpoints.
-    if (this->mpi_num_procs_ > 1) {
-        MPI_Barrier(MPI_COMM_WORLD);
-    }
-#endif
     snapshot_saver->archive_unit(this->unit_name(), this);
     for (auto& layer : layers_) {
         layer->save_checkpoint(snapshot_saver);

--- a/src/core/NgenSimulation.cpp
+++ b/src/core/NgenSimulation.cpp
@@ -116,6 +116,7 @@ void NgenSimulation::run_catchments(std::shared_ptr<State_Saver> checkpoint_save
             //   for steps 100-199 will be lost, and the program will likely hang as Rank 0 waits for those messages from Rank 1.
             // For now, set up a barrier to make sure all ranks can catch up before checkpointing.
             // A possible later improvement would be the ability to store and recreate the MPI messages when saving/loading checkpoints.
+            LOG(LogLevel::INFO, "Creating checkpoint at simulation step %d.", this->simulation_step_);
             this->sync_mpi_ranks();
             auto step_saver = checkpoint_saver->initialize_checkpoint_snapshot(simulation_step_, State_Saver::State_Durability::strict);
             this->save_checkpoint(step_saver);

--- a/src/core/NgenSimulation.cpp
+++ b/src/core/NgenSimulation.cpp
@@ -85,19 +85,27 @@ void NgenSimulation::run_catchments()
 
 void NgenSimulation::run_catchments(std::shared_ptr<State_Saver> checkpoint_saver, int frequency) {
     int num_times = get_num_output_times();
+    if (frequency > num_times) {
+        LOG(LogLevel::WARNING, "The frequency of checkpoints (%d) is less than the number of simulation steps (%d). No checkpoints will be generated.", frequency, num_times);
+    }
 
-    for (; simulation_step_ < num_times; simulation_step_++) {
+    while (simulation_step_ < num_times) {
         // Make room for this output step's results
         catchment_outflows_.resize(catchment_outflows_.size() + catchment_indexes_.size(), 0.0);
         nexus_downstream_flows_.resize(nexus_downstream_flows_.size() + nexus_indexes_.size(), 0.0);
         
         advance_models_one_output_step();
 
-        if (simulation_step_ + 1 < num_times) {
+        // advance_models_one_output_step runs the BMIs for the next time step,
+        // so the checkpoint state should include advancing the step
+        this->simulation_step_++;
+
+        if (simulation_step_ < num_times) {
             sim_time_->advance_timestep();
         }
 
-        if (simulation_step_ != 0 && simulation_step_ % frequency == 0) {
+        // this position allows creating a checkpoint on the very last step. This might be useful if t-route fails and we want to "skip" the final steps
+        if (simulation_step_ % frequency == 0) {
             // Remote data is currently handled by MPI, so saving a checkpoint without retreiving all messages could lose data.
             // An example would be checkpointing every 100 steps with two ranks. Rank 1 is faster than Rank 0, so it saves
             //   step 200 whilst Rank 1 has only saved step 100. If checkpoints are loaded, all data in MPI messages from Rank 1

--- a/src/core/NgenSimulation.cpp
+++ b/src/core/NgenSimulation.cpp
@@ -21,8 +21,26 @@
 #include "parallel_utils.h"
 
 namespace {
-    const auto NGEN_UNIT_NAME = "ngen";
     const auto TROUTE_UNIT_NAME = "troute";
+
+    #if NGEN_WITH_MPI
+    // Merge strings from multiple MPI ranks and broadcast the results to all ranks. Duplicates will be removed.
+    std::vector<std::string> collect_unique_strings(const std::vector<std::string> &items, int mpi_rank, int mpi_num_procs) {
+        // MPI_Gather all items to rank 0
+        std::vector<std::string> all_items
+            = parallel::gather_strings(items, mpi_rank, mpi_num_procs);
+        if (mpi_rank == 0) {
+            // filter to only the unique items
+            std::sort(all_items.begin(), all_items.end());
+            all_items.erase(
+                std::unique(all_items.begin(), all_items.end()),
+                all_items.end()
+            );
+        }
+        // MPI_Broadcast unique, sorted results to all ranks
+        return parallel::broadcast_strings(all_items, mpi_rank, mpi_num_procs);
+    }
+    #endif // NGEN_WITH_MPI
 }
 
 NgenSimulation::NgenSimulation(
@@ -87,10 +105,10 @@ void NgenSimulation::run_catchments(std::shared_ptr<State_Saver> checkpoint_save
             // For now, set up a barrier to make sure all ranks can catch up before checkpointing.
             // A possible later improvement would be the ability to store and recreate the MPI messages when saving/loading checkpoints.
             this->sync_mpi_ranks();
-            checkpoint_saver->clear_cache(this->mpi_rank_);
-            this->sync_mpi_ranks();
             auto step_saver = checkpoint_saver->initialize_checkpoint_snapshot(simulation_step_, State_Saver::State_Durability::strict);
             this->save_checkpoint(step_saver);
+            this->sync_mpi_ranks();
+            checkpoint_saver->clear_prior(this->mpi_rank_);
         }
     }
 }
@@ -226,7 +244,8 @@ void NgenSimulation::load_checkpoint(std::shared_ptr<State_Snapshot_Loader> chec
     }
 }
 
-std::vector<std::string> NgenSimulation::required_checkpoint_units() const {
+
+std::vector<std::string> NgenSimulation::required_checkpoint_units(bool merge_all_ranks) const {
     std::vector<std::string> units;
     units.push_back(this->unit_name());
     for (const auto &layer : this->layers_) {
@@ -234,6 +253,12 @@ std::vector<std::string> NgenSimulation::required_checkpoint_units() const {
         for (const auto &unit : layer_units)
             units.push_back(unit);
     }
+#if NGEN_WITH_MPI
+    if (merge_all_ranks && this->mpi_num_procs_ > 1) {
+        // merge all ranks' units so to ensure all read from the same source
+        units = collect_unique_strings(units, this->mpi_rank_, this->mpi_num_procs_);
+    }
+#endif // NGEN_WITH_MPI
     return units;
 }
 
@@ -287,18 +312,10 @@ void NgenSimulation::set_troute_inputs(
         for (const auto& id_pair : *feature_indexes) {
             local_ids.push_back(id_pair.first);
         }
-        // MPI_Gather all IDs into a single vector
-        std::vector<std::string> all_ids = parallel::gather_strings(local_ids, mpi_rank_, mpi_num_procs_);
-        if (mpi_rank_ == 0) {
-            // filter to only the unique IDs
-            std::sort(all_ids.begin(), all_ids.end());
-            all_ids.erase(
-                std::unique(all_ids.begin(), all_ids.end()),
-                all_ids.end()
-            );
-        }
-        // MPI_Broadcast so all processes share the IDs
-        all_ids = std::move(parallel::broadcast_strings(all_ids, mpi_rank_, mpi_num_procs_));
+        // gather all nexus IDs into a single vector
+        std::vector<std::string> all_ids = std::move(collect_unique_strings(
+            local_ids, mpi_rank_, mpi_num_procs_
+        ));
 
         // MPI_Reduce to collect the results from processes
         if (this->mpi_rank_ == 0) {

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -19,28 +19,41 @@ namespace realization {
         }
 
         void Bmi_Module_Formulation::save_state(std::shared_ptr<State_Snapshot_Saver> saver) {
-            uint64_t size = 1;
-            boost::span<char> data = this->get_serialization_state();
+            // get the BMI's state and the formulation's metadata
+            boost::span<char> bmi_data = this->get_serialization_state();
+            std::vector<char> metadata = this->create_state_metadata();
 
-            // Rely on Formulation_Manager also using this->get_id()
-            // as a unique key for the individual catchment
-            // formulations
+            // append the BMI state to the end of the metadata
+            metadata.reserve(metadata.size() + bmi_data.size());
+            memcpy(metadata.data() + metadata.size(), bmi_data.data(), bmi_data.size());
+
+            // save the merged state, then clear the state stored on the BMI
+            boost::span<char> data(metadata.data(), metadata.size() + bmi_data.size());
             saver->save_unit(this->save_state_unit_name(), data);
-
             this->free_serialization_state();
         }
 
         void Bmi_Module_Formulation::load_state(std::shared_ptr<State_Snapshot_Loader> loader) {
+            // get the data from the loader
             std::vector<char> buffer;
             loader->load_unit(this->save_state_unit_name(), buffer);
-            boost::span<char> data(buffer.data(), buffer.size());
-            this->load_serialization_state(data);
+
+            // extract the metadata
+            size_t metadata_size = this->load_state_metadata(buffer);
+
+            // send the remaining data to the BMI
+            boost::span<char> bmi_data(buffer.data() + metadata_size, buffer.size() - metadata_size);
+            this->load_serialization_state(bmi_data);
         }
 
         void Bmi_Module_Formulation::load_hot_start(std::shared_ptr<State_Snapshot_Loader> loader) {
+            // get a copy of the current metadata
+            std::vector<char> metadata = this->create_state_metadata();
             this->load_state(loader);
             double rt;
             this->get_bmi_model()->SetValue(StateSaveNames::FREE, &rt);
+            // reset the metadata after load
+            this->load_state_metadata(metadata);
         }
 
         boost::span<const std::string> Bmi_Module_Formulation::get_available_variable_names() const {
@@ -1118,5 +1131,17 @@ namespace realization {
             // send message to clear memory associated with serialized data
             void* _; // this pointer will be unused by SetValue
             bmi->SetValue(StateSaveNames::FREE, _);
+        }
+
+        std::vector<char> Bmi_Module_Formulation::create_state_metadata() const {
+            // WARNING: Other parts of NGEN assume that the metadata should be copied and reset after loading a hot start.
+            std::vector<char> data(sizeof(this->next_time_step_index));
+            memcpy(data.data(), &this->next_time_step_index, sizeof(this->next_time_step_index));
+            return data;
+        }
+
+        size_t Bmi_Module_Formulation::load_state_metadata(const std::vector<char> &data) {
+            memcpy(&this->next_time_step_index, data.data(), sizeof(this->next_time_step_index));
+            return sizeof(this->next_time_step_index);
         }
 }

--- a/src/realizations/catchment/Bmi_Module_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Module_Formulation.cpp
@@ -25,14 +25,14 @@ namespace realization {
             // Rely on Formulation_Manager also using this->get_id()
             // as a unique key for the individual catchment
             // formulations
-            saver->save_unit(this->get_id(), data);
+            saver->save_unit(this->save_state_unit_name(), data);
 
             this->free_serialization_state();
         }
 
         void Bmi_Module_Formulation::load_state(std::shared_ptr<State_Snapshot_Loader> loader) {
             std::vector<char> buffer;
-            loader->load_unit(this->get_id(), buffer);
+            loader->load_unit(this->save_state_unit_name(), buffer);
             boost::span<char> data(buffer.data(), buffer.size());
             this->load_serialization_state(data);
         }

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -26,7 +26,7 @@ using namespace realization;
 
 
 void Bmi_Multi_Formulation::save_state(std::shared_ptr<State_Snapshot_Saver> saver) {
-    LOG(LogLevel::DEBUG, "Saving state for Multi-BMI %s", this->get_id());
+    LOG(LogLevel::DEBUG, "Saving state for Multi-BMI %s", this->save_state_unit_name());
     vecbuf<char> data;
     boost::archive::binary_oarchive archive(data);
     // serialization function handles freeing the sub-BMI states after archiving them
@@ -38,13 +38,13 @@ void Bmi_Multi_Formulation::save_state(std::shared_ptr<State_Snapshot_Saver> sav
         bmi->free_serialization_state();
     }
     boost::span<const char> span(data.data(), data.size());
-    saver->save_unit(this->get_id(), span);
+    saver->save_unit(this->save_state_unit_name(), span);
 }
 
 void Bmi_Multi_Formulation::load_state(std::shared_ptr<State_Snapshot_Loader> loader) {
-    LOG(LogLevel::DEBUG, "Loading save state for Multi-BMI %s", this->get_id());
+    LOG(LogLevel::DEBUG, "Loading save state for Multi-BMI %s", this->save_state_unit_name());
     std::vector<char> data;
-    loader->load_unit(this->get_id(), data);
+    loader->load_unit(this->save_state_unit_name(), data);
     membuf stream(data.data(), data.size());
     boost::archive::binary_iarchive archive(stream);
     archive >> (*this);

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -27,7 +27,7 @@ using namespace realization;
 
 
 void Bmi_Multi_Formulation::save_state(std::shared_ptr<State_Snapshot_Saver> saver) {
-    LOG(LogLevel::DEBUG, "Saving state for Multi-BMI %s", this->save_state_unit_name());
+    LOG(LogLevel::DEBUG, "Saving state for Multi-BMI %s", this->save_state_unit_name().c_str());
     vecbuf<char> data;
     boost::archive::binary_oarchive archive(data);
     // serialization function handles freeing the sub-BMI states after archiving them
@@ -43,7 +43,7 @@ void Bmi_Multi_Formulation::save_state(std::shared_ptr<State_Snapshot_Saver> sav
 }
 
 void Bmi_Multi_Formulation::load_state(std::shared_ptr<State_Snapshot_Loader> loader) {
-    LOG(LogLevel::DEBUG, "Loading save state for Multi-BMI %s", this->save_state_unit_name());
+    LOG(LogLevel::DEBUG, "Loading save state for Multi-BMI %s", this->save_state_unit_name().c_str());
     std::vector<char> data;
     loader->load_unit(this->save_state_unit_name(), data);
     membuf stream(data.data(), data.size());

--- a/src/realizations/catchment/Bmi_Multi_Formulation.cpp
+++ b/src/realizations/catchment/Bmi_Multi_Formulation.cpp
@@ -21,6 +21,7 @@
 #include <boost/serialization/serialization.hpp>
 #include <boost/archive/binary_oarchive.hpp>
 #include <boost/archive/binary_iarchive.hpp>
+#include <boost/serialization/vector.hpp>
 
 using namespace realization;
 
@@ -51,13 +52,25 @@ void Bmi_Multi_Formulation::load_state(std::shared_ptr<State_Snapshot_Loader> lo
 }
 
 void Bmi_Multi_Formulation::load_hot_start(std::shared_ptr<State_Snapshot_Loader> loader) {
+    // create a copy of the BMIs' metadata
+    std::vector<std::vector<char>> metadata;
+    for (size_t i = 0; i < this->modules.size(); ++i) {
+        const auto &m = this->modules[i];
+        auto bmi = dynamic_cast<Bmi_Module_Formulation *>(m.get());
+        metadata.push_back(bmi->create_state_metadata());
+    }
+    // create copy of next_time_step_index to restore after loading
+    auto next_time_step_index = this->next_time_step_index;
     this->load_state(loader);
+    this->next_time_step_index = next_time_step_index;
     double rt;
     LOG(LogLevel::DEBUG, "Resetting time for sub-BMIs");
     // Multi-BMI's current forwards its primary BMI's current time, so no additional action needed for the formulation's reset time
-    for (const nested_module_ptr &m : modules) {
+    for (size_t i = 0; i < this->modules.size(); ++i) {
+        const auto &m = this->modules[i];
         auto bmi = dynamic_cast<Bmi_Module_Formulation *>(m.get());
         bmi->get_bmi_model()->SetValue(StateSaveNames::RESET, &rt);
+        bmi->load_state_metadata(metadata[i]);
     }
 }
 
@@ -664,11 +677,15 @@ template<class Archive>
 void Bmi_Multi_Formulation::serialize(Archive &ar, const unsigned int version) {
     uint64_t data_size;
     std::vector<char> buffer;
+    std::vector<char> metadata;
+    ar & this->next_time_step_index;
     for (const nested_module_ptr &m : modules) {
         auto bmi = dynamic_cast<Bmi_Module_Formulation *>(m.get());
         // if saving, make the BMI's state and record its size and data
         if (Archive::is_saving::value) {
             LOG(LogLevel::DEBUG, "Saving state from sub-BMI " + bmi->get_model_type_name());
+            metadata = std::move(bmi->create_state_metadata());
+            ar & metadata;
             boost::span<char> span = bmi->get_serialization_state();
             data_size = span.size();
             ar & data_size;
@@ -679,6 +696,8 @@ void Bmi_Multi_Formulation::serialize(Archive &ar, const unsigned int version) {
         // if loading, get the current data size stored at the front, then load that much data as a char blob passed to the BMI
         else {
             LOG(LogLevel::DEBUG, "Loading state from sub-BMI " + bmi->get_model_type_name());
+            ar & metadata;
+            bmi->load_state_metadata(metadata);
             ar & data_size;
             buffer.resize(data_size);
             ar & boost::serialization::make_array(buffer.data(), data_size);

--- a/src/state_save_restore/File_Per_Unit.cpp
+++ b/src/state_save_restore/File_Per_Unit.cpp
@@ -20,17 +20,6 @@
 #include <fstream>
 #include <iomanip>
 
-namespace unit_saving_utils {
-    std::string format_epoch(State_Saver::snapshot_time_t epoch)
-    {
-        time_t t = std::chrono::system_clock::to_time_t(epoch);
-        std::tm tm = *std::gmtime(&t);
-
-        std::stringstream tss;
-        tss << std::put_time(&tm, "%Y-%m-%dT%H:%M:%S");
-        return tss.str();
-    }
-}
 
 // This class is only declared and defined here, in the .cpp file,
 // because it is strictly an implementation detail of the top-level
@@ -66,9 +55,9 @@ std::shared_ptr<State_Snapshot_Saver> File_Per_Unit_Saver::initialize_snapshot(S
     return std::make_shared<File_Per_Unit_Snapshot_Saver>(path(this->base_path_), durability);
 }
 
-std::shared_ptr<State_Snapshot_Saver> File_Per_Unit_Saver::initialize_checkpoint_snapshot(snapshot_time_t epoch, State_Durability durability)
+std::shared_ptr<State_Snapshot_Saver> File_Per_Unit_Saver::initialize_checkpoint_snapshot(int step, State_Durability durability)
 {
-    path checkpoint_path = path(this->base_path_) / unit_saving_utils::format_epoch(epoch);
+    path checkpoint_path = path(this->base_path_) / std::to_string(step);
     create_directory(checkpoint_path);
     return std::make_shared<File_Per_Unit_Snapshot_Saver>(checkpoint_path, durability);
 }
@@ -188,9 +177,36 @@ std::shared_ptr<State_Snapshot_Loader> File_Per_Unit_Loader::initialize_snapshot
     return std::make_shared<File_Per_Unit_Snapshot_Loader>(path(dir_path_));
 }
 
-std::shared_ptr<State_Snapshot_Loader> File_Per_Unit_Loader::initialize_checkpoint_snapshot(State_Saver::snapshot_time_t epoch)
+std::shared_ptr<State_Snapshot_Loader> File_Per_Unit_Loader::initialize_checkpoint_snapshot(const std::vector<std::string> &required_units, int *const checkpoint_step)
 {
-    path checkpoint_path = path(dir_path_) / unit_saving_utils::format_epoch(epoch);;
-    return std::make_shared<File_Per_Unit_Snapshot_Loader>(checkpoint_path);
+    std::vector<path> options;
+    for (const auto &subdir : directory_iterator(dir_path_)) {
+        path subdir_path = subdir.path();
+        // make sure subfolder is a number from a timestep
+        if (subdir_path.filename().string().find_first_not_of("0123456789") == std::string::npos) {
+            options.push_back(subdir);
+        }
+    }
+    // sort options by the highest number representation
+    std::sort(options.begin(), options.end(), [](const path &a, const path &b) {
+        return std::stoi(a.filename().string()) > std::stoi(b.filename().string());
+    });
+    for (const path &option : options) {
+        auto loader = std::make_shared<File_Per_Unit_Snapshot_Loader>(option);
+        bool passes = true;
+        for (const auto &unit : required_units) {
+            if (!loader->has_unit(unit)) {
+                passes = false;
+                break;
+            }
+        }
+        if (passes) {
+            *checkpoint_step = std::stoi(option.filename().string());
+            return loader;
+        }
+    }
+    std::string error = "No checkpoint location found with all required units in root directory " + this->dir_path_;
+    LOG(LogLevel::FATAL, error);
+    throw std::runtime_error(error);
 }
 

--- a/src/state_save_restore/File_Per_Unit.cpp
+++ b/src/state_save_restore/File_Per_Unit.cpp
@@ -82,7 +82,7 @@ std::shared_ptr<State_Snapshot_Saver> File_Per_Unit_Saver::initialize_checkpoint
     return std::make_shared<File_Per_Unit_Snapshot_Saver>(checkpoint_path, durability);
 }
 
-void File_Per_Unit_Saver::clear_cache(int mpi_rank) {
+void File_Per_Unit_Saver::clear_prior(int mpi_rank) {
     if (mpi_rank == 0) { // reserve file system deletion to just the main MPI rank
         std::vector<path> subdirs;
         ordered_checkpoint_subfolders(this->base_path_, subdirs);

--- a/src/state_save_restore/File_Per_Unit.cpp
+++ b/src/state_save_restore/File_Per_Unit.cpp
@@ -17,9 +17,30 @@
   #error "No Filesystem library implementation available"
 #endif
 
+#include <boost/iostreams/device/file.hpp>
+#include <boost/iostreams/device/file_descriptor.hpp>
+#include <boost/iostreams/stream.hpp>
+
 #include <fstream>
 #include <iomanip>
 
+namespace {
+    // Populate a vector of paths with subfolders with names that can be interpreted as ints.
+    // The vector will be sorted by highest numeric representation first.
+    void ordered_checkpoint_subfolders(const std::string &root, std::vector<path> &subdirs) {
+        for (const auto &subdir : directory_iterator(root)) {
+            path subdir_path = subdir.path();
+            // make sure subfolder is a number from a timestep
+            if (subdir_path.filename().string().find_first_not_of("0123456789") == std::string::npos) {
+                subdirs.push_back(subdir);
+            }
+        }
+        // sort options by the highest number representation
+        std::sort(subdirs.begin(), subdirs.end(), [](const path &a, const path &b) {
+            return std::stoi(a.filename().string()) > std::stoi(b.filename().string());
+        });
+    }
+}
 
 // This class is only declared and defined here, in the .cpp file,
 // because it is strictly an implementation detail of the top-level
@@ -51,7 +72,6 @@ File_Per_Unit_Saver::File_Per_Unit_Saver(std::string base_path)
 File_Per_Unit_Saver::~File_Per_Unit_Saver() = default;
 
 std::shared_ptr<State_Snapshot_Saver> File_Per_Unit_Saver::initialize_snapshot(State_Durability durability) {
-    // TODO
     return std::make_shared<File_Per_Unit_Snapshot_Saver>(path(this->base_path_), durability);
 }
 
@@ -60,6 +80,17 @@ std::shared_ptr<State_Snapshot_Saver> File_Per_Unit_Saver::initialize_checkpoint
     path checkpoint_path = path(this->base_path_) / std::to_string(step);
     create_directory(checkpoint_path);
     return std::make_shared<File_Per_Unit_Snapshot_Saver>(checkpoint_path, durability);
+}
+
+void File_Per_Unit_Saver::clear_cache(int mpi_rank) {
+    if (mpi_rank == 0) { // reserve file system deletion to just the main MPI rank
+        std::vector<path> subdirs;
+        ordered_checkpoint_subfolders(this->base_path_, subdirs);
+        // delete all checkpoint directories save the most recent one
+        for (int i = 1; i < subdirs.size(); ++i) {
+            remove_all(subdirs[i]);
+        }
+    }
 }
 
 void File_Per_Unit_Saver::finalize()
@@ -177,20 +208,10 @@ std::shared_ptr<State_Snapshot_Loader> File_Per_Unit_Loader::initialize_snapshot
     return std::make_shared<File_Per_Unit_Snapshot_Loader>(path(dir_path_));
 }
 
-std::shared_ptr<State_Snapshot_Loader> File_Per_Unit_Loader::initialize_checkpoint_snapshot(const std::vector<std::string> &required_units, int *const checkpoint_step)
+std::shared_ptr<State_Snapshot_Loader> File_Per_Unit_Loader::initialize_checkpoint_snapshot(const std::vector<std::string> &required_units)
 {
     std::vector<path> options;
-    for (const auto &subdir : directory_iterator(dir_path_)) {
-        path subdir_path = subdir.path();
-        // make sure subfolder is a number from a timestep
-        if (subdir_path.filename().string().find_first_not_of("0123456789") == std::string::npos) {
-            options.push_back(subdir);
-        }
-    }
-    // sort options by the highest number representation
-    std::sort(options.begin(), options.end(), [](const path &a, const path &b) {
-        return std::stoi(a.filename().string()) > std::stoi(b.filename().string());
-    });
+    ordered_checkpoint_subfolders(this->dir_path_, options);
     for (const path &option : options) {
         auto loader = std::make_shared<File_Per_Unit_Snapshot_Loader>(option);
         bool passes = true;
@@ -201,7 +222,7 @@ std::shared_ptr<State_Snapshot_Loader> File_Per_Unit_Loader::initialize_checkpoi
             }
         }
         if (passes) {
-            *checkpoint_step = std::stoi(option.filename().string());
+            LOG(LogLevel::INFO, "Loading state from checkpoint step " + option.filename().string());
             return loader;
         }
     }

--- a/src/state_save_restore/State_Save_Restore.cpp
+++ b/src/state_save_restore/State_Save_Restore.cpp
@@ -1,5 +1,6 @@
 #include <state_save_restore/State_Save_Restore.hpp>
 #include <state_save_restore/File_Per_Unit.hpp>
+#include <state_save_restore/vecbuf.hpp>
 
 #include "Logger.hpp"
 
@@ -7,6 +8,9 @@
 #include <boost/property_tree/ptree.hpp>
 
 #include <string>
+
+#include <boost/archive/binary_oarchive.hpp>
+#include <boost/archive/binary_iarchive.hpp>
 
 State_Save_Config::State_Save_Config(boost::property_tree::ptree const& tree)
 {
@@ -19,6 +23,8 @@ State_Save_Config::State_Save_Config(boost::property_tree::ptree const& tree)
     }
 
     bool hot_start = false;
+    bool checkpoint_load = false;
+    bool checkpoint_save = false;
     for (const auto& saving_config : *maybe) {
         try {
             auto& subtree = saving_config.second;
@@ -27,12 +33,24 @@ State_Save_Config::State_Save_Config(boost::property_tree::ptree const& tree)
             auto where = subtree.get<std::string>("path");
             auto how = subtree.get<std::string>("type");
             auto when = subtree.get<std::string>("when");
+            auto frequency = subtree.get_optional<int>("frequency");
 
-            instance i{direction, what, where, how, when};
+            instance i{direction, what, where, how, when, frequency};
             if (i.timing_ == State_Save_When::StartOfRun && i.direction_ == State_Save_Direction::Load) {
                 if (hot_start)
                     throw std::runtime_error("Only one hot start state saving configuration is allowed.");
                 hot_start = true;
+            }
+            if (i.timing_ == State_Save_When::Checkpoint) {
+                if (i.direction_ == State_Save_Direction::Load) {
+                    if (checkpoint_load)
+                        throw std::runtime_error("Only one checkpointing load state saving configuration is allowed.");
+                    checkpoint_load = true;
+                } else if (i.direction_ == State_Save_Direction::Save) {
+                    if (checkpoint_save)
+                        throw std::runtime_error("Only one checkpointing save state saving configuration is allowed.");
+                    checkpoint_save = true;
+                }
             }
             instances_.push_back(i);
         } catch (std::exception &e) {
@@ -86,12 +104,50 @@ std::unique_ptr<State_Loader> State_Save_Config::hot_start() const {
             }
         }
     }
-    return std::unique_ptr<State_Loader>();
+    return NULL;
 }
 
-State_Save_Config::instance::instance(std::string const& direction, std::string const& label, std::string const& path, std::string const& mechanism, std::string const& timing)
+std::unique_ptr<State_Loader> State_Save_Config::checkpoint_loader() const {
+    for (const auto &i : this->instances_) {
+        if (i.direction_ == State_Save_Direction::Load && i.timing_ == State_Save_When::Checkpoint) {
+            if (i.mechanism_ == State_Save_Mechanism::FilePerUnit) {
+                return std::make_unique<File_Per_Unit_Loader>(i.path_);
+            } else {
+                Logger::LogAndThrow("State_Save_Config: Loading mechanism " + i.mechanism_string() + " is not supported for checkpoint loading.");
+            }
+        }
+    }
+    return NULL;
+}
+
+bool State_Save_Config::has_checkpoint_saver() const {
+    for (const auto &i : this->instances_) {
+        if (i.direction_ == State_Save_Direction::Save && i.timing_ == State_Save_When::Checkpoint) {
+            return true;
+        }
+    }
+    return false;
+}
+
+std::shared_ptr<State_Saver> State_Save_Config::checkpoint_saver(int *const frequency) const {
+    for (const auto &i : this->instances_) {
+        if (i.direction_ == State_Save_Direction::Save && i.timing_ == State_Save_When::Checkpoint) {
+            if (i.mechanism_ == State_Save_Mechanism::FilePerUnit) {
+                *frequency = i.frequency_;
+                return std::make_shared<File_Per_Unit_Saver>(i.path_);
+            } else {
+                Logger::LogAndThrow("State_Save_Config: Saving mechanism " + i.mechanism_string() + " is not supported for checkpoint saving.");
+            }
+        }
+    }
+    Logger::LogAndThrow("State_Save_Config: Failed to find a suitable checkpoint saving configuration.");
+    return NULL;
+}
+
+State_Save_Config::instance::instance(std::string const& direction, std::string const& label, std::string const& path, std::string const& mechanism, std::string const& timing, boost::optional<int> frequency)
     : label_(label)
     , path_(path)
+    , frequency_{-1}
 {
     if (direction == "save") {
         direction_ = State_Save_Direction::Save;
@@ -115,10 +171,22 @@ State_Save_Config::instance::instance(std::string const& direction, std::string 
 
     if (timing == "EndOfRun") {
         timing_ = State_Save_When::EndOfRun;
-    } else if (timing == "FirstOfMonth") {
-        timing_ = State_Save_When::FirstOfMonth;
     } else if (timing == "StartOfRun") {
         timing_ = State_Save_When::StartOfRun;
+    } else if (timing == "Checkpoint") { // starts with "Checkpoint"
+        timing_ = State_Save_When::Checkpoint;
+        if (direction_ == State_Save_Direction::Save) {
+            if (!frequency.has_value()) {
+                Logger::LogAndThrow("The checkpoint save configuration is missing a 'frequency' of checkpointing.");
+            }
+            frequency_ = frequency.get();
+            // make sure the frequency makes sense
+            if (frequency_ <= 0) {
+                std::stringstream ss;
+                ss << "The frequency of a checkpoint save must be greater than 0. The configured value is " << frequency_;
+                Logger::LogAndThrow(ss.str());
+            }
+        }
     } else {
         std::string message = "Unrecognized state saving timing '" + timing + "'";
         std::string throw_msg; throw_msg.assign(message);
@@ -142,13 +210,4 @@ State_Snapshot_Saver::State_Snapshot_Saver(State_Saver::State_Durability durabil
     : durability_(durability)
 {
 
-}
-
-State_Saver::snapshot_time_t State_Saver::snapshot_time_now() {
-#if __cplusplus < 201703L // C++ < 17
-    auto now = std::chrono::system_clock::now();
-    return std::chrono::time_point_cast<std::chrono::seconds>(now);
-#else
-    return std::chrono::floor<std::chrono::seconds>(std::chrono::system_clock::now());
-#endif
 }

--- a/src/state_save_restore/State_Save_Restore.cpp
+++ b/src/state_save_restore/State_Save_Restore.cpp
@@ -113,7 +113,10 @@ std::unique_ptr<State_Loader> State_Save_Config::checkpoint_loader() const {
             if (i.mechanism_ == State_Save_Mechanism::FilePerUnit) {
                 return std::make_unique<File_Per_Unit_Loader>(i.path_);
             } else {
-                Logger::LogAndThrow("State_Save_Config: Loading mechanism " + i.mechanism_string() + " is not supported for checkpoint loading.");
+                std::stringstream ss;
+                ss << "State_Save_Config: Loading mechanism " << i.mechanism_string() << " is not supported for checkpoint loading.";
+                LOG(LogLevel::FATAL, ss.str());
+                throw std::runtime_error(ss.str());
             }
         }
     }
@@ -136,12 +139,16 @@ std::shared_ptr<State_Saver> State_Save_Config::checkpoint_saver(int *const freq
                 *frequency = i.frequency_;
                 return std::make_shared<File_Per_Unit_Saver>(i.path_);
             } else {
-                Logger::LogAndThrow("State_Save_Config: Saving mechanism " + i.mechanism_string() + " is not supported for checkpoint saving.");
+                std::stringstream ss;
+                ss << "State_Save_Config: Saving mechanism " << i.mechanism_string() << " is not supported for checkpoint saving.";
+                LOG(LogLevel::FATAL, ss.str());
+                throw std::runtime_error(ss.str());
             }
         }
     }
-    Logger::LogAndThrow("State_Save_Config: Failed to find a suitable checkpoint saving configuration.");
-    return NULL;
+    const auto error = "State_Save_Config: Failed to find a suitable checkpoint saving configuration.";
+    LOG(LogLevel::FATAL, error);
+    throw std::runtime_error(error);
 }
 
 State_Save_Config::instance::instance(std::string const& direction, std::string const& label, std::string const& path, std::string const& mechanism, std::string const& timing, boost::optional<int> frequency)
@@ -177,14 +184,17 @@ State_Save_Config::instance::instance(std::string const& direction, std::string 
         timing_ = State_Save_When::Checkpoint;
         if (direction_ == State_Save_Direction::Save) {
             if (!frequency.has_value()) {
-                Logger::LogAndThrow("The checkpoint save configuration is missing a 'frequency' of checkpointing.");
+                const auto message = "The checkpoint save configuration is missing a 'frequency' of checkpointing.";
+                LOG(LogLevel::FATAL, message);
+                throw std::runtime_error(message);
             }
             frequency_ = frequency.get();
             // make sure the frequency makes sense
             if (frequency_ <= 0) {
                 std::stringstream ss;
                 ss << "The frequency of a checkpoint save must be greater than 0. The configured value is " << frequency_;
-                Logger::LogAndThrow(ss.str());
+                LOG(LogLevel::FATAL, ss.str());
+                throw std::runtime_error(ss.str());
             }
         }
     } else {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -461,6 +461,7 @@ ngen_add_test(
         NGen::logging
         NGen::core_mediator
         NGen::ngen_bmi
+        NGen::forcing
 )
 
 ########################### Netcdf Forcing Tests


### PR DESCRIPTION
Add checkpointing options for the NGEN simulation. These are controlled by the `state_saving` property of the realization config JSON. When running with checkpoints saving, when a checkpoint step is hit, a new subfolder with the name of the checkpoint will be generated, and model states will be added there. After successfully saving states, the folders of any prior checkpoint will be deleted. When loading checkpoints, NGEN will go through the subfolders of the checkpointing path in reverse numeric order and load from the first folder it finds with a complete state that can be loaded.

For saving checkpoints, an item must be added to the array that looks like
```JSON
{
  "direction": "save",
  "label": "...", // used only for reporting
  "path": "...", // path to the root folder states will be saved to. A new subfolder will be created for each checkpoint
  "type": "FilePerUnit",
  "when": "Checkpoint",
  "frequency": 1000 // integer for how many steps run between each checkpoint made
}
```

For loading checkpoints, an item must be added to the array that looks like
```JSON
{
  "direction": "load",
  "label": "...", // used only for reporting
  "path": "...", // path to the root folder checkpoint saves were saved to. The last subfolder with all required states will be selected when loading
  "type": "FilePerUnit",
  "when": "Checkpoint"
}
```

## Additions

- Parsing for checkpointing save and load configurations.
- Methods on `NgenSimluation` and BMI interfaces for loading a checkpointing state. The main difference between checkpointing and hot start methods is there is not an additional step to reset the BMI's internal time after loading a state.
- Methods on `NgenSimulation` and BMI interfaces for saving a checkpointing state. The main difference between checkpointing and end of run methods is additional data regarding the time and output state for `NgenSimulation` and `Layer` objects is saved.

## Removals

-

## Changes

- Some generic save and load methods were renamed to specify they're used with checkpointing. Because checkpointing requires extra data regarding the current time of the simulation, separate state saving and loading methods will be maintained to determine what state needs to be preserved and whether additional processing needs to happen after a state is restored.

## Testing

1.

## Screenshots


## Notes

- The current implementation will not preserve the catchment outputs (CSVs). There is ongoing discussion regarding the current catchment outputs (converting to NetCDF and creating periodic outputs instead of one lump output at the end primarily) that made implementing it now seem like wasted effort in the near future.

## Todos

- To account for delayed MPI messages from remote nexuses, an `MPI_Barrier` is run before saving the checkpointing. This could slow down the program, so an alternative approach would be to also store MPI messages that have not be received so they can be resent. This would likely be a very large effort to properly coordinate which messages are sent and received on checkpoint save and load, so we would probably only want to do this if we notice a significant performance impact from the `MPI_Barrier` use in checkpointing.

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [ ] Linux
