### PR TITLE
Update GH Actions Workflow cicd.yml to bust EWTS Docker cache when remote ref changes

### DIFF
--- a/.github/workflows/ngwpc-cicd.yml
+++ b/.github/workflows/ngwpc-cicd.yml
@@ -83,6 +83,7 @@ jobs:
       ngen_forcing_digest: ${{ steps.vars.outputs.ngen_forcing_digest }}
       ngen_forcing_revision: ${{ steps.vars.outputs.ngen_forcing_revision }}
       ewts_revision: ${{ steps.vars.outputs.ewts_revision }}
+      ewts_cache_bust: ${{ steps.vars.outputs.ewts_cache_bust }}
     steps:
       - name: Compute image vars
         id: vars
@@ -171,6 +172,21 @@ jobs:
 
           EWTS_REVISION=$(resolve_sha "https://github.com/${{ inputs.EWTS_ORG || github.repository_owner }}/nwm-ewts.git" "$(ref_or_default "${{ inputs.EWTS_REF }}")")
 
+          # Resolve EWTS ref for Docker cache busting
+          EWTS_ORG="${{ inputs.EWTS_ORG || github.repository_owner }}"
+          EWTS_REF="${{ inputs.EWTS_REF || 'development' }}"
+
+          if [[ "${EWTS_REF}" =~ ^[0-9a-f]{7,40}$ ]]; then
+            EWTS_CACHE_BUST="${EWTS_REF}"
+          else
+            EWTS_CACHE_BUST="$(git ls-remote "https://github.com/${EWTS_ORG}/nwm-ewts.git" "${EWTS_REF}" | awk '{print $1}')"
+          fi
+
+          if [ -z "${EWTS_CACHE_BUST}" ]; then
+            echo "ERROR: Could not resolve EWTS_REF=${EWTS_REF}"
+            exit 1
+          fi
+
           # save outputs
           cat >> "$GITHUB_OUTPUT" <<EOF
           org=${ORG}
@@ -184,6 +200,7 @@ jobs:
           ngen_forcing_digest=${NGEN_FORCING_DIGEST}
           ngen_forcing_revision=${NGEN_FORCING_REVISION}
           ewts_revision=${EWTS_REVISION}
+          ewts_cache_bust=${EWTS_CACHE_BUST}
           EOF
 
   # CodeQL scan
@@ -343,6 +360,7 @@ jobs:
             EWTS_ORG=${{ inputs.EWTS_ORG || github.repository_owner }}
             EWTS_REF=${{ inputs.EWTS_REF || needs.setup.outputs.default_ref }}
             EWTS_REVISION=${{ needs.setup.outputs.ewts_revision }}
+            EWTS_CACHE_BUST=${{ needs.setup.outputs.ewts_cache_bust }}
             IMAGE_SOURCE=https://github.com/${{ github.repository }}
             IMAGE_VENDOR=${{ github.repository_owner }}
             IMAGE_VERSION=${{ needs.setup.outputs.clean_ref }}


### PR DESCRIPTION
- Improved CI/CD handling of EWTS builds
    - Updated GitHub Actions workflow to resolve EWTS_REF to its commit SHA and pass it as the EWTS_CACHE_BUST build arg.
    - Ensures the EWTS Docker layer rebuilds when a branch/tag HEAD changes, while preserving cache stability when using fixed commit hashes.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
