### PR TITLE
Fix ewts linkage in the Dockerfile partitionGenerator stage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -405,7 +405,7 @@ if(NGEN_WITH_SQLITE)
 endif()
 
 if(USE_EWTS)
-    target_link_libraries(partitionGenerator PUBLIC ewts::ewts_ngen_bridge)
+    target_link_libraries(partitionGenerator PUBLIC NGen::ewts)
 endif()
 
 target_link_libraries(partitionGenerator PUBLIC NGen::core NGen::geojson)


### PR DESCRIPTION
Updated the ewts link to the Ngen::ewts library alias to ensure all the necessary libraries are linked.