### PR TITLE
Allow local image to be specified

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -350,7 +350,7 @@ RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-rocky \
     export LDFLAGS='-Wl,-L/usr/local/lib64/,-L/usr/local/lib/,-rpath,/usr/local/lib64/,-rpath,/usr/local/lib/' && \
     if [[ "${USE_EWTS_NORMALIZED}" =~ ^(ON|YES|TRUE|1)$ ]]; then \
         echo "Running compiler_bmi.sh (EWTS enabled)"; \
-        ./compiler_bmi.sh no-e; \
+        ./compiler_bmi.sh no-e --gh-org "${GH_ORG}" --ewts-ref "${EWTS_REF}" ; \
     else \
         echo "Running compiler.sh (EWTS disabled)"; \
         ./compiler.sh no-e; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,7 +83,6 @@ LABEL org.opencontainers.image.base.name="${FORCING_IMAGE_NAME}" \
 RUN set -eux && \
     dnf install -y \
         ccache \
-        udunits2 udunits2-devel \
         xz xz-devel \
     && dnf clean all && rm -rf /var/cache/dnf
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,19 +15,32 @@ ARG IMAGE_NAMESPACE=ngwpc
 ARG EWTS_ORG=${GH_ORG}
 ARG EWTS_REF=development
 ARG USE_EWTS=ON
+
+############################################################################
+# Image selection
 ############################################################################
 
-# Image selection
-ARG NGEN_FORCING_IMAGE_TAG=latest
-ARG NGEN_FORCING_IMAGE=ghcr.io/${GHCR_ORG}/ngen-bmi-forcing:${NGEN_FORCING_IMAGE_TAG}
+# Use the ngen-bmi-forcing image as the base. This already includes the
+# inherited Rocky-based compiled dependency stack plus the ngen-bmi-forcing
+# Python package.
+#
+# Default build:
+#   docker build -t ngen .
+#
+# Build from a different published forcing image:
+#   docker build \
+#     --build-arg FORCING_IMAGE=ghcr.io/ngwpc/ngen-bmi-forcing:development \
+#     -t ngen .
+#
+# Build from a locally built forcing image:
+#   docker build \
+#     --build-arg FORCING_IMAGE=ngen-bmi-forcing \
+#     -t ngen .
+ARG FORCING_IMAGE=ghcr.io/${GHCR_ORG}/ngen-bmi-forcing:latest
 
-FROM ${NGEN_FORCING_IMAGE} AS base
-
-# Uncomment when building locally
-# FROM ngen-bmi-forcing AS base
+FROM ${FORCING_IMAGE} AS base
 
 # Re-expose args after FROM for the remaining build stage
-# Keeps whatever value was already set
 ARG GH_ORG
 ARG GHCR_ORG
 ARG IMAGE_NAMESPACE
@@ -42,9 +55,10 @@ ARG EWTS_REF
 ARG USE_EWTS=ON
 
 # OCI Metadata Arguments
-ARG NGEN_FORCING_IMAGE
-ARG BASE_IMAGE_DIGEST="unknown"
-ARG BASE_IMAGE_REVISION="unknown"
+ARG FORCING_IMAGE
+ARG FORCING_IMAGE_NAME="${FORCING_IMAGE}"
+ARG FORCING_IMAGE_DIGEST="unknown"
+ARG FORCING_IMAGE_REVISION="unknown"
 ARG IMAGE_SOURCE="unknown"
 ARG IMAGE_VENDOR="unknown"
 ARG IMAGE_VERSION="unknown"
@@ -52,15 +66,15 @@ ARG IMAGE_REVISION="unknown"
 ARG EWTS_REVISION="unknown"
 
 # Image Labels: OCI-spec annotations followed by custom source-repo metadata.
-LABEL org.opencontainers.image.base.name="${NGEN_FORCING_IMAGE}" \
-    org.opencontainers.image.base.digest="${BASE_IMAGE_DIGEST}" \
+LABEL org.opencontainers.image.base.name="${FORCING_IMAGE_NAME}" \
+      org.opencontainers.image.base.digest="${FORCING_IMAGE_DIGEST}" \
     org.opencontainers.image.source="${IMAGE_SOURCE}" \
     org.opencontainers.image.vendor="${IMAGE_VENDOR}" \
     org.opencontainers.image.version="${IMAGE_VERSION}" \
     org.opencontainers.image.revision="${IMAGE_REVISION}" \
     org.opencontainers.image.title="Next Generation Water Modeling Engine and Framework Prototype" \
     org.opencontainers.image.description="Docker image for the NGEN application" \
-    io.${IMAGE_NAMESPACE}.image.base.revision="${BASE_IMAGE_REVISION}" \
+    io.${IMAGE_NAMESPACE}.image.base.revision="${FORCING_IMAGE_REVISION}" \
     io.${IMAGE_NAMESPACE}.ewts.org="${EWTS_ORG}" \
     io.${IMAGE_NAMESPACE}.ewts.ref="${EWTS_REF}" \
     io.${IMAGE_NAMESPACE}.ewts.revision="${EWTS_REVISION}"


### PR DESCRIPTION
Updated the build to allow the `ngen-forcing` image to be specified from the command line for local build instead of modifying the `Dockerfile` itself.

## Additions

- Comments and examples how to use the `FORCING_IMAGE` build argument to specify a local build of `ngen-forcing`
- Passed `EWTS_REF` and `GH_ORG` to `compiler_bmi.sh` 

## Removals

-

## Changes

- Changed the `NGEN_FORCING_IMAGE` build argument to `FORCING_IMAGE` and reflected this update in like named arguments.

## Testing

1. Tested running calibrations and forecasts in AWS workspace using ngenCERF GUI.


