### PR TITLE
64-bit Catchment and Nexus IDs (NGWPC-10861)

### DIFF
--- a/include/core/nexus/HY_PointHydroNexusRemote.hpp
+++ b/include/core/nexus/HY_PointHydroNexusRemote.hpp
@@ -43,7 +43,7 @@ class HY_PointHydroNexusRemote : public HY_PointHydroNexus
         void add_upstream_flow(double val, std::string catchment_id, time_step_t t) override;
 
         /** extract a numeric id from the catchment id for use as a mpi tag */
-        static long extract(std::string s) {  return std::stoi( s.substr( s.find(hy_features::identifiers::separator)+1 ) ); }
+        static long extract(std::string s) {  return std::stoll( s.substr( s.find(hy_features::identifiers::separator)+1 ) ); }
         
         const Catchments& get_local_contributing_catchments(){
             return local_contributers;
@@ -87,7 +87,7 @@ class HY_PointHydroNexusRemote : public HY_PointHydroNexus
         struct time_step_and_flow_t
         {
             long time_step;
-            long catchment_id;
+            int64_t catchment_id;
             double flow;
         };
 

--- a/include/forcing/ForcingsEngineLumpedDataProvider.hpp
+++ b/include/forcing/ForcingsEngineLumpedDataProvider.hpp
@@ -34,13 +34,13 @@ struct ForcingsEngineLumpedDataProvider final :
     ) override;
 
     //! Get this provider's Divide ID.
-    std::size_t divide() const noexcept;
+    int64_t divide() const noexcept;
 
     //! Get this provider's Divide ID index within the Forcings Engine.
     std::size_t divide_index() const noexcept;
 
   private:
-    std::size_t divide_id_;
+    int64_t divide_id_;
     std::size_t divide_idx_;
 
     // Search an array of numbers for the first instance of the current `divide_id_` and set the `divide_idx_` to that index if found

--- a/src/core/NgenSimulation.cpp
+++ b/src/core/NgenSimulation.cpp
@@ -289,16 +289,16 @@ void NgenSimulation::set_troute_inputs(
 #if NGEN_WITH_ROUTING
     if (this->mpi_rank_ == 0) {
         // set up nexus id indexes
-        std::vector<int> df_index(feature_indexes->size());
+        std::vector<int64_t> df_index(feature_indexes->size());
         for (const auto& key_value : *feature_indexes) {
             int id_index = key_value.second;
 
             // Convert string ID into numbers for T-route index
-            int id_as_int = -1;
+            int64_t id_as_int = -1;
             size_t sep_index = key_value.first.find(hy_features::identifiers::separator);
             if (sep_index != std::string::npos) {
                 std::string numbers = key_value.first.substr(sep_index + hy_features::identifiers::separator.length());
-                id_as_int = std::stoi(numbers);
+                id_as_int = std::stoll(numbers);
             }
             if (id_as_int == -1) {
                 std::string error_msg = "Cannot convert the ID to an integer: " + key_value.first;

--- a/src/core/nexus/HY_PointHydroNexusRemote.cpp
+++ b/src/core/nexus/HY_PointHydroNexusRemote.cpp
@@ -29,8 +29,8 @@ HY_PointHydroNexusRemote::HY_PointHydroNexusRemote(std::string nexus_id, Catchme
 {
    int count = 3;
    const int array_of_blocklengths[3] = { 1, 1, 1};
-   const MPI_Aint array_of_displacements[3] = { 0, sizeof(long), sizeof(long) + sizeof(long) };
-   const MPI_Datatype array_of_types[3] = { MPI_LONG, MPI_LONG, MPI_DOUBLE };
+   const MPI_Aint array_of_displacements[3] = { 0, sizeof(long), sizeof(int64_t) + sizeof(long) };
+   const MPI_Datatype array_of_types[3] = { MPI_LONG, MPI_INT64_T, MPI_DOUBLE };
 
    MPI_Type_create_struct(count, array_of_blocklengths, array_of_displacements, array_of_types, &time_step_and_flow_type);
 
@@ -199,7 +199,7 @@ void HY_PointHydroNexusRemote::add_upstream_flow(double val, std::string catchme
 
 		    // fill the message buffer
 		    stored_sends.back().buffer->time_step = t;
-		    stored_sends.back().buffer->catchment_id = std::stoi( id.substr( id.find(hy_features::identifiers::separator)+1 ) );
+		    stored_sends.back().buffer->catchment_id = std::stoll( id.substr( id.find(hy_features::identifiers::separator)+1 ) );
 
 		    // get the correct amount of flow using the inherted function this means are local bookkeeping is accurate
 		    stored_sends.back().buffer->flow = HY_PointHydroNexus::get_downstream_flow(id, t, 100.0);;

--- a/src/forcing/ForcingsEngineLumpedDataProvider.cpp
+++ b/src/forcing/ForcingsEngineLumpedDataProvider.cpp
@@ -11,7 +11,7 @@ namespace data_access {
 using Provider     = ForcingsEngineLumpedDataProvider;
 using BaseProvider = Provider::base_type;
 
-std::size_t convert_divide_id_stoi(const std::string& divide_id)
+int64_t convert_divide_id_stoll(const std::string& divide_id)
 {
     auto separator = divide_id.find('-');
     const char* split = (
@@ -25,7 +25,7 @@ std::size_t convert_divide_id_stoi(const std::string& divide_id)
     ss << "Converting divide ID: " << divide_id
        << " -> " << split << std::endl;
     LOG(ss.str(), LogLevel::DEBUG);
-    return std::atol(split);
+    return std::atoll(split);
 }
 
 Provider::ForcingsEngineLumpedDataProvider(
@@ -60,7 +60,7 @@ Provider::ForcingsEngineLumpedDataProvider(
     ss << "  divide ID:    " << divide_id << std::endl;
     LOG(ss.str(), LogLevel::DEBUG);
 
-    divide_id_ = convert_divide_id_stoi(divide_id);
+    divide_id_ = convert_divide_id_stoll(divide_id);
 
     // Check that CAT-ID is an available output name, otherwise we most likely aren't
     // running the correct configuration of the forcings engine for this class.
@@ -107,6 +107,10 @@ Provider::ForcingsEngineLumpedDataProvider(
         this->find_divide_id<long>(cat_id_ptr, size_id_dimension);
     } else if (cat_id_cpp_type == "unsigned long") {
         this->find_divide_id<unsigned long>(cat_id_ptr, size_id_dimension);
+    } else if (cat_id_cpp_type == "long long") {
+        this->find_divide_id<long long>(cat_id_ptr, size_id_dimension);
+    } else if (cat_id_cpp_type == "unsigned long long") {
+        this->find_divide_id<unsigned long long>(cat_id_ptr, size_id_dimension);
     } else if (cat_id_cpp_type == "float") {
         this->find_divide_id<float>(cat_id_ptr, size_id_dimension);
     } else if (cat_id_cpp_type == "double") {
@@ -150,7 +154,7 @@ inline void Provider::find_divide_id(const void *cat_id_ptr, const std::size_t s
     }
 }
 
-std::size_t Provider::divide() const noexcept
+int64_t Provider::divide() const noexcept
 {
     return divide_id_;
 }
@@ -166,9 +170,9 @@ Provider::data_type Provider::get_value(
 )
 {
     std::stringstream ss; 
-    if (!(divide_id_ == convert_divide_id_stoi(selector.get_id()))) {
+    if (!(divide_id_ == convert_divide_id_stoll(selector.get_id()))) {
         ss.str("");
-        ss << "get_value() divide_id_ " << divide_id_ << " != selector id " << convert_divide_id_stoi(selector.get_id());
+        ss << "get_value() divide_id_ " << divide_id_ << " != selector id " << convert_divide_id_stoll(selector.get_id());
         LOG(LogLevel::FATAL, ss.str());
         throw std::runtime_error{
             "Divide ID mismatch in the forcings engine."
@@ -259,9 +263,9 @@ std::vector<Provider::data_type> Provider::get_values(
 )
 {
     std::stringstream ss; 
-    if (!(divide_id_ == convert_divide_id_stoi(selector.get_id()))) {
+    if (!(divide_id_ == convert_divide_id_stoll(selector.get_id()))) {
         ss.str("");
-        ss << "get_values() divide id " << divide_id_ << "not equal to selector.get_id" << convert_divide_id_stoi(selector.get_id());
+        ss << "get_values() divide id " << divide_id_ << "not equal to selector.get_id" << convert_divide_id_stoll(selector.get_id());
         LOG(LogLevel::FATAL, ss.str());
         throw std::runtime_error{
             "Divide ID mismatch in the forcings engine."

--- a/src/geopackage/read.cpp
+++ b/src/geopackage/read.cpp
@@ -105,7 +105,7 @@ std::shared_ptr<geojson::FeatureCollection> ngen::geopackage::read(
             } else {
                 sep_index++;
             }
-            int id_num = std::atoi(filter_id.c_str() + sep_index);
+            int64_t id_num = std::atoll(filter_id.c_str() + sep_index);
             if (id_num <= 0) {
                 // check if the failed item is a fake terminal and igore if it is
                 std::string terminal = "wb-TERMINAL_SENTINEL-";


### PR DESCRIPTION
Changes references to catchment and nexus IDs to explicitly use 64-bit integers. A coming update to the NHF hydrofabric structure will use 64-bit integers instead of 32-bit and generate IDs from hashes. References to numeric IDs will use `int64_t` to ensure a 64-bit integer, and parsing will use `std::stoll` instead of `std::stoi`.

## Additions

-

## Removals

-

## Changes

- String parsing of IDs uses `atoll` or `std::stoll` to ensure 64-bit integers across systems.
- Variables and properties used to hold IDs will explicitly use `int64_t` instead of `int` or `long` for the data type.

## Testing

1. Run with RTE on Workspaces to ensure NGEN compiles and runs to completion.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [ ] Linux
