### PR TITLE
Use correct ewts headers for ngen 

### DIFF
--- a/include/Logger.hpp
+++ b/include/Logger.hpp
@@ -2,18 +2,7 @@
 #define NGEN_LOGGER_HPP
 
 #ifdef USE_EWTS
-#include "ewts/module_constants.hpp"
-#include "ewts/logger.hpp"
-#include "ewts/log_levels.hpp"
-
-#define LOG(...) ::ewts::GetLogger(::ewts::modules::EWTS_ID_NGEN).Log(__VA_ARGS__)
-#define GetLogLevel() ::ewts::GetLogger(::ewts::modules::EWTS_ID_NGEN).GetLogLevel()
-#define IsLoggingEnabled() ::ewts::GetLogger(::ewts::modules::EWTS_ID_NGEN).IsLoggingEnabled()
-
-using LogLevel = ::ewts::LogLevel;
-
-inline constexpr const char* NGEN_MODULE_ID = ::ewts::modules::EWTS_ID_NGEN;
-
+#include "ewts_ngen/logger.hpp"
 #else
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 // Log messages written to STDOUT


### PR DESCRIPTION
The ngen `Logger.hpp` file incorrectly included the ewts header files from the ewts runtime cpp build when it should have included the header files from the ewts integrations build.

## Changes

- Only include `ewts_ngen/logger`

## Testing

1. Built and ran a calibration in AWS Workspace using `peter_docker_dependencies`.