### PR TITLE
Ensure Forcing Cleanup Routine on NGEN Failure (NGWPC-10147)

### DIFF
--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -821,6 +821,8 @@ int main(int argc, char* argv[]) {
     int mpi_num_procs = 1;
     // Define in the non-MPI case so that we don't need to conditionally compile `if (mpi_rank == 0)`
     int mpi_rank = 0;
+    // exit code result of the simulation run
+    int result;
 
 #if NGEN_WITH_MPI
     // initialize MPI if needed
@@ -834,15 +836,22 @@ int main(int argc, char* argv[]) {
     // Need to bind to a variable so that the underlying reference count
     // is incremented, this essentially becomes the global reference to keep
     // the interpreter alive till the end of `main`
-    auto _interp = utils::ngenPy::InterpreterUtil::getInstance();
-#endif // NGEN_WITH_PYTHON
-
-    int result = run_ngen(argc, argv, mpi_num_procs, mpi_rank);
-
-#if NGEN_WITH_PYTHON
+    auto interp = utils::ngenPy::InterpreterUtil::getInstance();
+    try {
+        result = run_ngen(argc, argv, mpi_num_procs, mpi_rank);
+    } catch (...) {
+        // If any uncaught exception happens,
+        // explictly destroy the interpreter to ensure any
+        // python atexit registered actions will trigger.
+        interp.reset();
+        // Then, throw the original error.
+        throw;
+    }
     // explicitly destroy the interpreter before calling MPI_Finalize
-    _interp.reset();
-#endif
+    interp.reset();
+#else
+    result = run_ngen(argc, argv, mpi_num_procs, mpi_rank);
+#endif // NGEN_WITH_PYTHON
 
 #if NGEN_WITH_MPI
     MPI_Finalize();

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -840,6 +840,11 @@ int main(int argc, char* argv[]) {
     }
     // explicitly destroy the interpreter before calling MPI_Finalize
     interp.reset();
+#if NGEN_WITH_MPI
+    // ensure all interpreters are fully closed between MPI ranks before calling MPI_Finalize below
+    // this is needed if any python atexit registered functions would interact with MPI
+    MPI_Barrier(MPI_COMM_WORLD);
+#endif // NGEN_WITH_MPI
 #else
     result = run_ngen(argc, argv, mpi_num_procs, mpi_rank);
 #endif // NGEN_WITH_PYTHON

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -203,15 +203,6 @@ int run_ngen(int argc, char* argv[], int mpi_num_procs, int mpi_rank) {
     ss.str("");
     std::ios::sync_with_stdio(false);
 
-#if NGEN_WITH_PYTHON
-    // Start Python interpreter via the manager singleton
-    // Need to bind to a variable so that the underlying reference count
-    // is incremented, this essentially becomes the global reference to keep
-    // the interpreter alive till the end of `main`
-    auto _interp = utils::ngenPy::InterpreterUtil::getInstance();
-// utils::ngenPy::InterpreterUtil::getInstance();
-#endif // NGEN_WITH_PYTHON
-
     // Pull a few "options" form the cli input, this is a temporary solution to CLI parsing!
     // Use "positional args"
     // arg 0 is program name

--- a/src/forcing/ForcingsEngineDataProvider.cpp
+++ b/src/forcing/ForcingsEngineDataProvider.cpp
@@ -26,9 +26,8 @@ void assert_forcings_engine_requirements()
 {
     // Check that the python module is installed.
     {
-        auto interpreter_ = utils::ngenPy::InterpreterUtil::getInstance();
         try {
-            auto mod = interpreter_->getModule(forcings_engine_python_module);
+            auto mod = utils::ngenPy::InterpreterUtil::getPyModule(forcings_engine_python_module);
             auto cls = mod.attr(forcings_engine_python_class).cast<py::object>();
         } catch(std::exception& e) {
             std::string msg = "Failed to initialize ForcingsEngine: ForcingsEngine python module is not installed or is not properly configured. (" + 


### PR DESCRIPTION
Forcing Engine handles cleanup code through a function registered with `atexit.register`. When NGEN encounters an error that terminates the simulation early, this cleanup is not currently run. This PR aims to address this problem.

The change is to catch the exception from `run_ngen`, explicitly destroy the interpreter to ensure python's `atexit` runs, then rethrow the exception to seg fault the program.

There are two places where this update will not fix the current behavior:
1) A BMI terminates the program instead of passing NGEN an error. This would happen from C/C++ BMIs that call `abort()` or `stop` in FORTRAN.
2) During the stack unwind of `run_ngen`, multiple destructors throw errors. This seems most likely to happen if an exception is thrown on multiple BMI `Finalize()` steps as the code currently calls `Finalize()` in the BMIs' `shared_ptr` deletion.


## Additions

-

## Removals

-

## Changes

- Changes `main` to destroy the python instance if `run_ngen` throws an exception.
- Removes calls to `InterpreterUtil::getInstance()` outside `main` and static methods to ensure `main` is solely responsible for maintaining the lifetime of the interpreter.

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [ ] Linux
