### PR TITLE
NGEN Hanging on Error with MPI (NGWPC-10757)

### DIFF
--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -36,6 +36,7 @@
 #if NGEN_WITH_PYTHON
 #include "python/InterpreterUtil.hpp"
 #include <pybind11/embed.h>
+#include <pybind11/pybind11.h>
 #endif // NGEN_WITH_PYTHON
 
 #if NGEN_WITH_MPI
@@ -877,6 +878,19 @@ int main(int argc, char* argv[]) {
     auto interp = utils::ngenPy::InterpreterUtil::getInstance();
     try {
         result = run_ngen(argc, argv, mpi_num_procs, mpi_rank);
+
+    } catch (pybind11::error_already_set &e) {
+        // If the error comes from python,
+        // we cannot rethrow the execption after destroying the interpreter (doing so sometimes caused MPI runs to hang)
+        // First, copy the python error message so it an be reraised as a runtime_error
+        std::string error_msg = std::string("Uncaught python error: ") + e.what();
+        // direct the exception's full stack trace to be printed to stderr
+        e.discard_as_unraisable("Passing python error before tearing down interpreter.");
+        // destroy the interpreter to let python atexit actions trigger
+        interp.reset();
+        // throw the copied error to ensure MPI acknowledges the termination
+        throw std::runtime_error(error_msg);
+
     } catch (...) {
         // If any uncaught exception happens,
         // explictly destroy the interpreter to ensure any
@@ -892,7 +906,7 @@ int main(int argc, char* argv[]) {
     // this is needed if any python atexit registered functions would interact with MPI
     MPI_Barrier(MPI_COMM_WORLD);
 #endif // NGEN_WITH_MPI
-#else
+#else // not NGEN_WITH_PYTHON
     result = run_ngen(argc, argv, mpi_num_procs, mpi_rank);
 #endif // NGEN_WITH_PYTHON
 

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -884,6 +884,9 @@ int main(int argc, char* argv[]) {
         // we cannot rethrow the execption after destroying the interpreter (doing so sometimes caused MPI runs to hang)
         // First, copy the python error message so it an be reraised as a runtime_error
         std::string error_msg = std::string("Uncaught python error: ") + e.what();
+        // Log as a fatal error since it will end the program.
+        // This may result in double logging, but better to make sure it gets logged.
+        LOG(LogLevel::FATAL, error_msg);
         // destroy the interpreter to let python atexit actions trigger
         interp.reset();
         // throw the copied error to ensure MPI acknowledges the termination

--- a/src/NGen.cpp
+++ b/src/NGen.cpp
@@ -884,8 +884,6 @@ int main(int argc, char* argv[]) {
         // we cannot rethrow the execption after destroying the interpreter (doing so sometimes caused MPI runs to hang)
         // First, copy the python error message so it an be reraised as a runtime_error
         std::string error_msg = std::string("Uncaught python error: ") + e.what();
-        // direct the exception's full stack trace to be printed to stderr
-        e.discard_as_unraisable("Passing python error before tearing down interpreter.");
         // destroy the interpreter to let python atexit actions trigger
         interp.reset();
         // throw the copied error to ensure MPI acknowledges the termination


### PR DESCRIPTION
When running NGEN with MPI, the program would hang when an uncaught python error was expected to abort the simulation. This seems to be from rethrowing the `pybind11::error_already_set` exception after shutting down the interpreter. A separate catch for python exceptions is added that will copy the error text into a `std::runtime_exception` and throw that after shutting down the interpreter.

## Additions

- Catch for `run_ngen` that allows copying the python error text into a C++ object before throwing a new exception. This prevents trying to interact with the python `Exception` object after the interpreter has been shut down.

## Removals

-

## Changes

-

## Testing

1. MPI run using RTE. T-route's `update` method was modified to immediately throw an exception. The exception was logged to stderr and the run (all MPI processes) was aborted.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [ ] Linux
